### PR TITLE
Don't create stamp file until updater has completed

### DIFF
--- a/src/eos-updater.c
+++ b/src/eos-updater.c
@@ -77,7 +77,7 @@ update_stamp_file (void)
   GError *error = NULL;
   gboolean ret = TRUE;
 
-  if (g_mkdir_with_parents (UPDATE_STAMP_DIR, 0644) != 0) {
+  if (g_mkdir_with_parents (UPDATE_STAMP_DIR, 0755) != 0) {
     int saved_errno = errno;
     const char *err_str = g_strerror (saved_errno);
 


### PR DESCRIPTION
Currently we update the stamp file after a successful poll. However, if
the subsequent fetch and apply fails for any reason, the stamp file will
prevent the updater from running again on the next invocation. The user
would then have to wait 2 more weeks to finish the update.

Instead of updating after a successful poll, just wait until all steps
the updater is configured to run have completed successfully.

[endlessm/eos-shell#4514]
