### PR TITLE
eos-updater: Consistently error out at startup if not using OSTree

### DIFF
--- a/src/eos-updater.c
+++ b/src/eos-updater.c
@@ -106,6 +106,15 @@ on_bus_acquired (GDBusConnection *connection,
       eos_updater_set_update_id (updater, "");
       eos_updater_clear_error (updater, EOS_UPDATER_STATE_READY);
     }
+  else if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+    {
+      g_clear_error (&error);
+      g_set_error (&error, EOS_UPDATER_ERROR,
+                   EOS_UPDATER_ERROR_NOT_OSTREE_SYSTEM,
+                   "Not an OSTree-based system: cannot update it.");
+      eos_updater_set_error (updater, error);
+      g_clear_error (&error);
+    }
   else
     {
       eos_updater_set_error (updater, error);


### PR DESCRIPTION
If getting the booted checksum fails, consistently return
EOS_UPDATER_ERROR_NOT_OSTREE_SYSTEM, rather than a G_IO_ERROR which is
not suitable for sending over D-Bus. On a dev-converted system, getting
the booted checksum will fail as we are not booted into an OSTree
deployment.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15644