### PR TITLE
Disable all update steps on live sessions

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,6 +39,8 @@ eos_updater_SOURCES = \
 	eos-updater-apply.h \
 	eos-updater-fetch.c \
 	eos-updater-fetch.h \
+	eos-updater-live-boot.c \
+	eos-updater-live-boot.h \
 	eos-updater-poll.c \
 	eos-updater-poll.h \
 	eos-updater-util.c \

--- a/src/eos-updater-live-boot.c
+++ b/src/eos-updater-live-boot.c
@@ -1,0 +1,56 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2016 Endless Mobile
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Author: Will Thompson <wjt@endlessm.com>
+ */
+
+#include "eos-updater-live-boot.h"
+
+gboolean
+is_live_boot (void)
+{
+  const gchar *force = g_getenv ("EU_FORCE_LIVE_BOOT");
+  GError *error = NULL;
+  g_autofree gchar *cmdline = NULL;
+
+  if (force != NULL && *force != '\0')
+    {
+      return TRUE;
+    }
+
+  if (!g_file_get_contents ("/proc/cmdline", &cmdline, NULL, &error))
+    {
+      g_printerr ("unable to read /proc/cmdline: %s\n", error->message);
+      g_error_free (error);
+      return FALSE;
+    }
+
+  return g_regex_match_simple ("\\bendless\\.live_boot\\b", cmdline, 0, 0);
+}
+
+gboolean
+handle_on_live_boot (EosUpdater            *updater,
+                     GDBusMethodInvocation *call,
+                     gpointer               user_data)
+{
+  g_dbus_method_invocation_return_error (call,
+    EOS_UPDATER_ERROR, EOS_UPDATER_ERROR_LIVE_BOOT,
+    "Updater disabled on live systems");
+  return TRUE;
+}

--- a/src/eos-updater-live-boot.h
+++ b/src/eos-updater-live-boot.h
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
  *
- * Copyright © 2013 Collabora Ltd.
+ * Copyright © 2016 Endless Mobile
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -17,30 +17,20 @@
  * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
  * Boston, MA 02111-1307, USA.
  *
- * Author: Vivek Dasmohapatra <vivek@etla.org>
+ * Author: Will Thompson <wjt@endlessm.com>
  */
 
 #pragma once
 
+#include "eos-updater-generated.h"
+#include "eos-updater-util.h"
+#include <ostree.h>
+
 G_BEGIN_DECLS
 
-typedef enum {
-  EOS_UPDATER_ERROR_WRONG_STATE,
-  EOS_UPDATER_ERROR_LIVE_BOOT,
-  EOS_UPDATER_N_ERRORS /*< skip >*/
-} EosUpdaterError;
-
-typedef enum {
-  EOS_UPDATER_STATE_NONE = 0,
-  EOS_UPDATER_STATE_READY,
-  EOS_UPDATER_STATE_ERROR,
-  EOS_UPDATER_STATE_POLLING,
-  EOS_UPDATER_STATE_UPDATE_AVAILABLE,
-  EOS_UPDATER_STATE_FETCHING,
-  EOS_UPDATER_STATE_UPDATE_READY,
-  EOS_UPDATER_STATE_APPLYING_UPDATE,
-  EOS_UPDATER_STATE_UPDATE_APPLIED,
-  EOS_UPDATER_N_STATES,
-} EosUpdaterState;
+gboolean is_live_boot (void);
+gboolean handle_on_live_boot (EosUpdater            *updater,
+                              GDBusMethodInvocation *call,
+                              gpointer               user_data);
 
 G_END_DECLS

--- a/src/eos-updater-util.c
+++ b/src/eos-updater-util.c
@@ -34,7 +34,8 @@
 #define EOS_UPDATER_BRANCH_SELECTED "99f48aac-b5a0-426d-95f4-18af7d081c4e"
 
 static const GDBusErrorEntry eos_updater_error_entries[] = {
-  { EOS_UPDATER_ERROR_WRONG_STATE, "com.endlessm.Updater.Error.WrongState" }
+  { EOS_UPDATER_ERROR_WRONG_STATE, "com.endlessm.Updater.Error.WrongState" },
+  { EOS_UPDATER_ERROR_LIVE_BOOT, "com.endlessm.Updater.Error.LiveBoot" },
 };
 
 /* Ensure that every error code has an associated D-Bus error name */


### PR DESCRIPTION
eos-autoupdater.timer is already stopped and masked from the initramfs,
but this prevents any updates being fetched or installed.

The rationale here is that endless.live_boot sessions have a read-only
filesystem, with overlay+tmpfs mounted over directories which need to be
read-write. Running an ostree update on such a system is at best
wasteful and frustrating (it will be discarded as soon as you reboot, so
can never be used), and at worst disastrous (it fills /run, because
hardlinking files on overlay requires copying the file from the lower to
the upper filesystem, and your live system breaks until you reboot).

https://phabricator.endlessm.com/T13951
