### PR TITLE
T14640 — eos-updater-util: Log when entering or leaving an error state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ config
 configure
 compile
 depcomp
+m4/
 missing
 install-sh
 stamp-h1

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,22 +1,37 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-PKG_NAME="eos-updater"
+cd $srcdir
 
-(test -f $srcdir/configure.ac \
-  && test -f $srcdir/src/eos-updater.c) || {
-    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
-    echo " top-level $PKG_NAME directory"
-    exit 1
+(test -f configure.ac) || {
+	echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
+	exit 1
 }
 
-which gnome-autogen.sh || {
-    echo "You need to install gnome-common"
-    exit 1
-}
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
 
-REQUIRED_AUTOMAKE_VERSION=1.7
-. gnome-autogen.sh
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+	echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+	echo "*** If you wish to pass any to it, please specify them on the" >&2
+	echo "*** '$0' command line." >&2
+	echo "" >&2
+fi
+
+aclocal --install || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+	$srcdir/configure "$@" || exit 1
+
+	if [ "$1" = "--help" ]; then exit 0 else
+		echo "Now type 'make' to compile $PKG_NAME" || exit 1
+	fi
+else
+	echo "Skipping configure process."
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AS_IF([test "x$with_systemdsystemunitdir" != "xno"], [
 ])
 
 GLIB_REQUIRED_VERSION=2.44.0
-OSTREE_REQUIRED_VERSION=2015.6
+OSTREE_REQUIRED_VERSION=2016.15
 
 PKG_CHECK_MODULES([EOS_AUTOUPDATER],
                   [gio-unix-2.0 >= $GLIB_REQUIRED_VERSION

--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ AC_INIT([eos-updater],[1.0])
 AC_USE_SYSTEM_EXTENSIONS
 AM_INIT_AUTOMAKE([1.11.2 dist-xz no-dist-gzip tar-ustar foreign])
 AC_PROG_CC
+AC_CONFIG_MACRO_DIR([m4])
 
 PKG_PROG_PKG_CONFIG
 

--- a/src/eos-updater-util.c
+++ b/src/eos-updater-util.c
@@ -90,6 +90,8 @@ eos_updater_set_error (EosUpdater *updater,
 
   g_warn_if_fail (error != NULL);
 
+  message ("Changing to error state: %s, %d, %s", error_name, code, msg);
+
   eos_updater_set_error_name (updater, error_name);
   eos_updater_set_error_code (updater, code);
   eos_updater_set_error_message (updater, msg);
@@ -100,6 +102,8 @@ void
 eos_updater_clear_error (EosUpdater *updater,
                          EosUpdaterState state)
 {
+  message ("Clearing error state and changing to state %d", state);
+
   eos_updater_set_error_code (updater, 0);
   eos_updater_set_error_message (updater, "");
   eos_updater_set_state_changed (updater, state);


### PR DESCRIPTION
Ensure that the error details appear in the journal, so that it’s easier
to debug problems later, when we can’t necessarily query the error state
of eos-updater over D-Bus.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T14640

---

This also includes some changes to drop the gnome-common dependency, which made it a bit easier for me to compile eos-updater.