### PR TITLE
autoupdater: Port to libnm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,7 +56,7 @@ AC_DEFINE_UNQUOTED([EOS_AVAHI_PORT], [$port], [Socket activation port to be used
 GLIB_REQUIRED_VERSION=2.50.0
 OSTREE_REQUIRED_VERSION=2016.15
 AVAHI_REQUIRED_VERSION=0.6.31
-NM_REQUIRED_VERSION=0.9.8.6
+NM_REQUIRED_VERSION=1.2.0
 
 PKG_CHECK_MODULES([GIO],
                   [gio-unix-2.0 >= $GLIB_REQUIRED_VERSION])
@@ -68,7 +68,7 @@ PKG_CHECK_MODULES([SOUP],
                   [libsoup-2.4])
 
 PKG_CHECK_MODULES([EOS_AUTOUPDATER],
-                  [libnm-glib >= $NM_REQUIRED_VERSION
+                  [libnm >= $NM_REQUIRED_VERSION
                    libsystemd])
 
 PKG_CHECK_MODULES([EOS_UPDATE_SERVER],

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Build-Depends:
  libgirepository1.0-dev (>= 1.30.0),
  libglib2.0-dev (>= 2.50.0),
  libgsystem-dev,
- libnm-glib-dev,
+ libnm-dev (>= 1.2.0),
  libostree-dev (>= 2016.15+dev24.a109440),
  libsoup2.4-dev,
  libsystemd-dev,


### PR DESCRIPTION
The libnm-glib library is deprecated.

https://phabricator.endlessm.com/T15813

Unfortunately `make check` does not pass for me neither on my branch nor on the current master branch. Will need to investigate.