### PR TITLE
Add an ErrorName D-Bus property

### DIFF
--- a/src/eos-autoupdater.c
+++ b/src/eos-autoupdater.c
@@ -165,15 +165,14 @@ do_update_step (UpdateStep step, EosUpdater *proxy)
 static void
 report_error_status (EosUpdater *proxy)
 {
-  const gchar *error_message;
-  guint error_code;
+  const gchar *name, *error_message;
 
-  error_code = eos_updater_get_error_code (proxy);
+  name = eos_updater_get_error_name (proxy);
   error_message = eos_updater_get_error_message (proxy);
 
   sd_journal_send ("MESSAGE_ID=%s", EOS_UPDATER_DAEMON_ERROR_MSGID,
                    "PRIORITY=%d", LOG_ERR,
-                   "MESSAGE=EOS updater error (code:%u): %s", error_code, error_message,
+                   "MESSAGE=EOS updater error (%s): %s", name, error_message,
                    NULL);
 }
 

--- a/src/eos-updater-apply.c
+++ b/src/eos-updater-apply.c
@@ -50,9 +50,7 @@ apply_finished (GObject *object,
     }
   else
     {
-      eos_updater_set_error_code (updater, 0);
-      eos_updater_set_error_message (updater, "");
-      eos_updater_set_state_changed (updater, EOS_UPDATER_STATE_UPDATE_APPLIED);
+      eos_updater_clear_error (updater, EOS_UPDATER_STATE_UPDATE_APPLIED);
     }
 
   return;

--- a/src/eos-updater-fetch.c
+++ b/src/eos-updater-fetch.c
@@ -41,12 +41,11 @@ content_fetch_finished (GObject *object,
   if (error)
     {
       eos_updater_set_error (updater, error);
+      g_clear_error (&error);
     }
   else
     {
-      eos_updater_set_error_code (updater, 0);
-      eos_updater_set_error_message (updater, "");
-      eos_updater_set_state_changed (updater, EOS_UPDATER_STATE_UPDATE_READY);
+      eos_updater_clear_error (updater, EOS_UPDATER_STATE_UPDATE_READY);
     }
 
   return;

--- a/src/eos-updater-live-boot.h
+++ b/src/eos-updater-live-boot.h
@@ -28,7 +28,7 @@
 
 G_BEGIN_DECLS
 
-gboolean is_live_boot (void);
+gboolean is_installed_system (GError **error);
 gboolean handle_on_live_boot (EosUpdater            *updater,
                               GDBusMethodInvocation *call,
                               gpointer               user_data);

--- a/src/eos-updater-poll.c
+++ b/src/eos-updater-poll.c
@@ -78,18 +78,16 @@ metadata_fetch_finished (GObject *object,
       is_newer = ostree_commit_get_timestamp (commit) > ostree_commit_get_timestamp (current_commit);
 
       /* Everything is happy thusfar */
-      eos_updater_set_error_code (updater, 0);
-      eos_updater_set_error_message (updater, "");
       /* if we have a checksum for the remote upgrade candidate
        * and it's ≠ what we're currently booted into, advertise it as such.
        */
       if (is_newer && g_strcmp0 (cur, csum) != 0)
         {
-          eos_updater_set_state_changed (updater, EOS_UPDATER_STATE_UPDATE_AVAILABLE);
+          eos_updater_clear_error (updater, EOS_UPDATER_STATE_UPDATE_AVAILABLE);
         }
       else
         {
-          eos_updater_set_state_changed (updater, EOS_UPDATER_STATE_READY);
+          eos_updater_clear_error (updater, EOS_UPDATER_STATE_READY);
           goto out;
         }
 

--- a/src/eos-updater-util.c
+++ b/src/eos-updater-util.c
@@ -86,7 +86,11 @@ eos_updater_set_error (EosUpdater *updater,
 {
   gint code = error ? error->code : -1;
   const gchar *msg = (error && error->message) ? error->message : "Unspecified";
+  g_autofree gchar *error_name = g_dbus_error_encode_gerror (error);
 
+  g_warn_if_fail (error != NULL);
+
+  eos_updater_set_error_name (updater, error_name);
   eos_updater_set_error_code (updater, code);
   eos_updater_set_error_message (updater, msg);
   eos_updater_set_state_changed (updater, EOS_UPDATER_STATE_ERROR);

--- a/src/eos-updater-util.c
+++ b/src/eos-updater-util.c
@@ -81,7 +81,8 @@ eos_updater_set_state_changed (EosUpdater *updater, EosUpdaterState state)
 }
 
 void
-eos_updater_set_error (EosUpdater *updater, GError *error)
+eos_updater_set_error (EosUpdater *updater,
+                       const GError *error)
 {
   gint code = error ? error->code : -1;
   const gchar *msg = (error && error->message) ? error->message : "Unspecified";
@@ -89,6 +90,15 @@ eos_updater_set_error (EosUpdater *updater, GError *error)
   eos_updater_set_error_code (updater, code);
   eos_updater_set_error_message (updater, msg);
   eos_updater_set_state_changed (updater, EOS_UPDATER_STATE_ERROR);
+}
+
+void
+eos_updater_clear_error (EosUpdater *updater,
+                         EosUpdaterState state)
+{
+  eos_updater_set_error_code (updater, 0);
+  eos_updater_set_error_message (updater, "");
+  eos_updater_set_state_changed (updater, state);
 }
 
 OstreeRepo *

--- a/src/eos-updater-util.h
+++ b/src/eos-updater-util.h
@@ -50,7 +50,9 @@ void eos_updater_set_state_changed (EosUpdater *updater,
                                     EosUpdaterState state);
 
 void eos_updater_set_error (EosUpdater *updater,
-                            GError *error);
+                            const GError *error);
+void eos_updater_clear_error (EosUpdater *updater,
+                              EosUpdaterState state);
 
 OstreeRepo *eos_updater_local_repo (void);
 

--- a/src/eos-updater.c
+++ b/src/eos-updater.c
@@ -43,7 +43,6 @@ on_bus_acquired (GDBusConnection *connection,
   EosUpdater *updater = NULL;
   EosUpdaterData *data = user_data;
   GError *error = NULL;
-  EosUpdaterState state;
 
   g_autofree gchar *src = NULL;
   g_autofree gchar *ref = NULL;
@@ -83,23 +82,14 @@ on_bus_acquired (GDBusConnection *connection,
       eos_updater_set_download_size (updater, 0);
       eos_updater_set_downloaded_bytes (updater, 0);
       eos_updater_set_unpacked_size (updater, 0);
-      eos_updater_set_error_code (updater, 0);
-      eos_updater_set_error_message (updater, "");
       eos_updater_set_update_id (updater, "");
-      state = EOS_UPDATER_STATE_READY;
+      eos_updater_clear_error (updater, EOS_UPDATER_STATE_READY);
     }
   else
     {
-      eos_updater_set_error_code (updater, error->code);
-      eos_updater_set_error_message (updater, error->message);
-      state = EOS_UPDATER_STATE_ERROR;
+      eos_updater_set_error (updater, error);
+      g_clear_error (&error);
     }
-
-  /* We are deliberately not emitting a signal here. This
-   * isn't a state change, it's our initial state.
-   * krnowak: ORLY? It calls eos_updater_emit_state_changed…
-   */
-  eos_updater_set_state_changed (updater, state);
 
   /* Export the object (@manager takes its own reference to @object) */
   g_dbus_object_manager_server_export (manager, G_DBUS_OBJECT_SKELETON (object));

--- a/src/eos-updater.xml
+++ b/src/eos-updater.xml
@@ -3,7 +3,7 @@
     <method name="Poll" ></method>
     <method name="Fetch"></method>
     <method name="Apply"></method>
-    
+
     <property name="State"            type="u" access="read"/>
     <property name="UpdateID"         type="s" access="read"/>
     <property name="UpdateRefspec"    type="s" access="read"/>
@@ -16,9 +16,16 @@
     <property name="UnpackedSize"     type="x" access="read"/>
     <property name="FullDownloadSize" type="x" access="read"/>
     <property name="FullUnpackedSize" type="x" access="read"/>
+    <!-- An error code, in an unspecified error domain! See ErrorName. -->
     <property name="ErrorCode"        type="u" access="read"/>
+    <!-- a fully-qualified D-Bus error name, as might be returned from a D-Bus
+         method. "com.endlessm.Updater.Error.LiveBoot" when the system is a
+         read-only live USB, where updates are not supported.
+      -->
+    <property name="ErrorName"        type="s" access="read"/>
+    <!-- a human-readable, albeit unlocalized, error message -->
     <property name="ErrorMessage"     type="s" access="read"/>
-    
+
     <signal name="StateChanged">
       <arg type="u" name="state"/>
     </signal>
@@ -30,5 +37,3 @@
 
   </interface>
 </node>
-
-


### PR DESCRIPTION
As described in the XML comments, ErrorCode is actually totally useless for
determining what error has occurred. It is the `code` field of a
`GError`, but without the `domain` field you have no way of knowing if
`1` means EOS_UPDATER_ERROR_LIVE_BOOT or G_IO_ERROR_NOT_FOUND (which
happens in practice on converted systems).

Exposing a fully-qualified error name in a property is consistent with the
way errors are reported from D-Bus methods. There's also prior art: we used
this approach in Telepathy after learning the hard way that integers are no
good for extensibility.

EOS_UPDATER_ERROR_LIVE_BOOT is reported as follows:

    ErrorCode: uint32 1
   ErrorMessage: 'Updater disabled on live systems'
   ErrorName: 'com.endlessm.Updater.Error.LiveBoot'

On converted systems, we report this rather ugly representation of
G_IO_ERROR_NOT_FOUND:

    ErrorCode: uint32 1
   ErrorMessage: 'Not an ostree system'
   ErrorName:
'org.gtk.GDBus.UnmappedGError.Quark._g_2dio_2derror_2dquark.Code1'

We could address this by using a more descriptive GError in these cases,
from our own EOS_UPDATER_ERROR domain.

https://phabricator.endlessm.com/T13951