### PR TITLE
eos-updater: Handle G_IO_ERROR_FAILED when running in FBE test mode

### DIFF
--- a/src/eos-updater-poll.c
+++ b/src/eos-updater-poll.c
@@ -268,13 +268,16 @@ metadata_fetch (GTask *task,
 
   /* Check we’re not on a dev-converted system. */
   deployment = eos_updater_get_booted_deployment (&error);
-  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND) ||
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_FAILED))
     {
       g_task_return_new_error (task, EOS_UPDATER_ERROR,
                                EOS_UPDATER_ERROR_NOT_OSTREE_SYSTEM,
                                "Not an OSTree-based system: cannot update it.");
       return;
     }
+
+  g_clear_error (&error);
 
   /* Work out which sources to poll. */
   if (!read_config (get_config_file_path (), &config, &error))

--- a/src/eos-updater.c
+++ b/src/eos-updater.c
@@ -108,7 +108,8 @@ on_bus_acquired (GDBusConnection *connection,
       eos_updater_set_update_id (updater, "");
       eos_updater_clear_error (updater, EOS_UPDATER_STATE_READY);
     }
-  else if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+  else if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND) ||
+           g_error_matches (error, G_IO_ERROR, G_IO_ERROR_FAILED))
     {
       g_clear_error (&error);
       g_set_error (&error, EOS_UPDATER_ERROR,


### PR DESCRIPTION
When test mode is enabled in the first boot environment, overlay file
systems are mounted on top of everything (including /ostree), which
breaks OSTree. (This is expected.)

This causes libostree to return an error from ostree_sysroot_load(),
which we were not correctly handling, and hence were passing through the
wrong error domain over eos-updater’s D-Bus interface. This caused an
error message to appear in the UI when it wasn’t supposed to.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T16574