### PR TITLE
build: Change default LAN port from 12345 to 43381

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ AM_CONDITIONAL([WITH_METRICS], [test "x$want_metrics" = 'xyes'])
 AC_ARG_WITH([server-port],
             AS_HELP_STRING([--with-server-port], [Port number for the update server]),
             [port=$withval],
-            [port=12345])
+            [port=43381])
 AC_SUBST([server_port], [$port])
 AC_DEFINE_UNQUOTED([EOS_AVAHI_PORT], [$port], [Socket activation port to be used by eos-update-server])
 

--- a/src/docs/eos-update-server.8
+++ b/src/docs/eos-update-server.8
@@ -22,7 +22,7 @@ local network is controlled by \fBeos\-updater\-avahi\fP(8) and
 \fBeos\-update\-server.conf\fP(5).
 .PP
 When running, \fBeos\-update\-server\fP waits for requests on the specified
-port (default: 12345) and serves signed OSTree objects over HTTP. There is no
+port (default: 43381) and serves signed OSTree objects over HTTP. There is no
 authentication or encryption, as all objects are signed centrally.
 .PP
 Advertisement of updates can be disabled by setting the \fIAdvertiseUpdates=\fP


### PR DESCRIPTION
This one’s a little less overloaded (not officially or unofficially
assigned to anything).

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15894