### PR TITLE
eos-updater-poll-lan: Fix crash polling a LAN source on the same ref

### DIFF
--- a/src/eos-updater-poll-common.c
+++ b/src/eos-updater-poll-common.c
@@ -121,6 +121,9 @@ is_checksum_an_update (OstreeRepo *repo,
    */
   if (is_newer && g_strcmp0 (cur, checksum) != 0)
     *commit = g_steal_pointer (&update_commit);
+  else
+    *commit = NULL;
+
   return TRUE;
 }
 

--- a/src/eos-updater-poll-lan.c
+++ b/src/eos-updater-poll-lan.c
@@ -471,9 +471,14 @@ get_update_info_from_swms (LanData *lan_data,
 
       if (!is_checksum_an_update (repo, checksum, &commit, &local_error))
         {
-          message ("Commit %s from %s is not an update",
-                   checksum,
-                   url_override);
+          message ("Failed to fetch metadata for commit %s from %s: %s",
+                   checksum, url_override, local_error->message);
+          continue;
+        }
+      else if (commit == NULL)
+        {
+          message ("Commit %s from %s is not an update; ignoring",
+                   checksum, url_override);
           continue;
         }
 


### PR DESCRIPTION
If eos-updater polled for updates from another computer on the local
network which has the same (or an older) OSTree ref deployed as the
current computer, eos-updater would crash.

This never actually caused a problem, because eos-updater not running is
essentially equivalent to it running and being in the Ready state, which
is the state it would have switched back to after finding no newer
OSTree commits to fetch from the other computer. It would have caused
problems on networks where there’s more than one computer advertising
updates; but that’s not a configuration we support yet.

In any case, crashing is bad. Fix it. The confusion resulted from
is_checksum_an_update() returning TRUE while explicitly not returning
something in one of its out parameters, and the caller not handling this
situation correctly.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15908