### PR TITLE
T16387 test failure

### DIFF
--- a/src/eos-repo-server.c
+++ b/src/eos-repo-server.c
@@ -829,10 +829,10 @@ server_cb (SoupServer *soup_server,
 }
 
 static void
-request_started_cb (SoupServer        *soup_server,
-                    SoupMessage       *message,
-                    SoupClientContext *client,
-                    gpointer           user_data)
+request_read_cb (SoupServer        *soup_server,
+                 SoupMessage       *message,
+                 SoupClientContext *client,
+                 gpointer           user_data)
 {
   EosUpdaterRepoServer *server = EOS_UPDATER_REPO_SERVER (soup_server);
 
@@ -880,7 +880,7 @@ eos_updater_repo_server_initable_init (GInitable     *initable,
                            server_cb,
                            NULL,
                            NULL);
-  g_signal_connect (server, "request-started", (GCallback) request_started_cb, NULL);
+  g_signal_connect (server, "request-read", (GCallback) request_read_cb, NULL);
   g_signal_connect (server, "request-finished", (GCallback) request_finished_cb, NULL);
   g_signal_connect (server, "request-aborted", (GCallback) request_aborted_cb, NULL);
 

--- a/src/eos-update-server.c
+++ b/src/eos-update-server.c
@@ -262,7 +262,10 @@ no_requests_timeout (EosUpdaterRepoServer *server,
   gint64 diff;
 
   if (pending_requests > 0)
-    return FALSE;
+    {
+      g_debug ("%s: %u requests pending.", G_STRFUNC, pending_requests);
+      return FALSE;
+    }
 
   last_request_time = eos_updater_repo_server_get_last_request_time (server);
   monotonic_now = g_get_monotonic_time ();


### PR DESCRIPTION
This failure was only apparent when using keepalive connections to the server (or if the server started listening but was never sent a request).

https://phabricator.endlessm.com/T16387