### PR TITLE
Check if connected through mobile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,7 @@ GLIB_REQUIRED_VERSION=2.36.0
 
 PKG_CHECK_MODULES(EOS_UPDATER,
                   gio-unix-2.0 >= $GLIB_REQUIRED_VERSION
+                  libnm-glib
                   libsystemd-journal)
 
 AC_CONFIG_HEADERS([config.h])

--- a/data/eos-updater.conf
+++ b/data/eos-updater.conf
@@ -2,3 +2,4 @@
 
 LastAutomaticStep=3
 IntervalDays=14
+UpdateOnMobile=false


### PR DESCRIPTION
If connected through a mobile connection, we do not want to
automatically update the system, as there are cases where users
pay per amount of use, and the system upgrade can be quite huge.

[endlessm/eos-shell#3459]
