### PR TITLE
Update systemd dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ OSTREE_REQUIRED_VERSION=2015.6
 PKG_CHECK_MODULES([EOS_AUTOUPDATER],
                   [gio-unix-2.0 >= $GLIB_REQUIRED_VERSION
                   libnm-glib
-                  libsystemd-journal])
+                  libsystemd])
 
 PKG_CHECK_MODULES([EOS_UPDATER],
                   [gio-unix-2.0 >= $GLIB_REQUIRED_VERSION


### PR DESCRIPTION
libsystemd-journal has been merged into libsystemd on the newer systemd
(229) we are shipping on eos 2.7.

https://phabricator.endlessm.com/T6363