### PR TITLE
Add dependencies needed by eos-release-upgrade

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,14 +8,18 @@ Build-Depends: debhelper (>= 8.0.0),
 	libnm-glib-dev,
 	libsystemd-journal-dev,
 	dh-autoreconf,
-	dh-systemd
+	dh-systemd,
+	python
 
 Package: eos-updater
 Section: misc
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends},
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${python:Depends},
 	systemd (>= 200),
-	ostree
+	ostree,
+	python-gi,
+	gir1.2-glib-2.0,
+	gir1.2-ostree
 Description: Automatic updater for EndlessOS
  This package contains the automatic update
  component to keep Endless OS up to date.

--- a/debian/rules
+++ b/debian/rules
@@ -15,4 +15,4 @@ override_dh_auto_configure:
 	dh_auto_configure -- $(confflags)
 
 %:
-	dh $@ --with autotools-dev,autoreconf,systemd
+	dh $@ --with autotools-dev,autoreconf,systemd,python2


### PR DESCRIPTION
Use dh_python2 from the python package at build time to generate
python:Depends substvars. At runtime, require python-gi and the gir
packages for glib and ostree.

[endlessm/eos-shell#4574]
