### PR TITLE
Change ostree polling interval to 14 days

### DIFF
--- a/data/eos-updater.conf
+++ b/data/eos-updater.conf
@@ -1,4 +1,4 @@
 [Automatic Updates]
 
 LastAutomaticStep=3
-IntervalDays=1
+IntervalDays=14


### PR DESCRIPTION
The updater will stil launch 15 minutes after booting
and every 24 hours thereafter, but will only check the server
for an update if it has been at least 14 days since the last check.

[endlessm/eos-shell#2764]
