### PR TITLE
Changed default so that the updater does not download updates by default

### DIFF
--- a/data/eos-updater.conf
+++ b/data/eos-updater.conf
@@ -1,4 +1,4 @@
 [Automatic Updates]
 
-LastAutomaticStep=2
+LastAutomaticStep=1
 IntervalDays=1


### PR DESCRIPTION
Now, the updater only checks whether updates are available.

[endlessm/eos-shell#1240]
