### PR TITLE
Makefile: Move to AM_DISTCHECK_CONFIGURE_FLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,4 +7,4 @@ SUBDIRS = src data
 EXTRA_DIST = autogen.sh README.md
 
 # Ensure systemd units get installed under $(prefix) for distcheck
-DISTCHECK_CONFIGURE_FLAGS = --with-systemdsystemunitdir='$${libdir}/systemd/system'
+AM_DISTCHECK_CONFIGURE_FLAGS = --with-systemdsystemunitdir='$${libdir}/systemd/system'

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_INIT([eos-updater],[1.0])
 AC_USE_SYSTEM_EXTENSIONS
-AM_INIT_AUTOMAKE([dist-xz no-dist-gzip tar-ustar foreign])
+AM_INIT_AUTOMAKE([1.11.2 dist-xz no-dist-gzip tar-ustar foreign])
 AC_PROG_CC
 
 PKG_PROG_PKG_CONFIG


### PR DESCRIPTION
Since automake 1.11.2 it is recommended that packages
use AM_DISTCHECK_CONFIGURE_FLAGS instead of
DISTCHECK_CONFIGURE_FLAGS as the latter is intended
to be a user variable.

[endlessm/eos-sdk#3303]