### PR TITLE
tests: Improve check for skipping ‘unreadable file’ test

### DIFF
--- a/libeos-updater-util/tests/config.c
+++ b/libeos-updater-util/tests/config.c
@@ -155,6 +155,7 @@ test_config_file_unreadable (Fixture       *fixture,
 {
   g_autoptr(GError) error = NULL;
   g_autoptr(GKeyFile) key_file = NULL;
+  g_autofree gchar *temp = NULL;
   const gchar * const paths[] =
     {
       fixture->key_file_nonexistent_path,
@@ -163,10 +164,12 @@ test_config_file_unreadable (Fixture       *fixture,
       NULL
     };
 
-  /* If the test is run as root, the user can read any file anyway. */
-  if (geteuid () == 0)
+  /* If the test is run as root (or another user with CAP_DAC_OVERRIDE), the
+   * user can read any file anyway. */
+  if (g_file_get_contents (fixture->key_file_unreadable_path, &temp, NULL, NULL))
     {
-      g_test_skip ("Test cannot be run as root.");
+      g_test_skip ("Test cannot be run as a user with CAP_DAC_OVERRIDE or "
+                   "CAP_DAC_READ_SEARCH.");
       return;
     }
 


### PR DESCRIPTION
Previously this was testing for whether the effective UID was root, on
the assumption that root was the only user able to bypass DAC checks on
file permissions. However, on Jenkins it seems this is not the case —
there might be some UID remapping going on, or the jenkins user might
have CAP_DAC_OVERRIDE. In any case, the check can be improved by testing
to see if the user can read the ‘unreadable file’. If they can, skip the
test.

The test is run frequently enough locally by anyone developing
eos-updater that it will still be run enough to catch problems with the
code.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15545