### PR TITLE
Cleanup old remote ref

### DIFF
--- a/src/eos-updater-fetch.c
+++ b/src/eos-updater-fetch.c
@@ -88,17 +88,18 @@ content_fetch (GTask *task,
   GError *error = NULL;
   gs_free gchar *src = NULL;
   gs_free gchar *ref = NULL;
-  gs_free gchar *sum = NULL;
+  const gchar *sum;
   gchar *pullrefs[] = { NULL, NULL };
   GMainContext *task_context = g_main_context_new ();
 
   g_main_context_push_thread_default (task_context);
 
-  if (!eos_updater_resolve_upgrade (updater, repo, &src, &ref, &sum, &error))
+  if (!eos_updater_resolve_upgrade (updater, repo, &src, &ref, NULL, &error))
     goto error;
 
+  sum = eos_updater_get_update_id (updater);
+
   message ("Fetch: %s:%s resolved to: %s", src, ref, sum);
-  message ("User asked us for commit: %s", eos_updater_get_update_id (updater));
 
   /* rather than re-resolving the update, we get the last ID that the
    * user Poll()ed. We do this because that is the last update for which
@@ -106,7 +107,7 @@ content_fetch (GTask *task,
    * system hasn;t seen the download/unpack sizes for that so it cannot
    * be considered to have been approved.
    */
-  pullrefs[0] = (gchar *) eos_updater_get_update_id (updater);
+  pullrefs[0] = (gchar *) sum;
 
   progress = ostree_async_progress_new_and_connect (update_progress, updater);
 

--- a/src/eos-updater-fetch.c
+++ b/src/eos-updater-fetch.c
@@ -96,11 +96,23 @@ content_fetch (GTask *task,
   g_main_context_push_thread_default (task_context);
 
   refspec = eos_updater_get_update_refspec (updater);
+  if (refspec == NULL || *refspec == '\0')
+    {
+      g_set_error_literal (&error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                           "fetch called with empty update refspec");
+      goto error;
+    }
 
   if (!ostree_parse_refspec (refspec, &src, &ref, &error))
     goto error;
 
   sum = eos_updater_get_update_id (updater);
+  if (sum == NULL || *sum == '\0')
+    {
+      g_set_error_literal (&error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                           "fetch called with empty update commit");
+      goto error;
+    }
 
   message ("Fetch: %s:%s resolved to: %s", src, ref, sum);
 

--- a/src/eos-updater-fetch.c
+++ b/src/eos-updater-fetch.c
@@ -86,6 +86,7 @@ content_fetch (GTask *task,
   OstreeRepoPullFlags flags = OSTREE_REPO_PULL_FLAGS_NONE;
   gs_unref_object OstreeAsyncProgress *progress = NULL;
   GError *error = NULL;
+  const gchar *refspec;
   gs_free gchar *src = NULL;
   gs_free gchar *ref = NULL;
   const gchar *sum;
@@ -94,7 +95,9 @@ content_fetch (GTask *task,
 
   g_main_context_push_thread_default (task_context);
 
-  if (!eos_updater_resolve_upgrade (updater, repo, &src, &ref, NULL, &error))
+  refspec = eos_updater_get_update_refspec (updater);
+
+  if (!ostree_parse_refspec (refspec, &src, &ref, &error))
     goto error;
 
   sum = eos_updater_get_update_id (updater);

--- a/src/eos-updater-poll.c
+++ b/src/eos-updater-poll.c
@@ -164,6 +164,7 @@ metadata_fetch (GTask *task,
   gs_free gchar *remote = NULL;
   gs_free gchar *branch = NULL;
   gs_free gchar *refspec = NULL;
+  gs_free gchar *orig_refspec = NULL;
   gchar *pullrefs[] = { NULL, NULL };
   gchar *csum = NULL;
   GMainContext *task_context = g_main_context_new ();
@@ -171,7 +172,8 @@ metadata_fetch (GTask *task,
 
   g_main_context_push_thread_default (task_context);
 
-  if (!eos_updater_resolve_upgrade (updater, repo, &refspec, NULL, &error))
+  if (!eos_updater_resolve_upgrade (updater, repo, &refspec,
+                                    &orig_refspec, NULL, &error))
     goto error;
 
   if (!refspec) /* this means OnHold=true */
@@ -196,6 +198,7 @@ metadata_fetch (GTask *task,
     goto error;
 
   eos_updater_set_update_refspec (updater, refspec);
+  eos_updater_set_original_refspec (updater, orig_refspec);
 
   /* returning the sha256 sum of the just-fetched rev */
   g_task_return_pointer (task, csum, g_free);

--- a/src/eos-updater-poll.c
+++ b/src/eos-updater-poll.c
@@ -171,22 +171,22 @@ metadata_fetch (GTask *task,
 
   g_main_context_push_thread_default (task_context);
 
-  if (!eos_updater_resolve_upgrade (updater, repo,
-                                    &remote, &branch, NULL, &error))
+  if (!eos_updater_resolve_upgrade (updater, repo, &refspec, NULL, &error))
     goto error;
 
-  if (!branch) /* this means OnHold=true */
+  if (!refspec) /* this means OnHold=true */
     {
       g_task_return_pointer (task, NULL, NULL);
       goto cleanup;
     }
 
+  if (!ostree_parse_refspec (refspec, &remote, &branch, &error))
+    goto error;
+
   pullrefs[0] = branch;
 
   if (!ostree_repo_pull (repo, remote, pullrefs, flags, NULL, cancel, &error))
     goto error;
-
-  refspec = g_strdup_printf ("%s:%s", remote, branch);
 
   if (!ostree_repo_resolve_rev (repo, refspec, TRUE, &csum, &error))
     goto error;

--- a/src/eos-updater-poll.c
+++ b/src/eos-updater-poll.c
@@ -126,10 +126,6 @@ metadata_fetch_finished (GObject *object,
               g_clear_error (&error);
             }
         }
-
-      /* get the sha256 sum uf the currently booted image */
-      if (!eos_updater_resolve_upgrade (updater, repo, NULL, NULL, &cur, &error))
-        goto out;
     }
   else /* csum == NULL means OnHold=true, nothing to do here */
     eos_updater_set_state_changed (updater, EOS_UPDATER_STATE_READY);

--- a/src/eos-updater-poll.c
+++ b/src/eos-updater-poll.c
@@ -49,14 +49,19 @@ metadata_fetch_finished (GObject *object,
       gint64 new_unpacked = 0;
       gs_unref_variant GVariant *current_commit = NULL;
       gs_unref_variant GVariant *commit = NULL;
-      gs_free gchar *cur = NULL;
+      const gchar *cur;
       gboolean is_newer = FALSE;
       const gchar *label;
       const gchar *message;
 
       /* get the sha256 sum of the currently booted image */
-      if (!eos_updater_resolve_upgrade (updater, repo, NULL, NULL, &cur, &error))
-        goto out;
+      cur = eos_updater_get_current_id (updater);
+      if (cur == NULL || *cur == '\0')
+        {
+          g_set_error_literal (&error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                               "Could not determine booted checksum");
+          goto out;
+        }
 
       if (!ostree_repo_load_variant (repo, OSTREE_OBJECT_TYPE_COMMIT,
                                      cur, &current_commit, &error))

--- a/src/eos-updater-util.c
+++ b/src/eos-updater-util.c
@@ -164,6 +164,7 @@ gboolean
 eos_updater_resolve_upgrade (EosUpdater  *updater,
                              OstreeRepo *repo,
                              gchar     **upgrade_refspec,
+                             gchar     **original_refspec,
                              gchar     **booted_checksum,
                              GError    **error)
 {
@@ -363,6 +364,7 @@ eos_updater_resolve_upgrade (EosUpdater  *updater,
   message ("Using product branch %s", p_ref);
   ret = TRUE;
   *upgrade_refspec = g_strdup_printf ("%s:%s", o_remote, p_ref);
+  shuffle_out_values (original_refspec, o_refspec, NULL);
 
 out:
   if ((p_ref || on_hold) && !metric_sent)

--- a/src/eos-updater-util.h
+++ b/src/eos-updater-util.h
@@ -49,8 +49,7 @@ OstreeRepo * eos_updater_local_repo (void);
 
 gboolean eos_updater_resolve_upgrade (EosUpdater  *updater,
                                       OstreeRepo *repo,
-                                      gchar     **upgrade_remote,
-                                      gchar     **upgrade_ref,
+                                      gchar     **upgrade_refspec,
                                       gchar     **booted_checksum,
                                       GError    **error);
 

--- a/src/eos-updater-util.h
+++ b/src/eos-updater-util.h
@@ -50,6 +50,7 @@ OstreeRepo * eos_updater_local_repo (void);
 gboolean eos_updater_resolve_upgrade (EosUpdater  *updater,
                                       OstreeRepo *repo,
                                       gchar     **upgrade_refspec,
+                                      gchar     **original_refspec,
                                       gchar     **booted_checksum,
                                       GError    **error);
 

--- a/src/eos-updater.c
+++ b/src/eos-updater.c
@@ -63,7 +63,7 @@ on_bus_acquired (GDBusConnection *connection,
   g_signal_connect (updater, "handle-poll",  G_CALLBACK (handle_poll), repo);
   g_signal_connect (updater, "handle-apply", G_CALLBACK (handle_apply), repo);
 
-  if (eos_updater_resolve_upgrade (updater, repo, NULL, &sum, &error))
+  if (eos_updater_resolve_upgrade (updater, repo, NULL, NULL, &sum, &error))
     {
       eos_updater_set_current_id (updater, sum);
       eos_updater_set_download_size (updater, 0);

--- a/src/eos-updater.c
+++ b/src/eos-updater.c
@@ -63,7 +63,7 @@ on_bus_acquired (GDBusConnection *connection,
   g_signal_connect (updater, "handle-poll",  G_CALLBACK (handle_poll), repo);
   g_signal_connect (updater, "handle-apply", G_CALLBACK (handle_apply), repo);
 
-  if (eos_updater_resolve_upgrade (updater, repo, NULL, NULL, &sum, &error))
+  if (eos_updater_resolve_upgrade (updater, repo, NULL, &sum, &error))
     {
       eos_updater_set_current_id (updater, sum);
       eos_updater_set_download_size (updater, 0);

--- a/src/eos-updater.xml
+++ b/src/eos-updater.xml
@@ -7,6 +7,7 @@
     <property name="State"            type="u" access="read"/>
     <property name="UpdateID"         type="s" access="read"/>
     <property name="UpdateRefspec"    type="s" access="read"/>
+    <property name="OriginalRefspec"  type="s" access="read"/>
     <property name="CurrentID"        type="s" access="read"/>
     <property name="UpdateLabel"      type="s" access="read"/>
     <property name="UpdateMessage"    type="s" access="read"/>


### PR DESCRIPTION
Keep track of the original update refspec so it can be deleted and not keep a reference to a no longer wanted tree.

https://phabricator.endlessm.com/T11010