### PR TITLE
debian: Bump libostree dependency for new archive-z2 symbol

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Build-Depends:
  libglib2.0-dev (>= 2.50.0),
  libgsystem-dev,
  libnm-glib-dev,
- libostree-dev (>= 2016.15),
+ libostree-dev (>= 2016.15+dev24.a109440),
  libsoup2.4-dev,
  libsystemd-dev,
  ostree,


### PR DESCRIPTION
This is a follow-up commit for 7234b8ef which bumps our libostree
package dependency to the one including the new symbol. Note that this
doesn’t bump the dependency in configure.ac for the reasons mentioned in
commit 7234b8ef.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15909