### PR TITLE
docs: Fix man sections for .conf man pages

### DIFF
--- a/data/docs/eos-autoupdater.conf.5
+++ b/data/docs/eos-autoupdater.conf.5
@@ -1,6 +1,6 @@
 .\" Manpage for eos-autoupdater.conf.
 .\" Documentation is under the same licence as the eos-updater package.
-.TH man 8 "28 Feb 2017" "1.0" "eos\-autoupdater.conf man page"
+.TH man 5 "28 Feb 2017" "1.0" "eos\-autoupdater.conf man page"
 .\"
 .SH NAME
 .IX Header "NAME"

--- a/data/docs/eos-update-server.conf.5
+++ b/data/docs/eos-update-server.conf.5
@@ -1,6 +1,6 @@
 .\" Manpage for eos-update-server.conf.
 .\" Documentation is under the same licence as the eos-updater package.
-.TH man 8 "28 Feb 2017" "1.0" "eos\-update\-server.conf man page"
+.TH man 5 "28 Feb 2017" "1.0" "eos\-update\-server.conf man page"
 .\"
 .SH NAME
 .IX Header "NAME"

--- a/data/docs/eos-updater.conf.5
+++ b/data/docs/eos-updater.conf.5
@@ -1,6 +1,6 @@
 .\" Manpage for eos-updater.conf.
 .\" Documentation is under the same licence as the eos-updater package.
-.TH man 8 "28 Feb 2017" "1.0" "eos\-updater.conf man page"
+.TH man 5 "28 Feb 2017" "1.0" "eos\-updater.conf man page"
 .\"
 .SH NAME
 .IX Header "NAME"


### PR DESCRIPTION
They’re in section 5, and I forgot that the section is specified in the
page header, as well as in the filename and the installation path.

man, this is such a pain.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15702