### PR TITLE
util: Add functions for parsing the entire string as a number

### DIFF
--- a/eos-update-server/eos-update-server.c
+++ b/eos-update-server/eos-update-server.c
@@ -79,20 +79,16 @@ local_port_goption (const gchar *option_name,
                     GError **error)
 {
   guint64 number;
-  const gchar *endptr = NULL;
-  int saved_errno;
   Options* options = options_ptr;
+  g_autoptr(GError) local_error = NULL;
 
   if (!check_option_is (option_name, "--local-port", "-p", error))
     return FALSE;
 
-  errno = 0;
-  number = g_ascii_strtoull (value, (gchar **)&endptr, 10);
-  saved_errno = errno;
-  if (saved_errno != 0 || number == 0 || *endptr != '\0' || number > G_MAXUINT16)
+  if (!eos_string_to_unsigned (value, 10, 1, G_MAXUINT16, &number, &local_error))
     {
       g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
-                   "Invalid port number %s", value);
+                   "Invalid port number %s: %s", value, local_error->message);
       return FALSE;
     }
   options->local_port = number;

--- a/libeos-updater-util/tests/Makefile.am
+++ b/libeos-updater-util/tests/Makefile.am
@@ -55,10 +55,12 @@ test_programs = \
 	avahi-service-file \
 	config \
 	ostree \
+	util \
 	$(NULL)
 
 avahi_service_file_SOURCES = avahi-service-file.c
 config_SOURCES = config.c
 ostree_SOURCES = ostree.c
+util_SOURCES = util.c
 
 -include $(top_srcdir)/git.mk

--- a/libeos-updater-util/tests/util.c
+++ b/libeos-updater-util/tests/util.c
@@ -1,0 +1,255 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2017 Kinvolk GmbH
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Authors:
+ *  - Krzesimir Nowak <krzesimir@kinvolk.io>
+ */
+
+#include <locale.h>
+#include <glib.h>
+#include <libeos-updater-util/util.h>
+
+typedef enum
+  {
+    SIGNED,
+    UNSIGNED
+  } SignType;
+
+typedef struct
+{
+  const gchar *str;
+  SignType sign_type;
+  guint base;
+  gint min;
+  gint max;
+  gint expected;
+  gboolean should_fail;
+} TestData;
+
+const TestData test_data[] = {
+  /* typical cases for signed */
+  { "0",  SIGNED, 10, -2,  2,  0, FALSE },
+  { "+0", SIGNED, 10, -2,  2,  0, FALSE },
+  { "-0", SIGNED, 10, -2,  2,  0, FALSE },
+  { "-2", SIGNED, 10, -2,  2, -2, FALSE },
+  { "2",  SIGNED, 10, -2,  2,  2, FALSE },
+  { "+2", SIGNED, 10, -2,  2,  2, FALSE },
+  { "3",  SIGNED, 10, -2,  2,  0, TRUE  },
+  { "+3", SIGNED, 10, -2,  2,  0, TRUE  },
+  { "-3", SIGNED, 10, -2,  2,  0, TRUE  },
+
+  /* typical cases for unsigned */
+  { "-1", UNSIGNED, 10, 0, 2, 0, TRUE  },
+  { "1",  UNSIGNED, 10, 0, 2, 1, FALSE },
+  { "+1", UNSIGNED, 10, 0, 2, 0, TRUE  },
+  { "0",  UNSIGNED, 10, 0, 2, 0, FALSE },
+  { "+0", UNSIGNED, 10, 0, 2, 0, TRUE  },
+  { "-0", UNSIGNED, 10, 0, 2, 0, TRUE  },
+  { "2",  UNSIGNED, 10, 0, 2, 2, FALSE },
+  { "+2", UNSIGNED, 10, 0, 2, 0, TRUE  },
+  { "3",  UNSIGNED, 10, 0, 2, 0, TRUE  },
+  { "+3", UNSIGNED, 10, 0, 2, 0, TRUE  },
+
+  /* min == max cases for signed */
+  { "-2", SIGNED, 10, -2, -2, -2, FALSE },
+  { "-1", SIGNED, 10, -2, -2,  0, TRUE  },
+  { "-3", SIGNED, 10, -2, -2,  0, TRUE  },
+
+  /* min == max cases for unsigned */
+  { "2", UNSIGNED, 10, 2, 2, 2, FALSE },
+  { "3", UNSIGNED, 10, 2, 2, 0, TRUE  },
+  { "1", UNSIGNED, 10, 2, 2, 0, TRUE  },
+
+  /* invalid inputs */
+  { "",    SIGNED,   10, -2,  2,  0, TRUE },
+  { "",    UNSIGNED, 10,  0,  2,  0, TRUE },
+  { "a",   SIGNED,   10, -2,  2,  0, TRUE },
+  { "a",   UNSIGNED, 10,  0,  2,  0, TRUE },
+  { "1a",  SIGNED,   10, -2,  2,  0, TRUE },
+  { "1a",  UNSIGNED, 10,  0,  2,  0, TRUE },
+  { "- 1", SIGNED,   10, -2,  2,  0, TRUE },
+
+  /* leading/trailing whitespace */
+  { " 1", SIGNED,   10, -2,  2,  0, TRUE },
+  { " 1", UNSIGNED, 10,  0,  2,  0, TRUE },
+  { "1 ", SIGNED,   10, -2,  2,  0, TRUE },
+  { "1 ", UNSIGNED, 10,  0,  2,  0, TRUE },
+
+  /* hexadecimal numbers */
+  { "a",     SIGNED,   16,   0, 15, 10, FALSE },
+  { "a",     UNSIGNED, 16,   0, 15, 10, FALSE },
+  { "0xa",   SIGNED,   16,   0, 15,  0, TRUE  },
+  { "0xa",   UNSIGNED, 16,   0, 15,  0, TRUE  },
+  { "-0xa",  SIGNED,   16, -15, 15,  0, TRUE  },
+  { "-0xa",  UNSIGNED, 16,   0, 15,  0, TRUE  },
+  { "+0xa",  SIGNED,   16,   0, 15,  0, TRUE  },
+  { "+0xa",  UNSIGNED, 16,   0, 15,  0, TRUE  },
+  { "- 0xa", SIGNED,   16, -15, 15,  0, TRUE  },
+  { "- 0xa", UNSIGNED, 16,   0, 15,  0, TRUE  },
+  { "+ 0xa", SIGNED,   16, -15, 15,  0, TRUE  },
+  { "+ 0xa", UNSIGNED, 16,   0, 15,  0, TRUE  },
+};
+
+static void
+test_util_strtonum_usual (void)
+{
+  gsize idx;
+
+  for (idx = 0; idx < G_N_ELEMENTS (test_data); ++idx)
+    {
+      g_autoptr(GError) error = NULL;
+      const TestData *data = &test_data[idx];
+      gboolean result;
+      gint value;
+
+      switch (data->sign_type)
+        {
+        case SIGNED:
+          {
+            gint64 value64 = 0;
+            result = eos_string_to_signed (data->str,
+                                           data->base,
+                                           data->min,
+                                           data->max,
+                                           &value64,
+                                           &error);
+            value = value64;
+            g_assert_cmpint (value, ==, value64);
+            break;
+          }
+
+        case UNSIGNED:
+          {
+            guint64 value64 = 0;
+            result = eos_string_to_unsigned (data->str,
+                                             data->base,
+                                             data->min,
+                                             data->max,
+                                             &value64,
+                                             &error);
+            value = value64;
+            g_assert_cmpint (value, ==, value64);
+            break;
+          }
+
+        default:
+          g_assert_not_reached ();
+        }
+
+      if (data->should_fail)
+        {
+          g_assert_false (result);
+          g_assert_nonnull (error);
+        }
+      else
+        {
+          g_assert_true (result);
+          g_assert_null (error);
+          g_assert_cmpint (value, ==, data->expected);
+        }
+    }
+}
+
+static void
+test_util_strtonum_pathological (void)
+{
+  g_autoptr(GError) error = NULL;
+  const gchar *crazy_high = "999999999999999999999999999999999999";
+  const gchar *crazy_low = "-999999999999999999999999999999999999";
+  const gchar *max_uint64 = "18446744073709551615";
+  const gchar *max_int64 = "9223372036854775807";
+  const gchar *min_int64 = "-9223372036854775808";
+  guint64 uvalue = 0;
+  gint64 svalue = 0;
+
+  g_assert_false (eos_string_to_unsigned (crazy_high,
+                                          10,
+                                          0,
+                                          G_MAXUINT64,
+                                          NULL,
+                                          &error));
+  g_assert_nonnull (error);
+  g_clear_error (&error);
+  g_assert_false (eos_string_to_unsigned (crazy_low,
+                                          10,
+                                          0,
+                                          G_MAXUINT64,
+                                          NULL,
+                                          &error));
+  // crazy_low is a signed number so it is not a valid unsigned number
+  g_assert_nonnull (error);
+  g_clear_error (&error);
+
+  g_assert_false (eos_string_to_signed (crazy_high,
+                                        10,
+                                        G_MININT64,
+                                        G_MAXINT64,
+                                        NULL,
+                                        &error));
+  g_assert_nonnull (error);
+  g_clear_error (&error);
+  g_assert_false (eos_string_to_signed (crazy_low,
+                                        10,
+                                        G_MININT64,
+                                        G_MAXINT64,
+                                        NULL,
+                                        &error));
+  g_assert_nonnull (error);
+  g_clear_error (&error);
+
+  g_assert_true (eos_string_to_unsigned (max_uint64,
+                                         10,
+                                         0,
+                                         G_MAXUINT64,
+                                         &uvalue,
+                                         &error));
+  g_assert_no_error (error);
+  g_assert_cmpint (uvalue, ==, G_MAXUINT64);
+
+  g_assert_true (eos_string_to_signed (max_int64,
+                                       10,
+                                       G_MININT64,
+                                       G_MAXINT64,
+                                       &svalue,
+                                       &error));
+  g_assert_no_error (error);
+  g_assert_cmpint (svalue, ==, G_MAXINT64);
+
+  g_assert_true (eos_string_to_signed (min_int64,
+                                       10,
+                                       G_MININT64,
+                                       G_MAXINT64,
+                                       &svalue,
+                                       &error));
+  g_assert_no_error (error);
+  g_assert_cmpint (svalue, ==, G_MININT64);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  setlocale (LC_ALL, "");
+
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/util/strtonum/usual", test_util_strtonum_usual);
+  g_test_add_func ("/util/strtonum/pathological", test_util_strtonum_pathological);
+
+  return g_test_run ();
+}

--- a/libeos-updater-util/util.c
+++ b/libeos-updater-util/util.c
@@ -26,6 +26,7 @@
 
 #include <libsoup/soup.h>
 
+#include <errno.h>
 #include <string.h>
 
 OstreeRepo *
@@ -491,4 +492,206 @@ eos_updater_setup_quit_file (const gchar *path,
   quit_file->notify = notify;
 
   return g_steal_pointer (&quit_file);
+}
+
+static gboolean
+str_has_sign (const gchar *str)
+{
+  return str[0] == '-' || str[0] == '+';
+}
+
+static gboolean
+str_has_hex_prefix (const gchar *str)
+{
+  return str[0] == '0' && g_ascii_tolower (str[1]) == 'x';
+}
+
+/**
+ * eos_string_to_signed:
+ * @str: a string
+ * @base: base of a parsed number
+ * @min: a lower bound (inclusive)
+ * @max: an upper bound (inclusive)
+ * @out_num: (out) (optional): a return location for a number
+ * @error: a return location for #GError
+ *
+ * A convenience function for converting a string to a signed number.
+ *
+ * This function assumes that @str contains only a number of the given
+ * @base that is within inclusive bounds limited by @min and @max. If
+ * this is true, then the converted number is stored in @out_num. An
+ * empty string is not a valid input. A string with leading or
+ * trailing whitespace is also an invalid input.
+ *
+ * @base can be between 2 and 36 inclusive. Hexadecimal numbers must
+ * not be prefixed with "0x" or "0X". Such a problem does not exist
+ * for octal numbers, since they were usually prefixed with a zero
+ * which does not change the value of the parsed number.
+ *
+ * See g_ascii_strtoll() if you have more complex needs such as
+ * parsing a string which starts with a number, but then has other
+ * characters.
+ *
+ * Returns: %TRUE if @str was a number, otherwise %FALSE.
+ */
+gboolean
+eos_string_to_signed (const gchar  *str,
+                      guint         base,
+                      gint64        min,
+                      gint64        max,
+                      gint64       *out_num,
+                      GError      **error)
+{
+#if GLIB_CHECK_VERSION(2, 54, 0)
+  return g_ascii_string_to_signed (str, base, min, max, out_num, error);
+#else
+  gint64 number;
+  const gchar *end_ptr = NULL;
+  gint saved_errno = 0;
+
+  g_return_val_if_fail (str != NULL, FALSE);
+  g_return_val_if_fail (base >= 2 && base <= 36, FALSE);
+  g_return_val_if_fail (min <= max, FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+  if (str[0] == '\0')
+    {
+      g_set_error_literal (error,
+                           G_IO_ERROR, G_IO_ERROR_FAILED,
+                           "Empty string is not a number");
+      return FALSE;
+    }
+
+  errno = 0;
+  number = g_ascii_strtoll (str, (gchar **)&end_ptr, base);
+  saved_errno = errno;
+
+  if (/* We do not allow leading whitespace, but g_ascii_strtoll
+       * accepts it and just skips it, so we need to check for it
+       * ourselves.
+       */
+      g_ascii_isspace (str[0]) ||
+      /* We don't support hexadecimal numbers prefixed with 0x or
+       * 0X.
+       */
+      (base == 16 &&
+       (str_has_sign (str) ? str_has_hex_prefix (str + 1) : str_has_hex_prefix (str))) ||
+      (saved_errno != 0 && saved_errno != ERANGE) ||
+      end_ptr == NULL ||
+      *end_ptr != '\0')
+    {
+      g_set_error (error,
+                   G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "“%s” is not a signed number", str);
+      return FALSE;
+    }
+  if (saved_errno == ERANGE || number < min || number > max)
+    {
+      g_set_error (error,
+                   G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Number “%" G_GINT64_FORMAT "” is out of bounds"
+                   " [%" G_GINT64_FORMAT ", %" G_GINT64_FORMAT "]",
+                   number, min, max);
+      return FALSE;
+    }
+  if (out_num != NULL)
+    *out_num = number;
+  return TRUE;
+#endif
+}
+
+/**
+ * eos_string_to_unsigned:
+ * @str: a string
+ * @base: base of a parsed number
+ * @min: a lower bound (inclusive)
+ * @max: an upper bound (inclusive)
+ * @out_num: (out) (optional): a return location for a number
+ * @error: a return location for #GError
+ *
+ * A convenience function for converting a string to an unsigned number.
+ *
+ * This function assumes that @str contains only a number of the given
+ * @base that is within inclusive bounds limited by @min and @max. If
+ * this is true, then the converted number is stored in @out_num. An
+ * empty string is not a valid input. A string with leading or
+ * trailing whitespace is also an invalid input.
+ *
+ * @base can be between 2 and 36 inclusive. Hexadecimal numbers must
+ * not be prefixed with "0x" or "0X". Such a problem does not exist
+ * for octal numbers, since they were usually prefixed with a zero
+ * which does not change the value of the parsed number.
+ *
+ * See g_ascii_strtoull() if you have more complex needs such as
+ * parsing a string which starts with a number, but then has other
+ * characters.
+ *
+ * Returns: %TRUE if @str was a number, otherwise %FALSE.
+ */
+gboolean
+eos_string_to_unsigned (const gchar  *str,
+                        guint         base,
+                        guint64       min,
+                        guint64       max,
+                        guint64      *out_num,
+                        GError      **error)
+{
+#if GLIB_CHECK_VERSION(2, 54, 0)
+  return g_ascii_string_to_unsigned (str, base, min, max, out_num, error);
+#else
+  guint64 number;
+  const gchar *end_ptr = NULL;
+  gint saved_errno = 0;
+
+  g_return_val_if_fail (str != NULL, FALSE);
+  g_return_val_if_fail (base >= 2 && base <= 36, FALSE);
+  g_return_val_if_fail (min <= max, FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+  if (str[0] == '\0')
+    {
+      g_set_error_literal (error,
+                           G_IO_ERROR, G_IO_ERROR_FAILED,
+                           "Empty string is not a number");
+      return FALSE;
+    }
+
+  errno = 0;
+  number = g_ascii_strtoull (str, (gchar **)&end_ptr, base);
+  saved_errno = errno;
+
+  if (/* We do not allow leading whitespace, but g_ascii_strtoull
+       * accepts it and just skips it, so we need to check for it
+       * ourselves.
+       */
+      g_ascii_isspace (str[0]) ||
+      /* Unsigned number should have no sign.
+       */
+      str_has_sign (str) ||
+      /* We don't support hexadecimal numbers prefixed with 0x or
+       * 0X.
+       */
+      (base == 16 && str_has_hex_prefix (str)) ||
+      (saved_errno != 0 && saved_errno != ERANGE) ||
+      end_ptr == NULL ||
+      *end_ptr != '\0')
+    {
+      g_set_error (error,
+                   G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "“%s” is not an unsigned number", str);
+      return FALSE;
+    }
+  if (saved_errno == ERANGE || number < min || number > max)
+    {
+      g_set_error (error,
+                   G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Number “%" G_GUINT64_FORMAT "” is out of bounds"
+                   " [%" G_GUINT64_FORMAT ", %" G_GUINT64_FORMAT "]",
+                   number, min, max);
+      return FALSE;
+    }
+  if (out_num != NULL)
+    *out_num = number;
+  return TRUE;
+#endif
 }

--- a/libeos-updater-util/util.h
+++ b/libeos-updater-util/util.h
@@ -101,4 +101,18 @@ EosQuitFile *eos_updater_setup_quit_file (const gchar *path,
                                           guint timeout_seconds,
                                           GError **error);
 
+gboolean eos_string_to_signed (const gchar  *str,
+                               guint         base,
+                               gint64        min,
+                               gint64        max,
+                               gint64       *out_num,
+                               GError      **error);
+
+gboolean eos_string_to_unsigned (const gchar  *str,
+                                 guint         base,
+                                 guint64       min,
+                                 guint64       max,
+                                 guint64      *out_num,
+                                 GError      **error);
+
 G_END_DECLS

--- a/src/eos-autoupdater.c
+++ b/src/eos-autoupdater.c
@@ -20,6 +20,7 @@
 #include "eos-updater-types.h"
 #include "eos-updater-generated.h"
 #include <libeos-updater-util/config.h>
+#include <libeos-updater-util/util.h>
 
 #include <gio/gio.h>
 #include <glib.h>
@@ -788,7 +789,6 @@ get_dbus_timeout (void)
 {
   const gchar *value = NULL;
   gint64 timeout;
-  gchar *str_end = NULL;
 
   value = get_envvar_or ("EOS_UPDATER_TEST_AUTOUPDATER_DBUS_TIMEOUT",
                          NULL);
@@ -796,13 +796,7 @@ get_dbus_timeout (void)
   if (value == NULL || value[0] == '\0')
     return -1;
 
-  errno = 0;
-  timeout = g_ascii_strtoll (value, &str_end, 10);
-  if (errno != 0 ||
-      str_end == NULL ||
-      *str_end != '\0' ||
-      timeout > G_MAXINT ||
-      timeout < 0)
+  if (!eos_string_to_signed (value, 10, 0, G_MAXINT, &timeout, NULL))
     return -1;
 
   return timeout;

--- a/src/eos-updater-poll-lan.c
+++ b/src/eos-updater-poll-lan.c
@@ -29,7 +29,6 @@
 #include <libeos-updater-util/util.h>
 #include <libsoup/soup.h>
 #include <string.h>
-#include <errno.h>
 
 typedef enum
 {
@@ -243,20 +242,13 @@ check_dl_time (LanData *lan_data,
                GDateTime **utc_out)
 {
   gint64 utc_time;
-  gchar *utc_str_end = NULL;
   g_autoptr(GDateTime) utc = NULL;
 
   g_assert (dl_time != NULL);
 
   if (dl_time[0] == '\0')
     return FALSE;
-  errno = 0;
-  utc_time = g_ascii_strtoll (dl_time, &utc_str_end, 10);
-  if (errno == EINVAL)
-    return FALSE;
-  if (errno == ERANGE)
-    return FALSE;
-  if (*utc_str_end != '\0')
+  if (!eos_string_to_signed (dl_time, 10, G_MININT64, G_MAXINT64, &utc_time, NULL))
     return FALSE;
   utc = g_date_time_new_from_unix_utc (utc_time);
   if (utc == NULL)
@@ -328,12 +320,8 @@ static guint
 parse_txt_version (const gchar *txt_version)
 {
   guint64 v;
-  const gchar *end = NULL;
 
-  errno = 0;
-  v = g_ascii_strtoull (txt_version, (gchar **)&end, 10);
-
-  if (errno != 0 || end == NULL || *end != '\0' || end == txt_version || v > G_MAXUINT)
+  if (!eos_string_to_unsigned (txt_version, 10, 1, G_MAXUINT, &v, NULL))
     return 0;
 
   return v;


### PR DESCRIPTION
That thing got copy-pasted all over the place and I was about to do it
once again. Better just split it to function and add test to verify I
did not break anything.