### PR TITLE
debian: Add postinst script to delete outdated eos-updater.service

### DIFF
--- a/debian/eos-updater.postinst
+++ b/debian/eos-updater.postinst
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+#DEBHELPER#
+
+# Convert from eos-updater.{service,timer} being an alias for
+# eos-autoupdater.{service,timer}. eos-updater.timer should now never exist.
+grep -qs "ExecStart=.*eos-autoupdater" /etc/systemd/system/eos-updater.service && \
+  rm /etc/systemd/system/eos-updater.service
+rm -f /etc/systemd/system/eos-updater.timer


### PR DESCRIPTION
Previous versions of eos-updater provided eos-updater.{service,timer} as
aliases for eos-autoupdater.{service,timer}. The latest versions provide
eos-updater.service as an independent service file (for binding the
com.endlessm.Updater D-Bus service to systemd), and no
eos-updater.timer.

However, existing EOS deployments might have left-over
eos-updater.{service,timer} files in /etc/systemd/system due to
previously editing them. They won’t match the new unit file setup, and
will override it, causing eos-updater to not start on demand.

Fix that by deleting them in an eos-updater.postinst script. This will
only take effect on dev-converted systems — on non-dev-converted
systems, we have to rely on people having not edited the unit files.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15910