### PR TITLE
eos-updater-avahi: Add Wants= dependency from multi-user.target

### DIFF
--- a/eos-updater-avahi/eos-updater-avahi.service.in
+++ b/eos-updater-avahi/eos-updater-avahi.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Endless OS Avahi Advertisement Updater
 Documentation=man:eos-updater-avahi(8)
+Wants=avahi-daemon.service
 
 # Try to start the update server socket after updating the Avahi service file,
 # since eos-update-server.socket has a ConditionPathExists on it.
@@ -37,3 +38,4 @@ ProtectSystem=true
 
 [Install]
 Also=eos-update-server.service eos-updater-avahi.path
+WantedBy=multi-user.target


### PR DESCRIPTION
Previously, the eos-updater-avahi.service unit would only be triggered
when any of the paths watched by eos-updater-avahi.path were changed.
This isn’t actually what we want — we also want it to be triggered on
boot when those paths aren’t changed, just to sync the state of the
Avahi service file.

Add a WantedBy=multi-user.target to achieve that; and correctly add the
Wants=avahi-daemon.service relation to ensure this does pull the Avahi
daemon into the boot too.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T16000