### PR TITLE
new DNS-SD records

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -88,6 +88,7 @@ libeos_updater_util_libeos_updater_util_@EUU_API_VERSION@_la_SOURCES = \
 	libeos-updater-util/extensions.h \
 	libeos-updater-util/ostree-bloom-private.h \
 	libeos-updater-util/ostree-bloom.c \
+	libeos-updater-util/ostree-ref.h \
 	libeos-updater-util/ostree.c \
 	libeos-updater-util/ostree.h \
 	libeos-updater-util/refcounted.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -86,6 +86,8 @@ libeos_updater_util_libeos_updater_util_@EUU_API_VERSION@_la_SOURCES = \
 	libeos-updater-util/config.h \
 	libeos-updater-util/extensions.c \
 	libeos-updater-util/extensions.h \
+	libeos-updater-util/ostree-bloom-private.h \
+	libeos-updater-util/ostree-bloom.c \
 	libeos-updater-util/ostree.c \
 	libeos-updater-util/ostree.h \
 	libeos-updater-util/refcounted.h \

--- a/eos-updater-avahi/docs/eos-updater-avahi.8
+++ b/eos-updater-avahi/docs/eos-updater-avahi.8
@@ -117,6 +117,13 @@ Describes the DNS\-SD record for Avahi to advertise to the local network. No
 advertisement will be made if this file is not present. This is the file which
 \fBeos\-updater\-avahi\fP adds, updates and removes when run.
 .\"
+.IP \fI/etc/avahi/services/eos\-ostree\-updater\-[0–65535].service\fP 4
+.IX Item "/etc/avahi/services/eos-ostree-updater\-[0–65535].service"
+Similarly to the \fI/etc/avahi/services/eos\-updater.service\fP file,
+it describes the DNS\-SD record for Avahi, but a different format is
+used. Many files can exist, one for each advertised repository. These
+files are managed by \fBeos\-updater\-avahi\fP.
+.\"
 .IP \fI/etc/eos\-updater/eos\-update\-server.conf\fP 4
 .IX Item "/etc/eos\-updater/eos\-update\-server.conf"
 .IX Item "/usr/local/share/eos\-updater/eos\-update\-server.conf"

--- a/eos-updater-avahi/eos-updater-avahi.c
+++ b/eos-updater-avahi/eos-updater-avahi.c
@@ -18,15 +18,188 @@
  *
  * Authors:
  *  - Philip Withnall <withnall@endlessm.com>
+ *  - Krzesimir Nowak <krzesimir@kinvolk.io>
  */
 
 #include <glib.h>
 #include <libeos-update-server/config.h>
 #include <libeos-updater-util/avahi-service-file.h>
+#include <libeos-updater-util/extensions.h>
 #include <libeos-updater-util/ostree.h>
 #include <locale.h>
 #include <ostree.h>
 #include <stdlib.h>
+
+static gboolean
+get_refs (OstreeRepo     *repo,
+          gchar        ***out_refs,
+          GCancellable   *cancellable,
+          GError        **error)
+{
+  g_autoptr(GHashTable) refs = NULL;
+  GHashTableIter iter;
+  gchar *key;
+  gchar *value;
+  g_autoptr(GPtrArray) refs_array = NULL;
+
+  if (!ostree_repo_list_refs (repo,
+                              NULL, /* no prefix filtering */
+                              &refs,
+                              cancellable,
+                              error))
+    return FALSE;
+
+  if (g_hash_table_size (refs) == 0)
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                           "no refs to advertise");
+      return FALSE;
+    }
+  refs_array = g_ptr_array_new_full (g_hash_table_size (refs) + 1, g_free);
+  g_hash_table_iter_init (&iter, refs);
+  while (g_hash_table_iter_next (&iter, (gpointer *)&key, (gpointer *)&value))
+    {
+      g_autofree gchar *refspec = g_steal_pointer (&key);
+      g_autofree gchar *ref = NULL;
+
+      g_hash_table_iter_steal (&iter);
+      g_free (g_steal_pointer (&value));
+      if (!ostree_parse_refspec (refspec, NULL, &ref, error))
+        return FALSE;
+      g_ptr_array_add (refs_array, g_steal_pointer (&ref));
+    }
+  g_ptr_array_add (refs_array, NULL);
+
+  g_assert (out_refs);
+  *out_refs = (gchar **)g_ptr_array_free (g_steal_pointer (&refs_array), FALSE);
+  return TRUE;
+}
+
+static gboolean
+get_raw_summary_timestamp_from_metadata (GBytes    *summary,
+                                         gboolean  *out_found,
+                                         guint64   *out_timestamp,
+                                         GError   **error)
+{
+  g_autoptr(GVariant) summary_variant = g_variant_ref_sink (g_variant_new_from_bytes (OSTREE_SUMMARY_GVARIANT_FORMAT, summary, FALSE));
+  g_autoptr(GVariantIter) iter = NULL;
+  g_autofree gchar *key = NULL;
+  g_autoptr(GVariant) value = NULL;
+
+  g_variant_get (summary_variant, OSTREE_SUMMARY_GVARIANT_STRING, NULL, &iter);
+  while (g_variant_iter_next (iter, "{sv}", &key, &value))
+    {
+      if (g_strcmp0 (key, "ostree.summary.last-modified") == 0)
+        break;
+
+      g_free (g_steal_pointer (&key));
+      g_variant_unref (g_steal_pointer (&value));
+    }
+
+  g_assert (out_found != NULL);
+  g_assert (out_timestamp != NULL);
+  if (value == NULL)
+    {
+      *out_found = FALSE;
+      *out_timestamp = 0;
+      return TRUE;
+    }
+  if (!g_variant_is_of_type (value, G_VARIANT_TYPE_UINT64))
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                           "\"ostree.summary.last-modified\" "
+                           "metadata has an invalid type");
+      return FALSE;
+    }
+  *out_found = TRUE;
+  *out_timestamp = GUINT64_FROM_BE (g_variant_get_uint64 (value));
+  return TRUE;
+}
+
+static gboolean
+bad_timestamp (guint64   modification_time_secs,
+               GError  **error)
+{
+  g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+               "Invalid timestamp %" G_GUINT64_FORMAT,
+               modification_time_secs);
+  return FALSE;
+}
+
+static gboolean
+get_summary_timestamp_from_guint64 (guint64     modification_time_secs,
+                                    GDateTime **out_summary_timestamp,
+                                    GError    **error)
+{
+  g_autoptr(GDateTime) summary_timestamp = NULL;
+
+  if (modification_time_secs > G_MAXINT64)
+    return bad_timestamp (modification_time_secs, error);
+
+  summary_timestamp = g_date_time_new_from_unix_utc ((gint64)modification_time_secs);
+  if (summary_timestamp == NULL)
+    return bad_timestamp (modification_time_secs, error);
+
+  g_assert (out_summary_timestamp);
+  *out_summary_timestamp = g_steal_pointer (&summary_timestamp);
+  return TRUE;
+}
+
+static gboolean
+get_summary_timestamp (OstreeRepo    *repo,
+                       GDateTime    **out_summary_timestamp,
+                       GCancellable  *cancellable,
+                       GError       **error)
+{
+  // FIXME: Find the summary without using eos specific bits to ease
+  // the moving of this code to ostree.
+  g_autoptr(EosExtensions) extensions = eos_extensions_new_from_repo (repo,
+                                                                      cancellable,
+                                                                      error);
+  gboolean found;
+  guint64 raw_timestamp;
+
+  if (extensions == NULL)
+    return FALSE;
+
+  if (!get_raw_summary_timestamp_from_metadata (extensions->summary, &found, &raw_timestamp, error))
+    return FALSE;
+
+  if (!found)
+    raw_timestamp = extensions->summary_modification_time_secs;
+
+  return get_summary_timestamp_from_guint64 (raw_timestamp, out_summary_timestamp, error);
+}
+
+static gboolean
+get_refs_and_summary_timestamp (OstreeSysroot   *sysroot,
+                                gchar         ***out_refs,
+                                GDateTime      **out_summary_timestamp,
+                                GCancellable    *cancellable,
+                                GError         **error)
+{
+  g_autoptr(OstreeRepo) repo = NULL;
+  g_auto(GStrv) refs = NULL;
+  g_autoptr(GDateTime) summary_timestamp = NULL;
+
+  if (!ostree_sysroot_get_repo (sysroot,
+                                &repo,
+                                cancellable,
+                                error))
+    return FALSE;
+
+  if (!get_refs (repo, &refs, cancellable, error))
+    return FALSE;
+
+  if (!get_summary_timestamp (repo, &summary_timestamp, cancellable, error))
+    return FALSE;
+
+  g_assert (out_refs);
+  g_assert (out_summary_timestamp);
+  *out_refs = g_steal_pointer (&refs);
+  *out_summary_timestamp = g_steal_pointer (&summary_timestamp);
+  return TRUE;
+}
 
 static gboolean
 update_service_file (gboolean       advertise_updates,
@@ -106,6 +279,16 @@ update_service_file (gboolean       advertise_updates,
   /* Apply the policy. */
   if (!delete)
     {
+      g_autoptr(GDateTime) summary_timestamp = NULL;
+      g_auto(GStrv) refs = NULL;
+
+      if (!get_refs_and_summary_timestamp (sysroot,
+                                           &refs,
+                                           &summary_timestamp,
+                                           cancellable,
+                                           error))
+        return FALSE;
+
       if (!eos_avahi_service_file_generate (avahi_service_directory,
                                             commit_ostree_path,
                                             commit_date_time,
@@ -116,13 +299,33 @@ update_service_file (gboolean       advertise_updates,
                                          NULL);
           return FALSE;
         }
+      if (!eos_ostree_avahi_service_file_generate (avahi_service_directory,
+                                                   (const gchar *const *) refs,
+                                                   summary_timestamp,
+                                                   NULL, /* no options, use defaults */
+                                                   cancellable,
+                                                   error))
+        {
+          eos_ostree_avahi_service_file_delete (avahi_service_directory,
+                                                0,
+                                                cancellable,
+                                                NULL);
+          eos_avahi_service_file_delete (avahi_service_directory, cancellable,
+                                         NULL);
+          return FALSE;
+        }
 
       return TRUE;
     }
   else
     {
-      return eos_avahi_service_file_delete (avahi_service_directory,
-                                            cancellable, error);
+      if (!eos_avahi_service_file_delete (avahi_service_directory,
+                                          cancellable, error))
+        return FALSE;
+      return eos_ostree_avahi_service_file_delete (avahi_service_directory,
+                                                   0,
+                                                   cancellable,
+                                                   error);
     }
 }
 

--- a/libeos-update-server/repo.c
+++ b/libeos-update-server/repo.c
@@ -625,9 +625,19 @@ path_is_handled_as_is (const gchar *requested_path)
     }
 
   if (g_str_has_prefix (requested_path, "/deltas/") ||
-      g_str_has_prefix (requested_path, "/extensions/") ||
-      g_str_equal (requested_path, "/summary") ||
-      g_str_equal (requested_path, "/summary.sig"))
+      g_str_has_prefix (requested_path, "/extensions/"))
+    return TRUE;
+
+  return FALSE;
+}
+
+static gboolean
+path_is_summary (const gchar *path)
+{
+  if (g_str_equal (path, "/summary") ||
+      g_str_equal (path, "/summary.sig") ||
+      g_str_equal (path, "/extensions/eos/eos-summary") ||
+      g_str_equal (path, "/extensions/eos/eos-summary.sig"))
     return TRUE;
 
   return FALSE;
@@ -747,6 +757,40 @@ handle_config (EusRepo     *self,
 }
 
 static void
+handle_summary (EusRepo     *self,
+                SoupMessage *msg,
+                const gchar *requested_path)
+{
+  g_autofree gchar *eos_raw_path = NULL;
+
+  if (g_str_has_prefix (requested_path, "/summary"))
+    {
+      g_autofree gchar *raw_path = g_build_filename (self->cached_repo_root, requested_path, NULL);
+      g_autofree gchar *eos_summary_path = NULL;
+      gboolean served = FALSE;
+
+      if (!serve_file_if_exists (msg,
+                                 self->cached_repo_root,
+                                 raw_path,
+                                 self->cancellable,
+                                 &served))
+        return;
+      if (served)
+        return;
+
+      eos_summary_path = g_strconcat ("/extensions/eos/eos-", requested_path + 1, NULL);
+      eos_raw_path = g_build_filename (self->cached_repo_root, eos_summary_path, NULL);
+      g_debug ("no %s, falling back to %s", requested_path, eos_summary_path);
+    }
+  else
+    {
+      eos_raw_path = g_build_filename (self->cached_repo_root, requested_path, NULL);
+    }
+
+  serve_file (msg, self->cached_repo_root, eos_raw_path, self->cancellable);
+}
+
+static void
 handle_refs_heads (EusRepo     *self,
                    SoupMessage *msg,
                    const gchar *requested_path)
@@ -820,8 +864,10 @@ handle_path (EusRepo     *self,
     handle_objects_filez (self, msg, path);
   else if (path_is_handled_as_is (path))
     handle_as_is (self, msg, path);
-  else if (g_strcmp0 (path, "/config") == 0)
+  else if (g_str_equal (path, "/config"))
     handle_config (self, msg);
+  else if (path_is_summary (path))
+    handle_summary (self, msg, path);
   else if (g_str_has_prefix (path, "/refs/heads/"))
     handle_refs_heads (self, msg, path);
   else

--- a/libeos-updater-util/avahi-service-file.c
+++ b/libeos-updater-util/avahi-service-file.c
@@ -76,6 +76,7 @@ check_record_size (const gchar  *key,
 
 static gboolean
 handle_text_record (GString      *records_str,
+                    gsize        *total_size,
                     const gchar  *key,
                     GVariant     *text_value,
                     GError      **error)
@@ -91,6 +92,11 @@ handle_text_record (GString      *records_str,
   if (!check_record_size (key, record_size, error))
     return FALSE;
 
+  /* txt records are pascal strings, so one byte for length and then
+   * payload.
+   */
+  g_assert (total_size != NULL);
+  *total_size += 1 + record_size;
   escaped_key = g_markup_escape_text (key, key_length);
   escaped_value = g_markup_escape_text (value_string, value_string_length);
   g_string_append_printf (records_str,
@@ -102,6 +108,7 @@ handle_text_record (GString      *records_str,
 
 static gboolean
 handle_binary_record (GString      *records_str,
+                      gsize        *total_size,
                       const gchar  *key,
                       GVariant     *binary_value,
                       GError      **error)
@@ -119,6 +126,11 @@ handle_binary_record (GString      *records_str,
   if (!check_record_size (key, record_size, error))
     return FALSE;
 
+  /* txt records are pascal strings, so one byte for length and then
+   * payload.
+   */
+  g_assert (total_size != NULL);
+  *total_size += 1 + record_size;
   escaped_key = g_markup_escape_text (key, key_length);
   encoded_value = g_base64_encode (value_data, value_data_length);
   escaped_value = g_markup_escape_text (encoded_value, -1);
@@ -129,14 +141,121 @@ handle_binary_record (GString      *records_str,
   return TRUE;
 }
 
+static gboolean
+get_and_check_txt_records_size_level (GVariantDict  *options_dict,
+                                      guint8        *out_size_level,
+                                      GError       **error)
+{
+  guint8 size_level = EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_DNS_MESSAGE;
+
+  g_variant_dict_lookup (options_dict, EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_SIZE_LEVEL_Y,
+                         "y", &size_level);
+  switch (size_level)
+    {
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_CUSTOM:
+      if (!g_variant_dict_lookup (options_dict,
+                                  EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_CUSTOM_SIZE_T,
+                                  "t",
+                                  NULL))
+        {
+          g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                               "custom size level set, but no custom size "
+                               "limit passed to the options or it is of wrong type");
+          return FALSE;
+        }
+      /* fall through */
+
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_SUPPORT_FAULTY_HARDWARE:
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_DNS_MESSAGE:
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_ETHERNET_PACKET:
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_MULTICAST_DNS_PACKET:
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_16_BIT_LIMIT:
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_ABSOLUTELY_LAX:
+      if (out_size_level)
+        *out_size_level = size_level;
+      return TRUE;
+
+    default:
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "unknown value %" G_GUINT16_FORMAT " for the %s option",
+                   (guint16) size_level,
+                   EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_SIZE_LEVEL_Y);
+      return FALSE;
+    }
+}
+
+static gboolean
+validate_total_size (gsize          total_size,
+                     GVariantDict  *options_dict,
+                     GError       **error)
+{
+  guint8 size_level;
+  guint64 limit;
+
+  if (!get_and_check_txt_records_size_level (options_dict, &size_level, error))
+    return FALSE;
+
+  switch (size_level)
+    {
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_CUSTOM:
+      {
+        gboolean result = g_variant_dict_lookup (options_dict,
+                                                 EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_CUSTOM_SIZE_T,
+                                                 "t",
+                                                 &limit);
+        g_assert (result);
+      }
+      break;
+
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_SUPPORT_FAULTY_HARDWARE:
+      limit = 256;
+      break;
+
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_DNS_MESSAGE:
+      limit = 400;
+      break;
+
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_ETHERNET_PACKET:
+      limit = 1300;
+      break;
+
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_MULTICAST_DNS_PACKET:
+      limit = 8900;
+      break;
+
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_16_BIT_LIMIT:
+      limit = G_MAXUINT16;
+      break;
+
+    case EOS_OSTREE_AVAHI_SIZE_LEVEL_ABSOLUTELY_LAX:
+      return TRUE;
+
+    default:
+      g_assert_not_reached ();
+    }
+
+  if (total_size > limit)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "TXT records of size %" G_GSIZE_FORMAT " break "
+                   "the limit of %" G_GUINT64_FORMAT " bytes",
+                   total_size, limit);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
 static gchar *
-txt_records_to_string (GVariant  *txt_records,
-                       GError   **error)
+txt_records_to_string (GVariant      *txt_records,
+                       GVariantDict  *options_dict,
+                       GError       **error)
 {
   GVariantIter iter;
   g_autoptr(GString) str = NULL;
   GVariant *txt_value;
   const gchar *txt_key;
+  gsize total_size = 0;
 
   g_assert (g_variant_is_of_type (txt_records, G_VARIANT_TYPE ("a(sv)")));
 
@@ -149,12 +268,12 @@ txt_records_to_string (GVariant  *txt_records,
       switch (txt_value_type)
         {
         case TXT_VALUE_TYPE_TEXT:
-          if (!handle_text_record (str, txt_key, txt_value, error))
+          if (!handle_text_record (str, &total_size, txt_key, txt_value, error))
             return FALSE;
           break;
 
         case TXT_VALUE_TYPE_BINARY:
-          if (!handle_binary_record (str, txt_key, txt_value, error))
+          if (!handle_binary_record (str, &total_size, txt_key, txt_value, error))
             return FALSE;
           break;
 
@@ -163,19 +282,26 @@ txt_records_to_string (GVariant  *txt_records,
         }
     }
 
+  if (!validate_total_size (total_size,
+                            options_dict,
+                            error))
+    return NULL;
+
   return g_string_free (g_steal_pointer (&str), FALSE);
 }
 
 static GBytes *
-generate_from_avahi_service_template (const gchar  *name,
-                                      const gchar  *type,
-                                      guint16       port,
-                                      GVariant     *txt_records,
-                                      GError      **error)
+generate_from_avahi_service_template (const gchar   *name,
+                                      const gchar   *type,
+                                      guint16        port,
+                                      GVariant      *txt_records,
+                                      GVariantDict  *options_dict,
+                                      GError       **error)
 {
   g_autofree gchar *service_group = NULL;
   gsize service_group_len;  /* bytes, not including trailing nul */
   g_autofree gchar *txt_records_str = txt_records_to_string (txt_records,
+                                                             options_dict,
                                                              error);
   g_autofree gchar *type_escaped = NULL;
   g_autofree gchar *name_escaped = NULL;
@@ -206,6 +332,7 @@ generate_avahi_service_template_to_file (GFile         *path,
                                          const gchar   *type,
                                          guint16        port,
                                          GVariant      *txt_records,
+                                         GVariantDict  *options_dict,
                                          GCancellable  *cancellable,
                                          GError       **error)
 {
@@ -218,6 +345,7 @@ generate_avahi_service_template_to_file (GFile         *path,
                                                    type,
                                                    port,
                                                    reffed_txt_records,
+                                                   options_dict,
                                                    error);
   if (contents == NULL)
     return FALSE;
@@ -244,6 +372,7 @@ generate_v1_service_file (const gchar   *ostree_path,
   g_autofree gchar *timestamp_str = NULL;
   const GVariantType *records_type = G_VARIANT_TYPE ("a(sv)");
   g_auto(GVariantBuilder) records_builder = G_VARIANT_BUILDER_INIT (records_type);
+  g_auto(GVariantDict) empty_options_dict = G_VARIANT_DICT_INIT (NULL);
 
   timestamp_str = g_date_time_format (head_commit_timestamp, "%s");
   g_variant_builder_add (&records_builder, "(sv)",
@@ -261,6 +390,7 @@ generate_v1_service_file (const gchar   *ostree_path,
                                                   EOS_UPDATER_AVAHI_SERVICE_TYPE,
                                                   EOS_AVAHI_PORT,
                                                   g_variant_builder_end (&records_builder),
+                                                  &empty_options_dict,
                                                   cancellable,
                                                   error);
 }

--- a/libeos-updater-util/avahi-service-file.c
+++ b/libeos-updater-util/avahi-service-file.c
@@ -28,6 +28,8 @@
 #include <libeos-updater-util/util.h>
 #include <string.h>
 
+#include "ostree-bloom-private.h"
+
 #ifndef EOS_AVAHI_PORT
 #error "EOS_AVAHI_PORT is not defined"
 #endif
@@ -520,4 +522,695 @@ eos_avahi_service_file_delete (const gchar   *avahi_service_directory,
     return FALSE;
 
   return TRUE;
+}
+
+/* new DNS-SD records format for ostree */
+
+#define EOS_OSTREE_AVAHI_SERVICE_TYPE "_ostree_repo._tcp"
+
+#define EOS_OSTREE_AVAHI_VERSION_FIELD "v"
+#define EOS_OSTREE_AVAHI_VERSION_VARIANT_TYPE G_VARIANT_TYPE_BYTE
+
+#define EOS_OSTREE_AVAHI_V1_REFS_BLOOM_FILTER_FIELD "rb"
+#define EOS_OSTREE_AVAHI_V1_REFS_BLOOM_FILTER_VARIANT_TYPE (G_VARIANT_TYPE ("(yyay)"))
+#define EOS_OSTREE_AVAHI_V1_SUMMARY_TIMESTAMP_FIELD "st"
+#define EOS_OSTREE_AVAHI_V1_SUMMARY_TIMESTAMP_VARIANT_TYPE G_VARIANT_TYPE_UINT64
+#define EOS_OSTREE_AVAHI_V1_REPOSITORY_INDEX_FIELD "ri"
+#define EOS_OSTREE_AVAHI_V1_REPOSITORY_INDEX_VARIANT_TYPE G_VARIANT_TYPE_UINT16
+
+static GFile *
+get_ostree_service_file (const gchar *avahi_service_directory,
+                         guint16      repository_index)
+{
+  g_autofree gchar *filename = NULL;
+  g_autofree gchar *service_file_path = NULL;
+
+  filename = g_strdup_printf ("eos-ostree-updater-%" G_GUINT16_FORMAT ".service",
+                              repository_index);
+  service_file_path = g_build_filename (avahi_service_directory,
+                                        filename,
+                                        NULL);
+  return g_file_new_for_path (service_file_path);
+}
+
+static guint16
+get_repository_index (GVariantDict *options_dict)
+{
+  guint16 index = 0;
+
+  g_variant_dict_lookup (options_dict, EOS_OSTREE_AVAHI_OPTION_REPO_INDEX_Q,
+                         "q", &index);
+
+  return index;
+}
+
+static gboolean
+get_and_check_avahi_service_port (GVariantDict  *options_dict,
+                                  guint16       *out_port,
+                                  GError       **error)
+{
+  // FIXME: Should we store the port number in the configuration
+  // instead having it as the compile-time constant? I can't remember
+  // why I opted for this solution (was it lack of the configuration
+  // file?)
+  //
+  // In case when config file doesn't specify the port number and the
+  // number wasn't provided with the options_dict variant, likely bail
+  // out.
+  guint16 port = EOS_AVAHI_PORT;
+
+  g_variant_dict_lookup (options_dict, EOS_OSTREE_AVAHI_OPTION_PORT_Q,
+                         "q", &port);
+
+  if (port == 0)
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                           "invalid port number 0");
+      return FALSE;
+    }
+
+  if (out_port)
+    *out_port = port;
+  return TRUE;
+}
+
+static gboolean
+get_and_check_bloom_size (GVariantDict  *options_dict,
+                          guint32       *out_bloom_size,
+                          GError       **error)
+{
+  /* 255 bytes is a maximum size of the key=value TXT record pair.  We
+   * subtract the length of the key name, then 1 byte for =, 1 byte
+   * for bloom k and 1 byte for hash id. There is no space reserved
+   * for the array of bytes being the bloom filter bits, because it is
+   * the last member of the variant tuple and it is treated specially.
+   */
+  guint32 max_bloom_size = 255 - strlen (EOS_OSTREE_AVAHI_V1_REFS_BLOOM_FILTER_FIELD) - 3;
+  guint32 bloom_size = max_bloom_size;
+
+  g_variant_dict_lookup (options_dict, EOS_OSTREE_AVAHI_OPTION_BLOOM_SIZE_U,
+                         "u", &bloom_size);
+  if (bloom_size == 0)
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                           "bloom filter size must be greater than zero");
+      return FALSE;
+    }
+  if (bloom_size > max_bloom_size)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "bloom filter with size %" G_GUINT32_FORMAT " is too "
+                   "large to be sent via DNS-SD records, maximum allowed "
+                   "size is %" G_GUINT32_FORMAT,
+                   bloom_size, max_bloom_size);
+      return FALSE;
+    }
+
+  if (out_bloom_size)
+    *out_bloom_size = bloom_size;
+  return TRUE;
+}
+
+static gboolean
+get_and_check_bloom_k (GVariantDict  *options_dict,
+                       guint8        *out_bloom_k,
+                       GError       **error)
+{
+  guint8 bloom_k = 1;
+
+  g_variant_dict_lookup (options_dict, EOS_OSTREE_AVAHI_OPTION_BLOOM_K_Y,
+                         "y", &bloom_k);
+  if (bloom_k == 0)
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                           "bloom k parameter must be greater than zero");
+      return FALSE;
+    }
+
+  if (out_bloom_k)
+    *out_bloom_k = bloom_k;
+  return TRUE;
+}
+
+static gboolean
+get_and_check_bloom_hash_func_id (GVariantDict         *options_dict,
+                                  guint8               *out_bloom_hash_func_id,
+                                  GError              **error)
+{
+  guint8 bloom_hash_id = EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR;
+
+  g_variant_dict_lookup (options_dict, EOS_OSTREE_AVAHI_OPTION_BLOOM_HASH_ID_Y,
+                         "y", &bloom_hash_id);
+
+  switch (bloom_hash_id)
+    {
+    case EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR:
+      if (out_bloom_hash_func_id)
+        *out_bloom_hash_func_id = bloom_hash_id;
+      return TRUE;
+
+    default:
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "unknown bloom hash function id %u", bloom_hash_id);
+      return FALSE;
+    }
+}
+
+static guint8
+hash_func_to_id (OstreeBloomHashFunc hash_func)
+{
+  if (hash_func == ostree_str_bloom_hash)
+    return EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR;
+
+  g_assert_not_reached ();
+}
+
+static OstreeBloomHashFunc
+id_to_hash_func (guint8 id)
+{
+  switch (id)
+    {
+    case EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR:
+      return ostree_str_bloom_hash;
+
+    default:
+      g_assert_not_reached ();
+    }
+}
+
+static gboolean
+get_clean_bloom_filter (GVariantDict  *options_dict,
+                        OstreeBloom  **out_bloom_filter,
+                        GError       **error)
+{
+  guint32 bloom_size;
+  guint8 bloom_k;
+  guint8 bloom_hash_func_id;
+
+  if (!get_and_check_bloom_size (options_dict, &bloom_size, error))
+    return FALSE;
+
+  if (!get_and_check_bloom_k (options_dict, &bloom_k, error))
+    return FALSE;
+
+  if (!get_and_check_bloom_hash_func_id (options_dict,
+                                         &bloom_hash_func_id,
+                                         error))
+    return FALSE;
+
+  g_assert (out_bloom_filter != NULL);
+  *out_bloom_filter = ostree_bloom_new (bloom_size,
+                                        bloom_k,
+                                        id_to_hash_func (bloom_hash_func_id));
+  return TRUE;
+}
+
+static gboolean
+get_bloom_filter_data (const gchar *const  *refs_to_advertise,
+                       GVariantDict        *options_dict,
+                       guint8              *out_bloom_k,
+                       guint8              *out_bloom_hash_func_id,
+                       GBytes             **out_bloom_filter_bits,
+                       GError             **error)
+{
+  g_autoptr(OstreeBloom) filter = NULL;
+  const gchar *const *iter;
+
+  if (!get_clean_bloom_filter (options_dict, &filter, error))
+    return FALSE;
+
+  for (iter = refs_to_advertise; iter != NULL && *iter != NULL; ++iter)
+    ostree_bloom_add_element (filter, *iter);
+
+  g_assert (out_bloom_k != NULL);
+  g_assert (out_bloom_hash_func_id != NULL);
+  g_assert (out_bloom_filter_bits != NULL);
+  *out_bloom_k = ostree_bloom_get_k (filter);
+  *out_bloom_hash_func_id = hash_func_to_id (ostree_bloom_get_hash_func (filter));
+  *out_bloom_filter_bits = ostree_bloom_seal (filter);
+  return TRUE;
+}
+
+static GVariant *
+get_version_variant (guint8 version)
+{
+  GVariant *variant = g_variant_new ("y", 1);
+
+  g_assert (g_variant_is_of_type (variant,
+                                  EOS_OSTREE_AVAHI_VERSION_VARIANT_TYPE));
+
+  return variant;
+}
+
+static GVariant *
+get_summary_timestamp_variant (guint64 summary_timestamp)
+{
+  GVariant *variant = g_variant_new ("t", GUINT64_TO_BE (summary_timestamp));
+
+  g_assert (g_variant_is_of_type (variant,
+                                  EOS_OSTREE_AVAHI_V1_SUMMARY_TIMESTAMP_VARIANT_TYPE));
+
+  return variant;
+}
+
+static GVariant *
+get_repository_index_variant (guint16 repository_index)
+{
+  GVariant *variant = g_variant_new ("q", GUINT16_TO_BE (repository_index));
+
+  g_assert (g_variant_is_of_type (variant,
+                                  EOS_OSTREE_AVAHI_V1_REPOSITORY_INDEX_VARIANT_TYPE));
+
+  return variant;
+}
+
+static GVariant *
+get_bloom_filter_variant (guint8  bloom_k,
+                          guint8  bloom_hash_func_id,
+                          GBytes *bloom_filter_bits)
+{
+  gsize data_length;
+  gconstpointer data = g_bytes_get_data (bloom_filter_bits, &data_length);
+  GVariant *variant = g_variant_new ("(yy@ay)",
+                                     bloom_k,
+                                     bloom_hash_func_id,
+                                     g_variant_new_fixed_array (G_VARIANT_TYPE_BYTE,
+                                                                data,
+                                                                data_length,
+                                                                1));
+
+  g_assert (g_variant_is_of_type (variant,
+                                  EOS_OSTREE_AVAHI_V1_REFS_BLOOM_FILTER_VARIANT_TYPE));
+
+  return variant;
+}
+
+static GVariant *
+variant_to_binary_variant (GVariant *variant)
+{
+  g_autoptr(GVariant) reffed_variant = g_variant_ref_sink (variant);
+  g_autoptr(GBytes) bytes = g_variant_get_data_as_bytes (reffed_variant);
+
+  return g_variant_new_fixed_array (G_VARIANT_TYPE_BYTE,
+                                    g_bytes_get_data (bytes, NULL),
+                                    g_bytes_get_size (bytes),
+                                    1);
+}
+
+static gboolean
+generate_ostree_avahi_v1_service_file_from_variants (GFile         *service_file,
+                                                     guint16        port,
+                                                     GVariant      *version_variant,
+                                                     GVariant      *refs_bloom_filter_variant,
+                                                     GVariant      *summary_timestamp_variant,
+                                                     GVariant      *repository_index_variant,
+                                                     GVariantDict  *options_dict,
+                                                     GCancellable  *cancellable,
+                                                     GError       **error)
+{
+  const GVariantType *records_type = G_VARIANT_TYPE ("a(sv)");
+  g_auto(GVariantBuilder) records_builder = G_VARIANT_BUILDER_INIT (records_type);
+
+  g_variant_builder_add (&records_builder, "(sv)",
+                         EOS_OSTREE_AVAHI_VERSION_FIELD,
+                         variant_to_binary_variant (g_steal_pointer (&version_variant)));
+  // FIXME: Maybe split the rb field for overlong bloom filters into
+  // rb1 which would be of gvariant type (yyay), and the followup rbX
+  // fields, for X > 1, which would be simply of gvariant type ay).
+  g_variant_builder_add (&records_builder, "(sv)",
+                         EOS_OSTREE_AVAHI_V1_REFS_BLOOM_FILTER_FIELD,
+                         variant_to_binary_variant (g_steal_pointer (&refs_bloom_filter_variant)));
+  g_variant_builder_add (&records_builder, "(sv)",
+                         EOS_OSTREE_AVAHI_V1_SUMMARY_TIMESTAMP_FIELD,
+                         variant_to_binary_variant (g_steal_pointer (&summary_timestamp_variant)));
+  g_variant_builder_add (&records_builder, "(sv)",
+                         EOS_OSTREE_AVAHI_V1_REPOSITORY_INDEX_FIELD,
+                         variant_to_binary_variant (g_steal_pointer (&repository_index_variant)));
+
+  return generate_avahi_service_template_to_file (service_file,
+                                                  "EOS OSTree update service on %h",
+                                                  EOS_OSTREE_AVAHI_SERVICE_TYPE,
+                                                  port,
+                                                  g_variant_builder_end (&records_builder),
+                                                  options_dict,
+                                                  cancellable,
+                                                  error);
+}
+
+static gboolean
+get_unix_summary_timestamp (GDateTime  *summary_timestamp,
+                            guint64    *out_summary_timestamp_unix,
+                            GError    **error)
+{
+  gint64 timestamp_unix = g_date_time_to_unix (summary_timestamp);
+
+  if (timestamp_unix < 0)
+    {
+      g_autofree gchar *formatted = g_date_time_format (summary_timestamp, "%FT%T%:z");
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "invalid summary timestamp %s", formatted);
+      return FALSE;
+    }
+
+  g_assert (out_summary_timestamp_unix != NULL);
+  *out_summary_timestamp_unix = (guint64)timestamp_unix;
+  return TRUE;
+}
+
+static gboolean
+generate_ostree_avahi_v1_service_file (const gchar         *avahi_service_directory,
+                                       const gchar *const  *refs_to_advertise,
+                                       GDateTime           *summary_timestamp,
+                                       GVariantDict        *options_dict,
+                                       GCancellable        *cancellable,
+                                       GError             **error)
+{
+  guint8 bloom_k;
+  guint8 bloom_hash_func_id;
+  g_autoptr(GBytes) bloom_filter_bits = NULL;
+  guint16 port;
+  guint16 repository_index;
+  guint64 summary_timestamp_unix;
+  g_autoptr(GFile) service_file = NULL;
+
+  if (!get_bloom_filter_data (refs_to_advertise,
+                              options_dict,
+                              &bloom_k,
+                              &bloom_hash_func_id,
+                              &bloom_filter_bits,
+                              error))
+    return FALSE;
+
+  if (!get_and_check_avahi_service_port (options_dict, &port, error))
+    return FALSE;
+
+  if (!get_unix_summary_timestamp (summary_timestamp, &summary_timestamp_unix, error))
+    return FALSE;
+
+  repository_index = get_repository_index (options_dict);
+  service_file = get_ostree_service_file (avahi_service_directory,
+                                          repository_index);
+  return generate_ostree_avahi_v1_service_file_from_variants (service_file,
+                                                              port,
+                                                              get_version_variant (1),
+                                                              get_bloom_filter_variant (bloom_k,
+                                                                                        bloom_hash_func_id,
+                                                                                        bloom_filter_bits),
+                                                              get_summary_timestamp_variant (summary_timestamp_unix),
+                                                              get_repository_index_variant (repository_index),
+                                                              options_dict,
+                                                              cancellable,
+                                                              error);
+}
+
+static gboolean
+get_and_check_version (GVariantDict  *options_dict,
+                       guint8        *out_version,
+                       GError       **error)
+{
+  /* This can't be changed, otherwise it may break the code that does
+   * not force the version in options, so assumes that version 1 will
+   * be used.
+   */
+  guint8 version = 1;
+
+  g_variant_dict_lookup (options_dict, EOS_OSTREE_AVAHI_OPTION_FORCE_VERSION_Y,
+                         "y", &version);
+  if (version == 0 || version > 1)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "unknown TXT record version: %u", version);
+      return FALSE;
+    }
+
+  if (out_version)
+    *out_version = version;
+  return TRUE;
+}
+
+static gboolean
+check_v1_options (GVariantDict  *options_dict,
+                  GError       **error)
+{
+  if (!get_and_check_bloom_size (options_dict, NULL, error))
+    return FALSE;
+
+  if (!get_and_check_bloom_k (options_dict, NULL, error))
+    return FALSE;
+
+  if (!get_and_check_bloom_hash_func_id (options_dict, NULL, error))
+    return FALSE;
+
+  if (!get_and_check_avahi_service_port (options_dict, NULL, error))
+    return FALSE;
+
+  if (!get_and_check_txt_records_size_level (options_dict, NULL, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+/**
+ * eos_ostree_avahi_service_file_check_options:
+ * @options: (nullable): vardict #GVariant
+ * @error: return location for a #GError
+ *
+ * Validates the contents of @options. Unknown keys in @options are
+ * ignored. If some key-value pair in @options is not valid in some
+ * way, the function will fill the @error variable and return %FALSE.
+ *
+ * If @options has a floating reference then this function sinks it.
+ *
+ * Note that this function can not check the real validity of the
+ * #EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_SIZE_LEVEL_Y key - it only
+ * checks if the key has a valid value, but it is not able to check if
+ * generated TXT records do not break the imposed limit. This error
+ * can be reported only by the
+ * eos_ostree_avahi_service_file_generate() function.
+ *
+ * Returns: whether contents of @options are valid
+ */
+gboolean
+eos_ostree_avahi_service_file_check_options (GVariant  *options,
+                                             GError   **error)
+{
+  g_autoptr(GVariant) reffed_options = (options != NULL) ? g_variant_ref_sink (options) : NULL;
+  g_auto(GVariantDict) options_dict = G_VARIANT_DICT_INIT (reffed_options);
+  guint8 version;
+
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+  if (!get_and_check_version (&options_dict, &version, error))
+    return FALSE;
+
+  switch (version)
+    {
+    case 1:
+      return check_v1_options (&options_dict, error);
+
+    default:
+      g_assert_not_reached ();
+    }
+}
+
+/**
+ * eos_ostree_avahi_service_file_generate:
+ * @avahi_service_directory: path to the directory containing `.service` files
+ * @refs_to_advertise: an array of refs to advertise
+ * @summary_timestamp: timestamp of the repo summary
+ * @options: (nullable): vardict #GVariant
+ * @cancellable: (nullable): a #GCancellable
+ * @error: return location for a #GError
+ *
+ * Create a `.service` file in @avahi_service_directory for the updater. This
+ * instructs Avahi to advertise a DNS-SD service for the updater, with TXT
+ * records indicating this machine has the refs for @ostree_path available with
+ * a commit at @head_commit_timestamp.
+ *
+ * @refs_to_advertise is an array of refs that will be advertised over
+ * the network. Note that at least one ref is expected. How the ref is
+ * advertised is dependent on the used version of the DNS-SD records.
+ *
+ * @summary_timestamp describes how old the summary is. Ideally, it
+ * should be something that is provided by the source of the summary
+ * (like metadata in the summary). As a fallback, a modification time
+ * of the locally stored summary file could be used, but it is rather
+ * fragile.
+ *
+ * @options can contain various options, which are dependent on the
+ * version of DNS-SD records. For the details, start reading about the
+ * %EOS_OSTREE_AVAHI_OPTION_FORCE_VERSION_Y option. If @options is
+ * %NULL, default values will be used instead. Default values are
+ * described in each options' documentation.
+ *
+ * If @options has a floating reference then this function sinks it.
+ *
+ * If the `.service` file already exists, it will be atomically
+ * replaced. If the @avahi_service_directory does not exist, or is not
+ * writeable, an error will be returned. If an error is returned, the
+ * old file will remain in place (if it exists), unmodified.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ */
+gboolean
+eos_ostree_avahi_service_file_generate (const gchar         *avahi_service_directory,
+                                        const gchar *const  *refs_to_advertise,
+                                        GDateTime           *summary_timestamp,
+                                        GVariant            *options,
+                                        GCancellable        *cancellable,
+                                        GError             **error)
+{
+  g_autoptr(GVariant) reffed_options = (options != NULL) ? g_variant_ref_sink (options) : NULL;
+  g_auto(GVariantDict) options_dict = G_VARIANT_DICT_INIT (reffed_options);
+  guint8 version;
+
+  g_return_val_if_fail (avahi_service_directory != NULL, FALSE);
+  g_return_val_if_fail (refs_to_advertise != NULL && *refs_to_advertise != NULL, FALSE);
+  g_return_val_if_fail (summary_timestamp != NULL, FALSE);
+  g_return_val_if_fail (options == NULL ||
+                        g_variant_is_of_type (options, G_VARIANT_TYPE_VARDICT),
+                        FALSE);
+  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+  if (!get_and_check_version (&options_dict,
+                              &version,
+                              error))
+    return FALSE;
+
+  switch (version)
+    {
+    case 1:
+      return generate_ostree_avahi_v1_service_file (avahi_service_directory,
+                                                    refs_to_advertise,
+                                                    summary_timestamp,
+                                                    &options_dict,
+                                                    cancellable,
+                                                    error);
+
+    default:
+      g_assert_not_reached ();
+    }
+}
+
+/**
+ * eos_ostree_avahi_service_file_delete:
+ * @avahi_service_directory: path to the directory containing `.service` files
+ * @repository_index: index of a repository
+ * @cancellable: (nullable): a #GCancellable
+ * @error: return location for a #GError
+ *
+ * Delete the updater’s `.service` file for the given repository index
+ * from the @avahi_service_directory. This has the same semantics as
+ * g_file_delete(); except if no `.service` file exists, or if
+ * @avahi_service_directory does not exist, %TRUE is returned.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ */
+gboolean
+eos_ostree_avahi_service_file_delete (const gchar   *avahi_service_directory,
+                                      guint16        repository_index,
+                                      GCancellable  *cancellable,
+                                      GError       **error)
+{
+  g_autoptr(GFile) service_file = NULL;
+
+  g_return_val_if_fail (avahi_service_directory != NULL, FALSE);
+  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable),
+                        FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+  service_file = get_ostree_service_file (avahi_service_directory,
+                                          repository_index);
+
+  if (!delete_file_if_exists (service_file, cancellable, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static gboolean
+iterate_and_remove_ostree_service_files (GFileEnumerator  *enumerator,
+                                         GCancellable     *cancellable,
+                                         GError          **error)
+{
+  g_autoptr(GRegex) re = g_regex_new ("^eos-ostree-updater-([0-9]+)\\.service$",
+                                      G_REGEX_OPTIMIZE,
+                                      0,
+                                      NULL);
+
+  g_assert (re != NULL);
+
+  while (TRUE)
+    {
+      GFileInfo *file_info;
+      GFile* file;
+      g_autoptr(GError) local_error = NULL;
+      g_autoptr(GMatchInfo) match_info = NULL;
+      g_autofree gchar *matched_repository_index = NULL;
+      const gchar *filename;
+
+      if (!g_file_enumerator_iterate (enumerator,
+                                      &file_info,
+                                      &file,
+                                      cancellable,
+                                      error))
+        return FALSE;
+
+      if (file_info == NULL || file == NULL)
+        break;
+
+      filename = g_file_info_get_name (file_info);
+      if (!g_regex_match (re, filename, 0, &match_info))
+        continue;
+
+      matched_repository_index = g_match_info_fetch (match_info, 1);
+      if (!eos_string_to_unsigned (matched_repository_index, 10, 0, G_MAXUINT16, NULL, NULL))
+        continue;
+      if (!delete_file_if_exists (file, cancellable, error))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+/**
+ * eos_ostree_avahi_service_file_cleanup_directory:
+ * @avahi_service_directory: path to the directory containing `.service` files
+ * @cancellable: (nullable): a #GCancellable
+ * @error: return location for a #GError
+ *
+ * Delete the updater’s `.service` files for the repository indices in
+ * range from 0 to 65535 (inclusive) from the
+ * @avahi_service_directory. If other files exist in the directory,
+ * they are left untouched. Note that it will not remove the file
+ * generated by the eos_avahi_service_file_generate() function.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ */
+gboolean
+eos_ostree_avahi_service_file_cleanup_directory (const gchar   *avahi_service_directory,
+                                                 GCancellable  *cancellable,
+                                                 GError       **error)
+{
+  g_autoptr(GFile) dir = NULL;
+  g_autoptr(GFileEnumerator) enumerator = NULL;
+
+  g_return_val_if_fail (avahi_service_directory != NULL, FALSE);
+  g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable),
+                        FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+  dir = g_file_new_for_path (avahi_service_directory);
+  enumerator = g_file_enumerate_children (dir,
+                                          "",
+                                          G_FILE_QUERY_INFO_NONE,
+                                          cancellable,
+                                          error);
+  if (enumerator == NULL)
+    return FALSE;
+
+  return iterate_and_remove_ostree_service_files (enumerator,
+                                                  cancellable,
+                                                  error);
 }

--- a/libeos-updater-util/avahi-service-file.c
+++ b/libeos-updater-util/avahi-service-file.c
@@ -664,7 +664,7 @@ get_and_check_bloom_hash_func_id (GVariantDict         *options_dict,
 
   switch (bloom_hash_id)
     {
-    case EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR:
+    case EOS_OSTREE_AVAHI_BLOOM_HASH_ID_OSTREE_COLLECTION_REF:
       if (out_bloom_hash_func_id)
         *out_bloom_hash_func_id = bloom_hash_id;
       return TRUE;
@@ -679,8 +679,8 @@ get_and_check_bloom_hash_func_id (GVariantDict         *options_dict,
 static guint8
 hash_func_to_id (OstreeBloomHashFunc hash_func)
 {
-  if (hash_func == ostree_str_bloom_hash)
-    return EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR;
+  if (hash_func == ostree_collection_ref_bloom_hash)
+    return EOS_OSTREE_AVAHI_BLOOM_HASH_ID_OSTREE_COLLECTION_REF;
 
   g_assert_not_reached ();
 }
@@ -690,8 +690,8 @@ id_to_hash_func (guint8 id)
 {
   switch (id)
     {
-    case EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR:
-      return ostree_str_bloom_hash;
+    case EOS_OSTREE_AVAHI_BLOOM_HASH_ID_OSTREE_COLLECTION_REF:
+      return ostree_collection_ref_bloom_hash;
 
     default:
       g_assert_not_reached ();
@@ -726,20 +726,20 @@ get_clean_bloom_filter (GVariantDict  *options_dict,
 }
 
 static gboolean
-get_bloom_filter_data (const gchar *const  *refs_to_advertise,
-                       GVariantDict        *options_dict,
-                       guint8              *out_bloom_k,
-                       guint8              *out_bloom_hash_func_id,
-                       GBytes             **out_bloom_filter_bits,
-                       GError             **error)
+get_bloom_filter_data (OstreeCollectionRef **refs_to_advertise,
+                       GVariantDict         *options_dict,
+                       guint8               *out_bloom_k,
+                       guint8               *out_bloom_hash_func_id,
+                       GBytes              **out_bloom_filter_bits,
+                       GError              **error)
 {
   g_autoptr(OstreeBloom) filter = NULL;
-  const gchar *const *iter;
+  OstreeCollectionRef **iter;
 
   if (!get_clean_bloom_filter (options_dict, &filter, error))
     return FALSE;
 
-  for (iter = refs_to_advertise; iter != NULL && *iter != NULL; ++iter)
+  for (iter = refs_to_advertise; *iter != NULL; ++iter)
     ostree_bloom_add_element (filter, *iter);
 
   g_assert (out_bloom_k != NULL);
@@ -878,12 +878,12 @@ get_unix_summary_timestamp (GDateTime  *summary_timestamp,
 }
 
 static gboolean
-generate_ostree_avahi_v1_service_file (const gchar         *avahi_service_directory,
-                                       const gchar *const  *refs_to_advertise,
-                                       GDateTime           *summary_timestamp,
-                                       GVariantDict        *options_dict,
-                                       GCancellable        *cancellable,
-                                       GError             **error)
+generate_ostree_avahi_v1_service_file (const gchar          *avahi_service_directory,
+                                       OstreeCollectionRef **refs_to_advertise,
+                                       GDateTime            *summary_timestamp,
+                                       GVariantDict         *options_dict,
+                                       GCancellable         *cancellable,
+                                       GError              **error)
 {
   guint8 bloom_k;
   guint8 bloom_hash_func_id;
@@ -1053,12 +1053,12 @@ eos_ostree_avahi_service_file_check_options (GVariant  *options,
  * Returns: %TRUE on success, %FALSE otherwise
  */
 gboolean
-eos_ostree_avahi_service_file_generate (const gchar         *avahi_service_directory,
-                                        const gchar *const  *refs_to_advertise,
-                                        GDateTime           *summary_timestamp,
-                                        GVariant            *options,
-                                        GCancellable        *cancellable,
-                                        GError             **error)
+eos_ostree_avahi_service_file_generate (const gchar          *avahi_service_directory,
+                                        OstreeCollectionRef **refs_to_advertise,
+                                        GDateTime            *summary_timestamp,
+                                        GVariant             *options,
+                                        GCancellable         *cancellable,
+                                        GError              **error)
 {
   g_autoptr(GVariant) reffed_options = (options != NULL) ? g_variant_ref_sink (options) : NULL;
   g_auto(GVariantDict) options_dict = G_VARIANT_DICT_INIT (reffed_options);

--- a/libeos-updater-util/avahi-service-file.c
+++ b/libeos-updater-util/avahi-service-file.c
@@ -343,6 +343,23 @@ eos_avahi_service_file_generate (const gchar   *avahi_service_directory,
                                    service_file, cancellable, error);
 }
 
+static gboolean
+delete_file_if_exists (GFile         *file,
+                       GCancellable  *cancellable,
+                       GError       **error)
+{
+  g_autoptr(GError) local_error = NULL;
+
+  if (!g_file_delete (file, cancellable, &local_error) &&
+      !g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+    {
+      g_propagate_error (error, g_steal_pointer (&local_error));
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
 /**
  * eos_avahi_service_file_delete:
  * @avahi_service_directory: path to the directory containing `.service` files
@@ -361,7 +378,6 @@ eos_avahi_service_file_delete (const gchar   *avahi_service_directory,
                                GError       **error)
 {
   g_autoptr(GFile) service_file = NULL;
-  g_autoptr(GError) local_error = NULL;
 
   g_return_val_if_fail (avahi_service_directory != NULL, FALSE);
   g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable),
@@ -370,12 +386,8 @@ eos_avahi_service_file_delete (const gchar   *avahi_service_directory,
 
   service_file = get_service_file (avahi_service_directory);
 
-  if (!g_file_delete (service_file, cancellable, &local_error) &&
-      !g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
-    {
-      g_propagate_error (error, g_steal_pointer (&local_error));
-      return FALSE;
-    }
+  if (!delete_file_if_exists (service_file, cancellable, error))
+    return FALSE;
 
   return TRUE;
 }

--- a/libeos-updater-util/avahi-service-file.c
+++ b/libeos-updater-util/avahi-service-file.c
@@ -37,67 +37,191 @@ const gchar * const EOS_UPDATER_AVAHI_SERVICE_TYPE = "_eos_updater._tcp";
 const gchar * const eos_avahi_v1_ostree_path = "eos_ostree_path";
 const gchar * const eos_avahi_v1_head_commit_timestamp = "eos_head_commit_timestamp";
 
-static gchar *
-txt_records_to_string (const gchar **txt_records)
+typedef enum
+  {
+    TXT_VALUE_TYPE_TEXT,
+    TXT_VALUE_TYPE_BINARY,
+  } TxtValueType;
+
+static TxtValueType
+classify_txt_value (GVariant *txt_value)
 {
+  gboolean txt_value_is_text = g_variant_is_of_type (txt_value,
+                                                     G_VARIANT_TYPE_STRING);
+  gboolean txt_value_is_binary = g_variant_is_of_type (txt_value,
+                                                       G_VARIANT_TYPE_BYTESTRING);
+
+  g_assert (txt_value_is_binary || txt_value_is_text);
+
+  if (txt_value_is_text)
+    return TXT_VALUE_TYPE_TEXT;
+
+  return TXT_VALUE_TYPE_BINARY;
+}
+
+static gboolean
+check_record_size (const gchar  *key,
+                   gsize         record_size,
+                   GError      **error)
+{
+  if (record_size > 255)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "the TXT record with key %s is longer than 255 bytes", key);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+handle_text_record (GString      *records_str,
+                    const gchar  *key,
+                    GVariant     *text_value,
+                    GError      **error)
+{
+  gsize value_string_length;
+  const gchar *value_string = g_variant_get_string (text_value,
+                                                    &value_string_length);
+  gsize key_length = strlen (key);
+  g_autofree gchar *escaped_key = NULL;
+  g_autofree gchar *escaped_value = NULL;
+  gsize record_size = value_string_length + key_length + 1;
+
+  if (!check_record_size (key, record_size, error))
+    return FALSE;
+
+  escaped_key = g_markup_escape_text (key, key_length);
+  escaped_value = g_markup_escape_text (value_string, value_string_length);
+  g_string_append_printf (records_str,
+                          "    <txt-record>%s=%s</txt-record>\n",
+                          escaped_key,
+                          escaped_value);
+  return TRUE;
+}
+
+static gboolean
+handle_binary_record (GString      *records_str,
+                      const gchar  *key,
+                      GVariant     *binary_value,
+                      GError      **error)
+{
+  gsize value_data_length;
+  gconstpointer value_data = g_variant_get_fixed_array (binary_value,
+                                                        &value_data_length,
+                                                        1);
+  gsize key_length = strlen (key);
+  g_autofree gchar *escaped_key = NULL;
+  g_autofree gchar *encoded_value = NULL;
+  g_autofree gchar *escaped_value = NULL;
+  gsize record_size = value_data_length + key_length + 1;
+
+  if (!check_record_size (key, record_size, error))
+    return FALSE;
+
+  escaped_key = g_markup_escape_text (key, key_length);
+  encoded_value = g_base64_encode (value_data, value_data_length);
+  escaped_value = g_markup_escape_text (encoded_value, -1);
+  g_string_append_printf (records_str,
+                          "    <txt-record value-format=\"binary-base64\">%s=%s</txt-record>\n",
+                          escaped_key,
+                          escaped_value);
+  return TRUE;
+}
+
+static gchar *
+txt_records_to_string (GVariant  *txt_records,
+                       GError   **error)
+{
+  GVariantIter iter;
   g_autoptr(GString) str = NULL;
-  gsize idx;
+  GVariant *txt_value;
+  const gchar *txt_key;
+
+  g_assert (g_variant_is_of_type (txt_records, G_VARIANT_TYPE ("a(sv)")));
 
   str = g_string_new ("");
-
-  for (idx = 0; txt_records[idx] != NULL; idx++)
+  g_variant_iter_init (&iter, txt_records);
+  while (g_variant_iter_loop (&iter, "(&sv)", &txt_key, &txt_value))
     {
-      g_autofree gchar *record_escaped = g_markup_escape_text (txt_records[idx], -1);
-      g_string_append_printf (str, "    <txt-record>%s</txt-record>\n",
-                              record_escaped);
+      TxtValueType txt_value_type = classify_txt_value (txt_value);
+
+      switch (txt_value_type)
+        {
+        case TXT_VALUE_TYPE_TEXT:
+          if (!handle_text_record (str, txt_key, txt_value, error))
+            return FALSE;
+          break;
+
+        case TXT_VALUE_TYPE_BINARY:
+          if (!handle_binary_record (str, txt_key, txt_value, error))
+            return FALSE;
+          break;
+
+        default:
+          g_assert_not_reached ();
+        }
     }
 
   return g_string_free (g_steal_pointer (&str), FALSE);
 }
 
 static GBytes *
-generate_from_avahi_service_template (const gchar *type,
-                                      guint16 port,
-                                      const gchar *txt_version,
-                                      const gchar **txt_records)
+generate_from_avahi_service_template (const gchar  *name,
+                                      const gchar  *type,
+                                      guint16       port,
+                                      GVariant     *txt_records,
+                                      GError      **error)
 {
   g_autofree gchar *service_group = NULL;
   gsize service_group_len;  /* bytes, not including trailing nul */
-  g_autofree gchar *txt_records_str = txt_records_to_string (txt_records);
-  g_autofree gchar *type_escaped = g_markup_escape_text (type, -1);
-  g_autofree gchar *txt_version_escaped = g_markup_escape_text (txt_version, -1);
+  g_autofree gchar *txt_records_str = txt_records_to_string (txt_records,
+                                                             error);
+  g_autofree gchar *type_escaped = NULL;
+  g_autofree gchar *name_escaped = NULL;
 
+  if (txt_records_str == NULL)
+    return NULL;
+
+  type_escaped = g_markup_escape_text (type, -1);
+  name_escaped = g_markup_escape_text (name, -1);
   service_group = g_strdup_printf (
       "<service-group>\n"
-      "  <name replace-wildcards=\"yes\">EOS update service on %%h</name>\n"
+      "  <name replace-wildcards=\"yes\">%s</name>\n"
       "  <service>\n"
       "    <type>%s</type>\n"
       "    <port>%" G_GUINT16_FORMAT "</port>\n"
-      "    <txt-record>eos_txt_version=%s</txt-record>\n"
       "%s"
       "  </service>\n"
       "</service-group>\n",
-      type_escaped, port, txt_version_escaped, txt_records_str);
+      name_escaped, type_escaped, port, txt_records_str);
   service_group_len = strlen (service_group);
 
   return g_bytes_new_take (g_steal_pointer (&service_group), service_group_len);
 }
 
 static gboolean
-generate_avahi_service_template_to_file (GFile *path,
-                                         const gchar *txt_version,
-                                         const gchar **txt_records,
-                                         GCancellable *cancellable,
-                                         GError **error)
+generate_avahi_service_template_to_file (GFile         *path,
+                                         const gchar   *name,
+                                         const gchar   *type,
+                                         guint16        port,
+                                         GVariant      *txt_records,
+                                         GCancellable  *cancellable,
+                                         GError       **error)
 {
   g_autoptr(GBytes) contents = NULL;
   gconstpointer raw;
   gsize raw_len;
+  g_autoptr(GVariant) reffed_txt_records = g_variant_ref_sink (txt_records);
 
-  contents = generate_from_avahi_service_template (EOS_UPDATER_AVAHI_SERVICE_TYPE,
-                                                   EOS_AVAHI_PORT,
-                                                   txt_version,
-                                                   txt_records);
+  contents = generate_from_avahi_service_template (name,
+                                                   type,
+                                                   port,
+                                                   reffed_txt_records,
+                                                   error);
+  if (contents == NULL)
+    return FALSE;
+
   raw = g_bytes_get_data (contents, &raw_len);
   return g_file_replace_contents (path,
                                   raw,
@@ -110,35 +234,33 @@ generate_avahi_service_template_to_file (GFile *path,
                                   error);
 }
 
-static gchar *
-txt_record (const gchar *key,
-            const gchar *value)
-{
-  return g_strdup_printf ("%s=%s", key, value);
-}
-
 static gboolean
-generate_v1_service_file (const gchar *ostree_path,
-                          GDateTime *head_commit_timestamp,
-                          GFile *service_file,
-                          GCancellable *cancellable,
-                          GError **error)
+generate_v1_service_file (const gchar   *ostree_path,
+                          GDateTime     *head_commit_timestamp,
+                          GFile         *service_file,
+                          GCancellable  *cancellable,
+                          GError       **error)
 {
-  g_autoptr(GPtrArray) txt_records = NULL;
   g_autofree gchar *timestamp_str = NULL;
+  const GVariantType *records_type = G_VARIANT_TYPE ("a(sv)");
+  g_auto(GVariantBuilder) records_builder = G_VARIANT_BUILDER_INIT (records_type);
 
   timestamp_str = g_date_time_format (head_commit_timestamp, "%s");
-  txt_records = g_ptr_array_new_with_free_func (g_free);
+  g_variant_builder_add (&records_builder, "(sv)",
+                         "eos_txt_version",
+                         g_variant_new_string ("1"));
+  g_variant_builder_add (&records_builder, "(sv)",
+                         eos_avahi_v1_ostree_path,
+                         g_variant_new_string (ostree_path));
+  g_variant_builder_add (&records_builder, "(sv)",
+                         eos_avahi_v1_head_commit_timestamp,
+                         g_variant_new_string (timestamp_str));
 
-  g_ptr_array_add (txt_records, txt_record (eos_avahi_v1_ostree_path,
-                                            ostree_path));
-  g_ptr_array_add (txt_records, txt_record (eos_avahi_v1_head_commit_timestamp,
-                                            timestamp_str));
-
-  g_ptr_array_add (txt_records, NULL);
   return generate_avahi_service_template_to_file (service_file,
-                                                  "1",
-                                                  (const gchar **)txt_records->pdata,
+                                                  "EOS update service on %h",
+                                                  EOS_UPDATER_AVAHI_SERVICE_TYPE,
+                                                  EOS_AVAHI_PORT,
+                                                  g_variant_builder_end (&records_builder),
                                                   cancellable,
                                                   error);
 }
@@ -200,11 +322,11 @@ get_service_file (const gchar *avahi_service_directory)
  * Returns: %TRUE on success, %FALSE otherwise
  */
 gboolean
-eos_avahi_service_file_generate (const gchar *avahi_service_directory,
-                                 const gchar *ostree_path,
-                                 GDateTime *head_commit_timestamp,
-                                 GCancellable *cancellable,
-                                 GError **error)
+eos_avahi_service_file_generate (const gchar   *avahi_service_directory,
+                                 const gchar   *ostree_path,
+                                 GDateTime     *head_commit_timestamp,
+                                 GCancellable  *cancellable,
+                                 GError       **error)
 {
   g_autoptr(GFile) service_file = NULL;
 

--- a/libeos-updater-util/avahi-service-file.h
+++ b/libeos-updater-util/avahi-service-file.h
@@ -44,4 +44,142 @@ gboolean eos_avahi_service_file_delete (const gchar   *avahi_service_directory,
                                         GCancellable  *cancellable,
                                         GError       **error);
 
+/**
+ * EOS_OSTREE_AVAHI_OPTION_FORCE_VERSION_Y:
+ *
+ * Tells which version of DNS-SD records should be generated. Also,
+ * tells which set of options will be used when during the check or
+ * generation.
+ *
+ * Currently there is only one version available: 1.
+ *
+ * The options specific for the version 1 are:
+ *
+ * - %EOS_OSTREE_AVAHI_OPTION_BLOOM_HASH_ID_Y
+ * - %EOS_OSTREE_AVAHI_OPTION_BLOOM_K_Y
+ * - %EOS_OSTREE_AVAHI_OPTION_BLOOM_SIZE_U
+ * - %EOS_OSTREE_AVAHI_OPTION_REPO_INDEX_Q
+ * - %EOS_OSTREE_AVAHI_OPTION_PORT_Q
+ * - %EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_SIZE_LEVEL_Y
+ * - %EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_CUSTOM_SIZE_T
+ *
+ * Default value of this option (if not overridden) is 1.
+ */
+#define EOS_OSTREE_AVAHI_OPTION_FORCE_VERSION_Y "force-version"
+/**
+ * EOS_OSTREE_AVAHI_OPTION_BLOOM_HASH_ID_Y:
+ *
+ * Specifies the ID of the hashing function for the bloom filter. See
+ * #EosOstreeAvahiBloomHashId for possible values.
+ *
+ * Default value of this option (if not overridden) is
+ * %EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR.
+ */
+#define EOS_OSTREE_AVAHI_OPTION_BLOOM_HASH_ID_Y "bloom-hash-id"
+/**
+ * EOS_OSTREE_AVAHI_OPTION_BLOOM_K_Y:
+ *
+ * Specifies the k parameter for the bloom filter. It translates to
+ * how many times an element will be hashed before using it to set a
+ * bit in the bloom filter.
+ *
+ * Default value of this option (if not overridden) is 1.
+ */
+#define EOS_OSTREE_AVAHI_OPTION_BLOOM_K_Y "bloom-k"
+/**
+ * EOS_OSTREE_AVAHI_OPTION_BLOOM_SIZE_U:
+ *
+ * Specifies the size of the bloom filter in bytes. Note that it
+ * cannot exceed the 250 bytes to fit it in the TXT record. The maths
+ * behind it is as follows:
+ *
+ * The TXT record can have maximum 256 bytes. 1 byte is reserved
+ * implicitly for the size of the record (you can think about the
+ * record as a pascal string). 2 bytes go for the name of the TXT
+ * record (it is "rb" from "refs bloom"). 1 byte go for the equal
+ * sign. 1 byte goes for the bloom k paramater and 1 byte goes for the
+ * bloom hashing function ID. That gives us 250 bytes max.
+ *
+ * Default value of this option (if not overridden) is 250.
+ */
+#define EOS_OSTREE_AVAHI_OPTION_BLOOM_SIZE_U "bloom-size"
+/**
+ * EOS_OSTREE_AVAHI_OPTION_REPO_INDEX_Q:
+ *
+ * Specifies the repo index for which the service file will be
+ * generated.
+ *
+ * Default value of this option (if not overridden) is 0.
+ */
+#define EOS_OSTREE_AVAHI_OPTION_REPO_INDEX_Q "repository-index"
+/**
+ * EOS_OSTREE_AVAHI_OPTION_PORT_Q:
+ *
+ * Specifies the port where the server serving the repository contents
+ * is listening.
+ *
+ * Default value of this option (if not overridden) is set at the
+ * compilation time.
+ */
+#define EOS_OSTREE_AVAHI_OPTION_PORT_Q "port"
+/**
+ * EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_SIZE_LEVEL_Y:
+ *
+ * Specifies the size limit generated TXT records can have. See
+ * #EosOstreeAvahiSizeLevel for possible values.
+ *
+ * Default value of this option (if not overridden) is
+ * %EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_DNS_MESSAGE.
+ */
+#define EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_SIZE_LEVEL_Y "txt-records-size-level"
+/**
+ * EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_CUSTOM_SIZE_T:
+ *
+ * Specifies the custom size limit. Only applicable if
+ * %EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_SIZE_LEVEL_Y was set to
+ * %EOS_OSTREE_AVAHI_SIZE_LEVEL_CUSTOM.
+ *
+ * It has no default value - must be specified explicitly.
+ */
+#define EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_CUSTOM_SIZE_T "txt-records-custom-size"
+
+/**
+ * EosOstreeAvahiBloomHashId:
+ * @EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR: Use ostree_str_bloom_hash() for hashing; it takes nul-terminated strings as an input.
+ *
+ * Possible values for the
+ * %EOS_OSTREE_AVAHI_OPTION_BLOOM_HASH_ID_Y option.
+ */
+typedef enum
+  {
+    EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR = 1
+  } EosOstreeAvahiBloomHashId;
+
+/**
+ * EosOstreeAvahiSizeLevel:
+ * @EOS_OSTREE_AVAHI_SIZE_LEVEL_CUSTOM: The size limit is specified in the %EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_CUSTOM_SIZE_T option
+ * @EOS_OSTREE_AVAHI_SIZE_LEVEL_SUPPORT_FAULTY_HARDWARE: TXT records size cannot exceed 256 bytes
+ * @EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_DNS_MESSAGE: TXT records size cannot exceed approximately 400
+ * bytes
+ * @EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_ETHERNET_PACKET: TXT records size cannot exceed approximately 1300
+ * bytes
+ * @EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_MULTICAST_DNS_PACKET: TXT records size cannot exceed approximately 8900
+ * bytes
+ * @EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_16_BIT_LIMIT: TXT records size cannot exceed %G_MAXUINT16 bytes
+ * @EOS_OSTREE_AVAHI_SIZE_LEVEL_ABSOLUTELY_LAX: TXT records size can be of any size
+ *
+ * Possible values for the
+ * %EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_SIZE_LEVEL_Y option.
+ */
+typedef enum
+  {
+    EOS_OSTREE_AVAHI_SIZE_LEVEL_CUSTOM,
+    EOS_OSTREE_AVAHI_SIZE_LEVEL_SUPPORT_FAULTY_HARDWARE,
+    EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_DNS_MESSAGE,
+    EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_ETHERNET_PACKET,
+    EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_MULTICAST_DNS_PACKET,
+    EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_16_BIT_LIMIT,
+    EOS_OSTREE_AVAHI_SIZE_LEVEL_ABSOLUTELY_LAX
+  } EosOstreeAvahiSizeLevel;
+
 G_END_DECLS

--- a/libeos-updater-util/avahi-service-file.h
+++ b/libeos-updater-util/avahi-service-file.h
@@ -27,6 +27,8 @@
 #include <gio/gio.h>
 #include <glib.h>
 
+#include "ostree-ref.h"
+
 G_BEGIN_DECLS
 
 extern const gchar * const EOS_UPDATER_AVAHI_SERVICE_TYPE;
@@ -60,7 +62,8 @@ gboolean eos_avahi_service_file_delete (const gchar   *avahi_service_directory,
  *
  * Fields for version 1 of TXT records:
  *
- * - refs bloom filter, a Bloom filter that contains all the refs the host has
+ * - refs bloom filter, a Bloom filter that contains all the
+ *   collection refs the host has
  *   - key: "rb"
  *   - type: "(yyay)" (tuple containing a byte, a byte and an array of bytes)
  *   - contents: first byte is the "k" parameter, second byte is the
@@ -109,7 +112,7 @@ gboolean eos_avahi_service_file_delete (const gchar   *avahi_service_directory,
  * #EosOstreeAvahiBloomHashId for possible values.
  *
  * Default value of this option (if not overridden) is
- * %EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR.
+ * %EOS_OSTREE_AVAHI_BLOOM_HASH_ID_OSTREE_COLLECTION_REF.
  */
 #define EOS_OSTREE_AVAHI_OPTION_BLOOM_HASH_ID_Y "bloom-hash-id"
 /**
@@ -181,14 +184,16 @@ gboolean eos_avahi_service_file_delete (const gchar   *avahi_service_directory,
 
 /**
  * EosOstreeAvahiBloomHashId:
- * @EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR: Use ostree_str_bloom_hash() for hashing; it takes nul-terminated strings as an input.
+ * @EOS_OSTREE_AVAHI_BLOOM_HASH_ID_OSTREE_COLLECTION_REF: Use
+ * ostree_collection_ref_bloom_hash() for hashing; it takes
+ * #OstreeCollectionRef instance as an input.
  *
  * Possible values for the
  * %EOS_OSTREE_AVAHI_OPTION_BLOOM_HASH_ID_Y option.
  */
 typedef enum
   {
-    EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR = 1
+    EOS_OSTREE_AVAHI_BLOOM_HASH_ID_OSTREE_COLLECTION_REF = 1
   } EosOstreeAvahiBloomHashId;
 
 /**
@@ -220,12 +225,12 @@ typedef enum
 
 gboolean eos_ostree_avahi_service_file_check_options (GVariant  *options,
                                                       GError   **error);
-gboolean eos_ostree_avahi_service_file_generate (const gchar         *avahi_service_directory,
-                                                 const gchar *const  *refs_to_advertise,
-                                                 GDateTime           *summary_timestamp,
-                                                 GVariant            *options,
-                                                 GCancellable        *cancellable,
-                                                 GError             **error);
+gboolean eos_ostree_avahi_service_file_generate (const gchar          *avahi_service_directory,
+                                                 OstreeCollectionRef **refs_to_advertise,
+                                                 GDateTime            *summary_timestamp,
+                                                 GVariant             *options,
+                                                 GCancellable         *cancellable,
+                                                 GError              **error);
 gboolean eos_ostree_avahi_service_file_delete (const gchar   *avahi_service_directory,
                                                guint16        repository_index,
                                                GCancellable  *cancellable,

--- a/libeos-updater-util/avahi-service-file.h
+++ b/libeos-updater-util/avahi-service-file.h
@@ -182,4 +182,20 @@ typedef enum
     EOS_OSTREE_AVAHI_SIZE_LEVEL_ABSOLUTELY_LAX
   } EosOstreeAvahiSizeLevel;
 
+gboolean eos_ostree_avahi_service_file_check_options (GVariant  *options,
+                                                      GError   **error);
+gboolean eos_ostree_avahi_service_file_generate (const gchar         *avahi_service_directory,
+                                                 const gchar *const  *refs_to_advertise,
+                                                 GDateTime           *summary_timestamp,
+                                                 GVariant            *options,
+                                                 GCancellable        *cancellable,
+                                                 GError             **error);
+gboolean eos_ostree_avahi_service_file_delete (const gchar   *avahi_service_directory,
+                                               guint16        repository_index,
+                                               GCancellable  *cancellable,
+                                               GError       **error);
+gboolean eos_ostree_avahi_service_file_cleanup_directory (const gchar   *avahi_service_directory,
+                                                          GCancellable  *cancellable,
+                                                          GError       **error);
+
 G_END_DECLS

--- a/libeos-updater-util/avahi-service-file.h
+++ b/libeos-updater-util/avahi-service-file.h
@@ -44,6 +44,42 @@ gboolean eos_avahi_service_file_delete (const gchar   *avahi_service_directory,
                                         GCancellable  *cancellable,
                                         GError       **error);
 
+/* new DNS-SD records format for ostree */
+/* TXT records' values are basically serialized GVariants. Below all
+ * the keys and their GVariant types are described.
+ *
+ * The TXT records are served for the service type
+ * "_ostree_repo._tcp".
+ *
+ * Common fields for all versions of TXT records:
+ *
+ * - version, describes the version of the TXT records format:
+ *   - key: "v"
+ *   - type: "y" (byte)
+ *   - contents: a version number (note: it is not an ascii digit)
+ *
+ * Fields for version 1 of TXT records:
+ *
+ * - refs bloom filter, a Bloom filter that contains all the refs the host has
+ *   - key: "rb"
+ *   - type: "(yyay)" (tuple containing a byte, a byte and an array of bytes)
+ *   - contents: first byte is the "k" parameter, second byte is the
+ *               hash id, an array of bytes are the bloom filter bits
+ *
+ * - repository index, a number identifying an OSTree repository
+ *   - key: "ri"
+ *   - type: "q" (big-endian uint16)
+ *   - contents: it gets appended to the host's URL as "/%u"
+ *
+ * - summary timestamp,
+ *   - key: "st",
+ *   - type: "t" (big-endian uint64)
+ *   - contents: a unix utc timestamp of the summary in seconds,
+ *               ideally telling when the original summary was
+ *               created, otherwise it could also be the modification
+ *               time of the summary file on host
+ */
+
 /**
  * EOS_OSTREE_AVAHI_OPTION_FORCE_VERSION_Y:
  *

--- a/libeos-updater-util/extensions.h
+++ b/libeos-updater-util/extensions.h
@@ -75,6 +75,7 @@ struct _EosExtensions
 
   GBytes *summary;
   GBytes *summary_sig;
+  guint64 summary_modification_time_secs; /* since the Unix epoch, UTC */
   GPtrArray *refs;
 };
 

--- a/libeos-updater-util/ostree-bloom-private.h
+++ b/libeos-updater-util/ostree-bloom-private.h
@@ -1,0 +1,83 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2017 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Authors:
+ *  - Philip Withnall <withnall@endlessm.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+/* TODO: Docs */
+typedef struct _OstreeBloom OstreeBloom;
+
+/* TODO: Docs */
+typedef guint64 (*OstreeBloomHashFunc) (gconstpointer element,
+                                        guint8        k);
+
+#define OSTREE_TYPE_BLOOM (ostree_bloom_get_type ())
+
+G_GNUC_INTERNAL
+GType ostree_bloom_get_type (void);
+
+G_GNUC_INTERNAL
+OstreeBloom *ostree_bloom_new (gsize               n_bytes,
+                               guint8              k,
+                               OstreeBloomHashFunc hash_func);
+
+G_GNUC_INTERNAL
+OstreeBloom *ostree_bloom_new_from_bytes (GBytes              *bytes,
+                                          guint8               k,
+                                          OstreeBloomHashFunc  hash_func);
+
+G_GNUC_INTERNAL
+OstreeBloom *ostree_bloom_ref (OstreeBloom *bloom);
+G_GNUC_INTERNAL
+void ostree_bloom_unref (OstreeBloom *bloom);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (OstreeBloom, ostree_bloom_unref)
+
+G_GNUC_INTERNAL
+gboolean ostree_bloom_maybe_contains (OstreeBloom   *bloom,
+                                      gconstpointer  element);
+
+G_GNUC_INTERNAL
+GBytes *ostree_bloom_seal (OstreeBloom *bloom);
+
+G_GNUC_INTERNAL
+void ostree_bloom_add_element (OstreeBloom   *bloom,
+                               gconstpointer  element);
+
+G_GNUC_INTERNAL
+gsize ostree_bloom_get_size (OstreeBloom *bloom);
+G_GNUC_INTERNAL
+guint8 ostree_bloom_get_k (OstreeBloom *bloom);
+G_GNUC_INTERNAL
+OstreeBloomHashFunc ostree_bloom_get_hash_func (OstreeBloom *bloom);
+
+G_GNUC_INTERNAL
+guint64 ostree_str_bloom_hash (gconstpointer element,
+                               guint8        k);
+
+G_END_DECLS

--- a/libeos-updater-util/ostree-bloom-private.h
+++ b/libeos-updater-util/ostree-bloom-private.h
@@ -29,10 +29,31 @@
 
 G_BEGIN_DECLS
 
-/* TODO: Docs */
+/**
+ * OstreeBloom:
+ *
+ * An implementation of a [bloom filter](https://en.wikipedia.org/wiki/Bloom_filter)
+ * which is suitable for building a filter and looking keys up in an existing
+ * filter.
+ *
+ * Since: 2017.8
+ */
 typedef struct _OstreeBloom OstreeBloom;
 
-/* TODO: Docs */
+/**
+ * OstreeBloomHashFunc:
+ * @element: a pointer to the element to hash
+ * @k: hash function parameter
+ *
+ * Function prototype for a
+ * [universal hash function](https://en.wikipedia.org/wiki/Universal_hashing),
+ * parameterised on @k, which hashes @element to a #guint64 hash value.
+ *
+ * It is up to the implementer of the hash function whether %NULL is valid for
+ * @element.
+ *
+ * Since: 2017.8
+ */
 typedef guint64 (*OstreeBloomHashFunc) (gconstpointer element,
                                         guint8        k);
 
@@ -80,4 +101,7 @@ G_GNUC_INTERNAL
 guint64 ostree_str_bloom_hash (gconstpointer element,
                                guint8        k);
 
+G_GNUC_INTERNAL
+guint64 ostree_collection_ref_bloom_hash (gconstpointer element,
+                                          guint8        k);
 G_END_DECLS

--- a/libeos-updater-util/ostree-bloom.c
+++ b/libeos-updater-util/ostree-bloom.c
@@ -1,0 +1,556 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2017 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Authors:
+ *  - Philip Withnall <withnall@endlessm.com>
+ */
+
+#include "config.h"
+
+#include <assert.h>
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "ostree-bloom-private.h"
+
+/**
+ * SECTION:bloom
+ *
+ * TODO
+ *
+ * TODO: Discuss m, k, universal hash functions, mutability, binary stability
+ *
+ * Reference:
+ *  - https://en.wikipedia.org/wiki/Bloom_filter
+ *  - https://llimllib.github.io/bloomfilter-tutorial/
+ *
+ * Since: 2017.7
+ */
+
+struct _OstreeBloom
+{
+  guint ref_count;
+  gsize n_bytes;
+  gboolean is_mutable;  /* determines which of [im]mutable_bytes is accessed */
+  union
+    {
+      guint8 *mutable_bytes;  /* owned; mutually exclusive */
+      GBytes *immutable_bytes;  /* owned; mutually exclusive */
+    };
+  guint8 k;
+  OstreeBloomHashFunc hash_func;
+};
+
+G_DEFINE_BOXED_TYPE (OstreeBloom, ostree_bloom, ostree_bloom_ref, ostree_bloom_unref)
+
+/**
+ * ostree_bloom_new:
+ * @n_bytes: size to make the bloom filter, in bytes
+ * @k: number of hash functions to use
+ * @hash_func: universal hash function to use
+ *
+ * Create a new mutable #OstreeBloom filter, with all its bits initialised to
+ * zero. Set elements in the filter using ostree_bloom_add_element(), and seal
+ * it to return an immutable #GBytes using ostree_bloom_seal().
+ *
+ * To load an #OstreeBloom from an existing #GBytes, use
+ * ostree_bloom_new_from_bytes().
+ *
+ * Note that @n_bytes is in bytes, so is 8 times smaller than the parameter `m`
+ * which is used when describing bloom filters academically.
+ *
+ * Returns: (transfer full): a new mutable bloom filter
+ *
+ * Since: 2017.7
+ */
+OstreeBloom *
+ostree_bloom_new (gsize               n_bytes,
+                  guint8              k,
+                  OstreeBloomHashFunc hash_func)
+{
+  g_autoptr(OstreeBloom) bloom = NULL;
+
+  g_return_val_if_fail (n_bytes > 0, NULL);
+  g_return_val_if_fail (k > 0, NULL);
+  g_return_val_if_fail (hash_func != NULL, NULL);
+
+  bloom = g_new0 (OstreeBloom, 1);
+  bloom->ref_count = 1;
+
+  bloom->is_mutable = TRUE;
+  bloom->mutable_bytes = g_malloc0 (n_bytes);
+  bloom->n_bytes = n_bytes;
+  bloom->k = k;
+  bloom->hash_func = hash_func;
+
+  return g_steal_pointer (&bloom);
+}
+
+/**
+ * ostree_bloom_new_from_bytes:
+ * @bytes: array of bytes containing the filter data
+ * @k: number of hash functions to use
+ * @hash_func: universal hash function to use
+ *
+ * Load an immutable #OstreeBloom filter from the given @bytes. Check whether
+ * elements are probably set in the filter using ostree_bloom_maybe_contains().
+ *
+ * To create a new mutable #OstreeBloom, use ostree_bloom_new().
+ *
+ * Note that all the bits in @bytes are loaded, so the parameter `m` for the
+ * filter (as commonly used in academic literature) is always a multiple of 8.
+ *
+ * Returns: (transfer full): a new immutable bloom filter
+ *
+ * Since: 2017.7
+ */
+OstreeBloom *
+ostree_bloom_new_from_bytes (GBytes              *bytes,
+                             guint8               k,
+                             OstreeBloomHashFunc  hash_func)
+{
+  g_autoptr(OstreeBloom) bloom = NULL;
+
+  g_return_val_if_fail (bytes != NULL, NULL);
+  g_return_val_if_fail (g_bytes_get_size (bytes) > 0, NULL);
+  g_return_val_if_fail (k > 0, NULL);
+  g_return_val_if_fail (hash_func != NULL, NULL);
+
+  bloom = g_new0 (OstreeBloom, 1);
+  bloom->ref_count = 1;
+
+  bloom->is_mutable = FALSE;
+  bloom->immutable_bytes = g_bytes_ref (bytes);
+  bloom->n_bytes = g_bytes_get_size (bytes);
+  bloom->k = k;
+  bloom->hash_func = hash_func;
+
+  return g_steal_pointer (&bloom);
+}
+
+/**
+ * ostree_bloom_ref:
+ * @bloom: an #OstreeBloom
+ *
+ * Increase the reference count of @bloom.
+ *
+ * Returns: (transfer full): @bloom
+ * Since: 2017.7
+ */
+OstreeBloom *
+ostree_bloom_ref (OstreeBloom *bloom)
+{
+  g_return_val_if_fail (bloom != NULL, NULL);
+  g_return_val_if_fail (bloom->ref_count >= 1, NULL);
+  g_return_val_if_fail (bloom->ref_count == G_MAXUINT - 1, NULL);
+
+  bloom->ref_count++;
+
+  return bloom;
+}
+
+/**
+ * ostree_bloom_unref:
+ * @bloom: (transfer full): an #OstreeBloom
+ *
+ * Decrement the reference count of @bloom. If it reaches zero, the filter
+ * is destroyed.
+ *
+ * Since: 2017.7
+ */
+void
+ostree_bloom_unref (OstreeBloom *bloom)
+{
+  g_return_if_fail (bloom != NULL);
+  g_return_if_fail (bloom->ref_count >= 1);
+
+  bloom->ref_count--;
+
+  if (bloom->ref_count == 0)
+    {
+      if (bloom->is_mutable)
+        g_clear_pointer (&bloom->mutable_bytes, g_free);
+      else
+        g_clear_pointer (&bloom->immutable_bytes, g_bytes_unref);
+      bloom->n_bytes = 0;
+      g_free (bloom);
+    }
+}
+
+static inline gboolean
+ostree_bloom_get_bit (OstreeBloom *bloom,
+                      gsize        idx)
+{
+  const guint8 *bytes;
+
+  if (bloom->is_mutable)
+    bytes = bloom->mutable_bytes;
+  else
+    bytes = g_bytes_get_data (bloom->immutable_bytes, NULL);
+
+  g_assert (idx / 8 < bloom->n_bytes);
+  return (bytes[idx / 8] & (1 << (idx % 8)));
+}
+
+static inline void
+ostree_bloom_set_bit (OstreeBloom *bloom,
+                      gsize        idx)
+{
+  g_assert (bloom->is_mutable);
+  g_assert (idx / 8 < bloom->n_bytes);
+  bloom->mutable_bytes[idx / 8] |= (1 << (idx % 8));
+}
+
+/**
+ * ostree_bloom_maybe_contains:
+ * @bloom: an #OstreeBloom
+ * @element: (nullable): element to check for membership
+ *
+ * TODO; nullability depends on hash function
+ *
+ * Returns: %TRUE if @element is potentially in @bloom; %FALSE if it definitely
+ *    isn’t
+ * Since: 2017.7
+ */
+gboolean
+ostree_bloom_maybe_contains (OstreeBloom   *bloom,
+                             gconstpointer  element)
+{
+  guint8 i;
+
+  g_return_val_if_fail (bloom != NULL, TRUE);
+  g_return_val_if_fail (bloom->ref_count >= 1, TRUE);
+
+  for (i = 0; i < bloom->k; i++)
+    {
+      gsize idx;
+
+      idx = bloom->hash_func (element, i);
+
+      if (!ostree_bloom_get_bit (bloom, idx % (bloom->n_bytes * 8)))
+        return FALSE;  /* definitely not in the set */
+    }
+
+  return TRUE;  /* possibly in the set */
+}
+
+/**
+ * ostree_bloom_seal:
+ * @bloom: an #OstreeBloom
+ *
+ * TODO; OK to call multiple times
+ *
+ * Returns: (transfer full): a #GBytes containing the immutable filter data
+ * Since: 2017.7
+ */
+GBytes *
+ostree_bloom_seal (OstreeBloom *bloom)
+{
+  g_return_val_if_fail (bloom != NULL, NULL);
+  g_return_val_if_fail (bloom->ref_count >= 1, NULL);
+
+  if (bloom->is_mutable)
+    {
+      bloom->is_mutable = FALSE;
+      bloom->immutable_bytes = g_bytes_new_take (g_steal_pointer (&bloom->mutable_bytes), bloom->n_bytes);
+    }
+
+  return g_bytes_ref (bloom->immutable_bytes);
+}
+
+/**
+ * ostree_bloom_add_element:
+ * @bloom: an #OstreeBloom
+ * @element: (nullable): element to add to the filter
+ *
+ * TODO; nullability depends on hash function
+ *
+ * Since: 2017.7
+ */
+void
+ostree_bloom_add_element (OstreeBloom   *bloom,
+                          gconstpointer  element)
+{
+  guint8 i;
+
+  g_return_if_fail (bloom != NULL);
+  g_return_if_fail (bloom->ref_count >= 1);
+  g_return_if_fail (bloom->is_mutable);
+
+  for (i = 0; i < bloom->k; i++)
+    {
+      gsize idx = bloom->hash_func (element, i);
+      ostree_bloom_set_bit (bloom, idx % (bloom->n_bytes * 8));
+    }
+}
+
+/**
+ * ostree_bloom_get_size:
+ * @bloom: an #OstreeBloom
+ *
+ * Get the size of the #OstreeBloom filter, in bytes, as configured at
+ * construction time.
+ *
+ * Returns: the bloom filter’s size in bytes, guaranteed to be >0
+ * Since: 2017.7
+ */
+gsize
+ostree_bloom_get_size (OstreeBloom *bloom)
+{
+  g_return_val_if_fail (bloom != NULL, 0);
+
+  return bloom->n_bytes;
+}
+
+/**
+ * ostree_bloom_get_k:
+ * @bloom: an #OstreeBloom
+ *
+ * Get the `k` value from the #OstreeBloom filter, as configured at
+ * construction time.
+ *
+ * Returns: the bloom filter’s `k` value, guaranteed to be >0
+ * Since: 2017.7
+ */
+guint8
+ostree_bloom_get_k (OstreeBloom *bloom)
+{
+  g_return_val_if_fail (bloom != NULL, 0);
+
+  return bloom->k;
+}
+
+/**
+ * ostree_bloom_get_hash_func:
+ * @bloom: an #OstreeBloom
+ *
+ * Get the #OstreeBloomHashFunc from the #OstreeBloom filter, as configured at
+ * construction time.
+ *
+ * Returns: the bloom filter’s universal hash function
+ * Since: 2017.7
+ */
+OstreeBloomHashFunc
+ostree_bloom_get_hash_func (OstreeBloom *bloom)
+{
+  g_return_val_if_fail (bloom != NULL, NULL);
+
+  return bloom->hash_func;
+}
+
+/* SipHash code adapted from https://github.com/veorq/SipHash/blob/master/siphash.c */
+
+/*
+   SipHash reference C implementation
+   Copyright (c) 2012-2016 Jean-Philippe Aumasson
+   <jeanphilippe.aumasson@gmail.com>
+   Copyright (c) 2012-2014 Daniel J. Bernstein <djb@cr.yp.to>
+   To the extent possible under law, the author(s) have dedicated all copyright
+   and related and neighboring rights to this software to the public domain
+   worldwide. This software is distributed without any warranty.
+   You should have received a copy of the CC0 Public Domain Dedication along
+   with
+   this software. If not, see
+   <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+/* default: SipHash-2-4 */
+#define cROUNDS 2
+#define dROUNDS 4
+
+#define ROTL(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
+
+#define U32TO8_LE(p, v)                                                        \
+    (p)[0] = (uint8_t)((v));                                                   \
+    (p)[1] = (uint8_t)((v) >> 8);                                              \
+    (p)[2] = (uint8_t)((v) >> 16);                                             \
+    (p)[3] = (uint8_t)((v) >> 24);
+
+#define U64TO8_LE(p, v)                                                        \
+    U32TO8_LE((p), (uint32_t)((v)));                                           \
+    U32TO8_LE((p) + 4, (uint32_t)((v) >> 32));
+
+#define U8TO64_LE(p)                                                           \
+    (((uint64_t)((p)[0])) | ((uint64_t)((p)[1]) << 8) |                        \
+     ((uint64_t)((p)[2]) << 16) | ((uint64_t)((p)[3]) << 24) |                 \
+     ((uint64_t)((p)[4]) << 32) | ((uint64_t)((p)[5]) << 40) |                 \
+     ((uint64_t)((p)[6]) << 48) | ((uint64_t)((p)[7]) << 56))
+
+#define SIPROUND                                                               \
+    do {                                                                       \
+        v0 += v1;                                                              \
+        v1 = ROTL(v1, 13);                                                     \
+        v1 ^= v0;                                                              \
+        v0 = ROTL(v0, 32);                                                     \
+        v2 += v3;                                                              \
+        v3 = ROTL(v3, 16);                                                     \
+        v3 ^= v2;                                                              \
+        v0 += v3;                                                              \
+        v3 = ROTL(v3, 21);                                                     \
+        v3 ^= v0;                                                              \
+        v2 += v1;                                                              \
+        v1 = ROTL(v1, 17);                                                     \
+        v1 ^= v2;                                                              \
+        v2 = ROTL(v2, 32);                                                     \
+    } while (0)
+
+#ifdef DEBUG
+#define TRACE                                                                  \
+    do {                                                                       \
+        printf("(%3d) v0 %08x %08x\n", (int)inlen, (uint32_t)(v0 >> 32),       \
+               (uint32_t)v0);                                                  \
+        printf("(%3d) v1 %08x %08x\n", (int)inlen, (uint32_t)(v1 >> 32),       \
+               (uint32_t)v1);                                                  \
+        printf("(%3d) v2 %08x %08x\n", (int)inlen, (uint32_t)(v2 >> 32),       \
+               (uint32_t)v2);                                                  \
+        printf("(%3d) v3 %08x %08x\n", (int)inlen, (uint32_t)(v3 >> 32),       \
+               (uint32_t)v3);                                                  \
+    } while (0)
+#else
+#define TRACE
+#endif
+
+static int siphash(const uint8_t *in, const size_t inlen, const uint8_t *k,
+                   uint8_t *out, const size_t outlen) {
+
+    assert((outlen == 8) || (outlen == 16));
+    uint64_t v0 = 0x736f6d6570736575ULL;
+    uint64_t v1 = 0x646f72616e646f6dULL;
+    uint64_t v2 = 0x6c7967656e657261ULL;
+    uint64_t v3 = 0x7465646279746573ULL;
+    uint64_t k0 = U8TO64_LE(k);
+    uint64_t k1 = U8TO64_LE(k + 8);
+    uint64_t m;
+    int i;
+    const uint8_t *end = in + inlen - (inlen % sizeof(uint64_t));
+    const int left = inlen & 7;
+    uint64_t b = ((uint64_t)inlen) << 56;
+    v3 ^= k1;
+    v2 ^= k0;
+    v1 ^= k1;
+    v0 ^= k0;
+
+    if (outlen == 16)
+        v1 ^= 0xee;
+
+    for (; in != end; in += 8) {
+        m = U8TO64_LE(in);
+        v3 ^= m;
+
+        TRACE;
+        for (i = 0; i < cROUNDS; ++i)
+            SIPROUND;
+
+        v0 ^= m;
+    }
+
+    switch (left) {
+    case 7:
+        b |= ((uint64_t)in[6]) << 48;
+    case 6:
+        b |= ((uint64_t)in[5]) << 40;
+    case 5:
+        b |= ((uint64_t)in[4]) << 32;
+    case 4:
+        b |= ((uint64_t)in[3]) << 24;
+    case 3:
+        b |= ((uint64_t)in[2]) << 16;
+    case 2:
+        b |= ((uint64_t)in[1]) << 8;
+    case 1:
+        b |= ((uint64_t)in[0]);
+        break;
+    case 0:
+        break;
+    }
+
+    v3 ^= b;
+
+    TRACE;
+    for (i = 0; i < cROUNDS; ++i)
+        SIPROUND;
+
+    v0 ^= b;
+
+    if (outlen == 16)
+        v2 ^= 0xee;
+    else
+        v2 ^= 0xff;
+
+    TRACE;
+    for (i = 0; i < dROUNDS; ++i)
+        SIPROUND;
+
+    b = v0 ^ v1 ^ v2 ^ v3;
+    U64TO8_LE(out, b);
+
+    if (outlen == 8)
+        return 0;
+
+    v1 ^= 0xdd;
+
+    TRACE;
+    for (i = 0; i < dROUNDS; ++i)
+        SIPROUND;
+
+    b = v0 ^ v1 ^ v2 ^ v3;
+    U64TO8_LE(out + 8, b);
+
+    return 0;
+}
+
+/**
+ * ostree_str_bloom_hash:
+ * @element: element to calculate the hash for
+ * @k: hash function index
+ *
+ * TODO: k is in 0..k-1 from the bloom filter; output range is unrestricted;
+ * type of @element depends on the hash function; %NULL not supported
+ *
+ * Reference:
+ *  - https://www.131002.net/siphash/
+ *
+ * Returns: TODO
+ * Since: 2017.7
+ */
+guint64
+ostree_str_bloom_hash (gconstpointer element,
+                       guint8        k)
+{
+  const gchar *str = element;
+  gsize str_len;
+  union
+    {
+      guint64 u64;
+      guint8 u8[8];
+    } out_le;
+  guint8 k_array[16];
+  gsize i;
+
+  str_len = strlen (str);
+  for (i = 0; i < G_N_ELEMENTS (k_array); i++)
+    k_array[i] = k;
+
+  siphash ((const guint8 *) str, str_len, k_array, out_le.u8, sizeof (out_le));
+
+  return le64toh (out_le.u64);
+}

--- a/libeos-updater-util/ostree-bloom.c
+++ b/libeos-updater-util/ostree-bloom.c
@@ -34,16 +34,44 @@
 
 /**
  * SECTION:bloom
+ * @title: Bloom filter
+ * @short_description: Bloom filter implementation supporting building and
+ *    reading filters
+ * @stability: Unstable
+ * @include: libostree/ostree-bloom-private.h
  *
- * TODO
+ * #OstreeBloom is an implementation of a bloom filter which supports writing to
+ * and loading from a #GBytes bit array. The caller must store metadata about
+ * the bloom filter (its hash function and `k` parameter value) separately, as
+ * the same values must be used when reading from a serialised bit array as were
+ * used to build the array in the first place.
  *
- * TODO: Discuss m, k, universal hash functions, mutability, binary stability
+ * This is a standard implementation of a bloom filter, and background reading
+ * on the theory can be
+ * [found on Wikipedia](https://en.wikipedia.org/wiki/Bloom_filter). In
+ * particular, a bloom filter is parameterised by `m` and `k` parameters: the
+ * size of the bit array (in bits) is `m`, and the number of hash functions
+ * applied to each element is `k`. Bloom filters require a universal hash
+ * function which can be parameterised by `k`. We have #OstreeBloomHashFunc,
+ * with ostree_str_bloom_hash() being an implementation for strings.
+ *
+ * The serialised output from a bloom filter is guaranteed to be stable across
+ * versions of libostree as long as the same values for `k` and the hash
+ * function are used.
+ *
+ * #OstreeBloom is mutable when constructed with ostree_bloom_new(), and elements
+ * can be added to it using ostree_bloom_add_element(), until ostree_bloom_seal()
+ * is called to serialise it and make it immutable. After then, the bloom filter
+ * can only be queried using ostree_bloom_maybe_contains().
+ *
+ * If constructed with ostree_bloom_new_from_bytes(), the bloom filter is
+ * immutable from construction, and can only be queried.
  *
  * Reference:
  *  - https://en.wikipedia.org/wiki/Bloom_filter
  *  - https://llimllib.github.io/bloomfilter-tutorial/
  *
- * Since: 2017.7
+ * Since: 2017.8
  */
 
 struct _OstreeBloom
@@ -80,7 +108,7 @@ G_DEFINE_BOXED_TYPE (OstreeBloom, ostree_bloom, ostree_bloom_ref, ostree_bloom_u
  *
  * Returns: (transfer full): a new mutable bloom filter
  *
- * Since: 2017.7
+ * Since: 2017.8
  */
 OstreeBloom *
 ostree_bloom_new (gsize               n_bytes,
@@ -121,7 +149,7 @@ ostree_bloom_new (gsize               n_bytes,
  *
  * Returns: (transfer full): a new immutable bloom filter
  *
- * Since: 2017.7
+ * Since: 2017.8
  */
 OstreeBloom *
 ostree_bloom_new_from_bytes (GBytes              *bytes,
@@ -154,7 +182,7 @@ ostree_bloom_new_from_bytes (GBytes              *bytes,
  * Increase the reference count of @bloom.
  *
  * Returns: (transfer full): @bloom
- * Since: 2017.7
+ * Since: 2017.8
  */
 OstreeBloom *
 ostree_bloom_ref (OstreeBloom *bloom)
@@ -175,7 +203,7 @@ ostree_bloom_ref (OstreeBloom *bloom)
  * Decrement the reference count of @bloom. If it reaches zero, the filter
  * is destroyed.
  *
- * Since: 2017.7
+ * Since: 2017.8
  */
 void
 ostree_bloom_unref (OstreeBloom *bloom)
@@ -196,6 +224,7 @@ ostree_bloom_unref (OstreeBloom *bloom)
     }
 }
 
+/* @idx is in bits, not bytes. */
 static inline gboolean
 ostree_bloom_get_bit (OstreeBloom *bloom,
                       gsize        idx)
@@ -211,6 +240,7 @@ ostree_bloom_get_bit (OstreeBloom *bloom,
   return (bytes[idx / 8] & (1 << (idx % 8)));
 }
 
+/* @idx is in bits, not bytes. */
 static inline void
 ostree_bloom_set_bit (OstreeBloom *bloom,
                       gsize        idx)
@@ -225,11 +255,13 @@ ostree_bloom_set_bit (OstreeBloom *bloom,
  * @bloom: an #OstreeBloom
  * @element: (nullable): element to check for membership
  *
- * TODO; nullability depends on hash function
+ * Check whether @element is potentially in @bloom, or whether it definitely
+ * isn’t. @element may be %NULL only if the hash function passed to @bloom at
+ * construction time supports %NULL elements.
  *
  * Returns: %TRUE if @element is potentially in @bloom; %FALSE if it definitely
  *    isn’t
- * Since: 2017.7
+ * Since: 2017.8
  */
 gboolean
 ostree_bloom_maybe_contains (OstreeBloom   *bloom,
@@ -257,10 +289,16 @@ ostree_bloom_maybe_contains (OstreeBloom   *bloom,
  * ostree_bloom_seal:
  * @bloom: an #OstreeBloom
  *
- * TODO; OK to call multiple times
+ * Seal a constructed bloom filter, so that elements may no longer be added to
+ * it, and queries can now be performed against it. The serialised form of the
+ * bloom filter is returned as a bit array. Note that this does not include
+ * information about the filter hash function or parameters; the caller is
+ * responsible for serialising those separately if appropriate.
+ *
+ * It is safe to call this function multiple times.
  *
  * Returns: (transfer full): a #GBytes containing the immutable filter data
- * Since: 2017.7
+ * Since: 2017.8
  */
 GBytes *
 ostree_bloom_seal (OstreeBloom *bloom)
@@ -282,9 +320,11 @@ ostree_bloom_seal (OstreeBloom *bloom)
  * @bloom: an #OstreeBloom
  * @element: (nullable): element to add to the filter
  *
- * TODO; nullability depends on hash function
+ * Add the given @element to the bloom filter, which must not yet have been
+ * sealed (ostree_bloom_seal()). @element may be %NULL if the hash function
+ * passed to @bloom at construction time supports %NULL elements.
  *
- * Since: 2017.7
+ * Since: 2017.8
  */
 void
 ostree_bloom_add_element (OstreeBloom   *bloom,
@@ -311,7 +351,7 @@ ostree_bloom_add_element (OstreeBloom   *bloom,
  * construction time.
  *
  * Returns: the bloom filter’s size in bytes, guaranteed to be >0
- * Since: 2017.7
+ * Since: 2017.8
  */
 gsize
 ostree_bloom_get_size (OstreeBloom *bloom)
@@ -329,7 +369,7 @@ ostree_bloom_get_size (OstreeBloom *bloom)
  * construction time.
  *
  * Returns: the bloom filter’s `k` value, guaranteed to be >0
- * Since: 2017.7
+ * Since: 2017.8
  */
 guint8
 ostree_bloom_get_k (OstreeBloom *bloom)
@@ -347,7 +387,7 @@ ostree_bloom_get_k (OstreeBloom *bloom)
  * construction time.
  *
  * Returns: the bloom filter’s universal hash function
- * Since: 2017.7
+ * Since: 2017.8
  */
 OstreeBloomHashFunc
 ostree_bloom_get_hash_func (OstreeBloom *bloom)
@@ -518,19 +558,26 @@ static int siphash(const uint8_t *in, const size_t inlen, const uint8_t *k,
     return 0;
 }
 
+/* End SipHash copied code. */
+
 /**
  * ostree_str_bloom_hash:
  * @element: element to calculate the hash for
  * @k: hash function index
  *
- * TODO: k is in 0..k-1 from the bloom filter; output range is unrestricted;
- * type of @element depends on the hash function; %NULL not supported
+ * A universal hash function implementation for strings. It expects @element to
+ * be a pointer to a string (i.e. @element has type `const gchar*`), and expects
+ * @k to be in the range `[0, k_max)`, where `k_max` is the `k` value used to
+ * construct the bloom filter. The output range from this hash function could be
+ * any value in #guint64, and it handles input strings of any length.
+ *
+ * This function does not allow %NULL as a valid value for @element.
  *
  * Reference:
  *  - https://www.131002.net/siphash/
  *
- * Returns: TODO
- * Since: 2017.7
+ * Returns: hash of the string at @element using parameter @k
+ * Since: 2017.8
  */
 guint64
 ostree_str_bloom_hash (gconstpointer element,
@@ -553,4 +600,34 @@ ostree_str_bloom_hash (gconstpointer element,
   siphash ((const guint8 *) str, str_len, k_array, out_le.u8, sizeof (out_le));
 
   return le64toh (out_le.u64);
+}
+
+/**
+ * ostree_collection_ref_bloom_hash:
+ * @element: element to calculate the hash for
+ * @k: hash function index
+ *
+ * A universal hash function implementation for #OstreeCollectionRef.
+ * It expects @element to be a pointer to a #OstreeCollectionRef, and
+ * expects @k to be in the range `[0, k_max)`, where `k_max` is the
+ * `k` value used to construct the bloom filter. The output range from
+ * this hash function could be any value in #guint64.
+ *
+ * This function does not allow %NULL as a valid value for @element.
+ *
+ * Reference:
+ *  - https://www.131002.net/siphash/
+ *
+ * Returns: hash of the #OstreeCollectionRef at @element using
+ * parameter @k
+ *
+ * Since: 2017.8
+ */
+guint64
+ostree_collection_ref_bloom_hash (gconstpointer element,
+                                  guint8        k)
+{
+  const OstreeCollectionRef *ref = element;
+
+  return ostree_str_bloom_hash (ref->collection_id, k) ^ ostree_str_bloom_hash (ref->ref_name, k);
 }

--- a/libeos-updater-util/ostree-ref.c
+++ b/libeos-updater-util/ostree-ref.c
@@ -1,0 +1,190 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2017 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Authors:
+ *  - Philip Withnall <withnall@endlessm.com>
+ */
+
+#include "config.h"
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
+
+#include "ostree-autocleanups.h"
+#include "ostree-core.h"
+#include "ostree-ref.h"
+
+G_DEFINE_BOXED_TYPE (OstreeCollectionRef, ostree_collection_ref,
+                     ostree_collection_ref_dup, ostree_collection_ref_free)
+
+/**
+ * ostree_collection_ref_new:
+ * @collection_id: (nullable): a collection ID, or %NULL for a plain ref
+ * @ref_name: a ref name
+ *
+ * Create a new #OstreeCollectionRef containing (@collection_id, @ref_name). If
+ * @collection_id is %NULL, this is equivalent to a plain ref name string (not a
+ * refspec; no remote name is included), which can be used for non-P2P
+ * operations.
+ *
+ * Returns: (transfer full): a new #OstreeCollectionRef
+ * Since: 2017.8
+ */
+OstreeCollectionRef *
+ostree_collection_ref_new (const gchar *collection_id,
+                           const gchar *ref_name)
+{
+  g_autoptr(OstreeCollectionRef) collection_ref = NULL;
+
+  g_return_val_if_fail (collection_id == NULL);
+  g_return_val_if_fail (ostree_validate_rev (ref_name, NULL), NULL);
+
+  collection_ref = g_new0 (OstreeCollectionRef, 1);
+  collection_ref->collection_id = g_strdup (collection_id);
+  collection_ref->ref_name = g_strdup (ref_name);
+
+  return g_steal_pointer (&collection_ref);
+}
+
+/**
+ * ostree_collection_ref_dup:
+ * @ref: an #OstreeCollectionRef
+ *
+ * Create a copy of the given @ref.
+ *
+ * Returns: (transfer full): a newly allocated copy of @ref
+ * Since: 2017.8
+ */
+OstreeCollectionRef *
+ostree_collection_ref_dup (const OstreeCollectionRef *ref)
+{
+  g_return_val_if_fail (ref != NULL, NULL);
+
+  return ostree_collection_ref_new (ref->collection_id, ref->ref_name);
+}
+
+/**
+ * ostree_collection_ref_free:
+ * @ref: (transfer full): an #OstreeCollectionRef
+ *
+ * Free the given @ref.
+ *
+ * Since: 2017.8
+ */
+void
+ostree_collection_ref_free (OstreeCollectionRef *ref)
+{
+  g_return_if_fail (ref != NULL);
+
+  g_free (ref->collection_id);
+  g_free (ref->ref_name);
+  g_free (ref);
+}
+
+/**
+ * ostree_collection_ref_hash:
+ * @ref: an #OstreeCollectionRef
+ *
+ * Hash the given @ref. This function is suitable for use with #GHashTable.
+ * @ref must be non-%NULL.
+ *
+ * Returns: hash value for @ref
+ * Since: 2017.8
+ */
+guint
+ostree_collection_ref_hash (gconstpointer ref)
+{
+  const OstreeCollectionRef *_ref = ref;
+
+  if (_ref->collection_id != NULL)
+    return g_str_hash (_ref->collection_id) ^ g_str_hash (_ref->ref_name);
+  else
+    return g_str_hash (_ref->ref_name);
+}
+
+/**
+ * ostree_collection_ref_equal:
+ * @ref1: an #OstreeCollectionRef
+ * @ref2: another #OstreeCollectionRef
+ *
+ * Compare @ref1 and @ref2 and return %TRUE if they have the same collection ID and
+ * ref name, and %FALSE otherwise. Both @ref1 and @ref2 must be non-%NULL.
+ *
+ * Returns: %TRUE if @ref1 and @ref2 are equal, %FALSE otherwise
+ * Since: 2017.8
+ */
+gboolean
+ostree_collection_ref_equal (gconstpointer ref1,
+                             gconstpointer ref2)
+{
+  const OstreeCollectionRef *_ref1 = ref1, *_ref2 = ref2;
+
+  return (g_strcmp0 (_ref1->collection_id, _ref2->collection_id) == 0 &&
+          g_strcmp0 (_ref1->ref_name, _ref2->ref_name) == 0);
+}
+
+/**
+ * ostree_collection_ref_dupv:
+ * @refs: (array zero-terminated=1): %NULL-terminated array of #OstreeCollectionRefs
+ *
+ * Copy an array of #OstreeCollectionRefs, including deep copies of all its
+ * elements. @refs must be %NULL-terminated; it may be empty, but must not be
+ * %NULL.
+ *
+ * Returns: (transfer full) (array zero-terminated=1): a newly allocated copy of @refs
+ * Since: 2017.8
+ */
+OstreeCollectionRef **
+ostree_collection_ref_dupv (const OstreeCollectionRef * const *refs)
+{
+  gsize i,  n_refs = g_strv_length ((gchar **) refs);  /* hack */
+  g_auto(OstreeCollectionRefv) new_refs = NULL;
+
+  g_return_val_if_fail (refs != NULL, NULL);
+
+  new_refs = g_new0 (OstreeCollectionRef*, n_refs + 1);
+
+  for (i = 0; i < n_refs; i++)
+    new_refs[i] = ostree_collection_ref_dup (refs[i]);
+  new_refs[i] = NULL;
+
+  return g_steal_pointer (&new_refs);
+}
+
+/**
+ * ostree_collection_ref_freev:
+ * @refs: (transfer full) (array zero-terminated=1): an array of #OstreeCollectionRefs
+ *
+ * Free the given array of @refs, including freeing all its elements. @refs
+ * must be %NULL-terminated; it may be empty, but must not be %NULL.
+ *
+ * Since: 2017.8
+ */
+void
+ostree_collection_ref_freev (OstreeCollectionRef **refs)
+{
+  gsize i;
+
+  g_return_if_fail (refs != NULL);
+
+  for (i = 0; refs[i] != NULL; i++)
+    ostree_collection_ref_free (refs[i]);
+  g_free (refs);
+}

--- a/libeos-updater-util/ostree-ref.h
+++ b/libeos-updater-util/ostree-ref.h
@@ -1,0 +1,90 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2017 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Authors:
+ *  - Philip Withnall <withnall@endlessm.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
+
+#include "ostree-types.h"
+
+G_BEGIN_DECLS
+
+/**
+ * OstreeCollectionRef:
+ * @collection_id: (nullable): collection ID which provided the ref, or %NULL if there
+ *    is no associated collection
+ * @ref_name: ref name
+ *
+ * A structure which globally uniquely identifies a ref as the tuple
+ * (@collection_id, @ref_name). For backwards compatibility, @collection_id may be %NULL,
+ * indicating a ref name which is not globally unique.
+ *
+ * Since: 2017.8
+ */
+typedef struct
+{
+  gchar *collection_id;  /* (nullable) */
+  gchar *ref_name;  /* (not nullable) */
+} OstreeCollectionRef;
+
+#ifndef __GI_SCANNER__
+_OSTREE_PUBLIC
+GType ostree_collection_ref_get_type (void);
+
+_OSTREE_PUBLIC
+OstreeCollectionRef *ostree_collection_ref_new (const gchar *collection_id,
+                                                const gchar *ref_name);
+_OSTREE_PUBLIC
+OstreeCollectionRef *ostree_collection_ref_dup (const OstreeCollectionRef *ref);
+_OSTREE_PUBLIC
+void ostree_collection_ref_free (OstreeCollectionRef *ref);
+#endif
+
+_OSTREE_PUBLIC
+guint ostree_collection_ref_hash (gconstpointer ref);
+_OSTREE_PUBLIC
+gboolean ostree_collection_ref_equal (gconstpointer ref1,
+                                      gconstpointer ref2);
+
+_OSTREE_PUBLIC
+OstreeCollectionRef **ostree_collection_ref_dupv (const OstreeCollectionRef * const *refs);
+_OSTREE_PUBLIC
+void ostree_collection_ref_freev (OstreeCollectionRef **refs);
+
+/**
+ * OstreeCollectionRefv:
+ *
+ * A %NULL-terminated array of #OstreeCollectionRef instances, designed to
+ * be used with g_auto():
+ *
+ * |[<!-- language="C" -->
+ * g_auto(OstreeCollectionRefv) refs = NULL;
+ * ]|
+ *
+ * Since: 2017.8
+ */
+typedef OstreeCollectionRef** OstreeCollectionRefv;
+
+G_END_DECLS

--- a/libeos-updater-util/tests/avahi-service-file.c
+++ b/libeos-updater-util/tests/avahi-service-file.c
@@ -30,6 +30,7 @@ typedef struct
 {
   gchar *tmp_dir;
   GDateTime *example_timestamp;  /* owned */
+  const gchar *refs[2];
 } Fixture;
 
 /* Set up a temporary directory to create test service files in. */
@@ -42,6 +43,8 @@ setup (Fixture       *fixture,
   fixture->tmp_dir = g_dir_make_tmp ("eos-updater-util-tests-avahi-service-file-XXXXXX",
                                      &error);
   g_assert_no_error (error);
+  fixture->refs[0] = "ref";
+  fixture->refs[1] = NULL;
 
   fixture->example_timestamp = g_date_time_new_utc (2017, 2, 17, 0, 0, 0);
 }
@@ -319,6 +322,543 @@ test_avahi_service_file_delete_denied (Fixture       *fixture,
   g_assert_cmpint (g_rmdir (subdirectory), ==, 0);
 }
 
+static const gchar *
+get_encoded_bloom_bits (gboolean short_bloom_size)
+{
+  /* - AQEAA... - guint8 1, guint8 1, guint8[] of bloom filter bits encoding "ref" */
+  if (short_bloom_size)
+    return "AQEAAAAAAAAAAAAACAA=";
+  return "AQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+}
+
+static const gchar *
+get_encoded_repository_index (gboolean default_repository_index)
+{
+  /* - AAA= - big-endian guint16 0
+   * - AAY= - big-endian guint16 6
+   */
+  if (default_repository_index)
+    return "AAA=";
+  return "AAY=";
+}
+
+/* Check the contents of a generated .service file. */
+static void
+assert_ostree_service_file_contents_valid (const gchar *service_file,
+                                           gboolean     short_bloom_size,
+                                           gboolean     default_repository_index)
+{
+  g_autoptr(GError) error = NULL;
+  g_autofree gchar *contents = NULL;
+  gsize length;
+  const gchar *encoded_bloom_bits;
+  const gchar *encoded_repository_index;
+  g_autofree gchar *expected_contents = NULL;
+
+  g_file_get_contents (service_file, &contents, &length, &error);
+  g_assert_no_error (error);
+  encoded_bloom_bits = get_encoded_bloom_bits (short_bloom_size);
+  encoded_repository_index = get_encoded_repository_index (default_repository_index);
+  /* base64 values below are (note that these are raw numbers, not characters):
+   * - AQ== - guint8 1
+   * - AAAAAFhoRoA= - big-endian guint64 1483228800 (2017-01-01 00:00:00 UTC)
+   */
+  expected_contents = g_strdup_printf ("<service-group>\n"
+                                       "  <name replace-wildcards=\"yes\">EOS OSTree update service on %%h</name>\n"
+                                       "  <service>\n"
+                                       "    <type>_ostree_repo._tcp</type>\n"
+                                       "    <port>43381</port>\n"
+                                       "    <txt-record value-format=\"binary-base64\">v=AQ==</txt-record>\n"
+                                       "    <txt-record value-format=\"binary-base64\">rb=%s</txt-record>\n"
+                                       "    <txt-record value-format=\"binary-base64\">st=AAAAAFhoRoA=</txt-record>\n"
+                                       "    <txt-record value-format=\"binary-base64\">ri=%s</txt-record>\n"
+                                       "  </service>\n"
+                                       "</service-group>\n",
+                                       encoded_bloom_bits,
+                                       encoded_repository_index);
+
+  g_assert_cmpstr (contents, ==, expected_contents);
+  g_assert_cmpuint (length, ==, strlen (contents));
+}
+
+typedef enum
+  {
+    SET_NOTHING                 = 0,
+    SET_FORCE_VERSION           = 1 << 0,
+    SET_BLOOM_HASH_ID           = 1 << 1,
+    SET_BLOOM_K                 = 1 << 2,
+    SET_BLOOM_SIZE              = 1 << 3,
+    SET_REPOSITORY_INDEX        = 1 << 4,
+    SET_PORT                    = 1 << 5,
+    SET_TXT_RECORDS_SIZE_LEVEL  = 1 << 6,
+    SET_TXT_RECORDS_CUSTOM_SIZE = 1 << 7,
+  } TestSetFlags;
+
+typedef struct
+{
+  guint32 set_flags;
+  guint8 force_version;
+  guint8 bloom_hash_id;
+  guint8 bloom_k;
+  guint32 bloom_size;
+  guint16 repository_index;
+  guint16 port;
+  guint8 txt_records_size_level;
+  guint64 txt_records_custom_size;
+} AvahiOstreeTestOptions;
+
+#define CHECK_FLAG(flags, flag) (((flags) & (flag)) == (flag))
+
+static GVariant *
+avahi_ostree_test_options_to_variant (const AvahiOstreeTestOptions *test_options)
+{
+  g_auto(GVariantDict) options_dict = G_VARIANT_DICT_INIT (NULL);
+
+  if (CHECK_FLAG (test_options->set_flags, SET_FORCE_VERSION))
+    g_variant_dict_insert (&options_dict,
+                           EOS_OSTREE_AVAHI_OPTION_FORCE_VERSION_Y,
+                           "y",
+                           test_options->force_version);
+
+  if (CHECK_FLAG (test_options->set_flags, SET_BLOOM_HASH_ID))
+    g_variant_dict_insert (&options_dict,
+                           EOS_OSTREE_AVAHI_OPTION_BLOOM_HASH_ID_Y,
+                           "y",
+                           test_options->bloom_hash_id);
+
+  if (CHECK_FLAG (test_options->set_flags, SET_BLOOM_K))
+    g_variant_dict_insert (&options_dict,
+                           EOS_OSTREE_AVAHI_OPTION_BLOOM_K_Y,
+                           "y",
+                           test_options->bloom_k);
+
+  if (CHECK_FLAG (test_options->set_flags, SET_BLOOM_SIZE))
+    g_variant_dict_insert (&options_dict,
+                           EOS_OSTREE_AVAHI_OPTION_BLOOM_SIZE_U,
+                           "u",
+                           test_options->bloom_size);
+
+  if (CHECK_FLAG (test_options->set_flags, SET_REPOSITORY_INDEX))
+    g_variant_dict_insert (&options_dict,
+                           EOS_OSTREE_AVAHI_OPTION_REPO_INDEX_Q,
+                           "q",
+                           test_options->repository_index);
+
+  if (CHECK_FLAG (test_options->set_flags, SET_PORT))
+    g_variant_dict_insert (&options_dict,
+                           EOS_OSTREE_AVAHI_OPTION_PORT_Q,
+                           "q",
+                           test_options->port);
+
+  if (CHECK_FLAG (test_options->set_flags, SET_TXT_RECORDS_SIZE_LEVEL))
+    g_variant_dict_insert (&options_dict,
+                           EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_SIZE_LEVEL_Y,
+                           "y",
+                           test_options->txt_records_size_level);
+
+  if (CHECK_FLAG (test_options->set_flags, SET_TXT_RECORDS_CUSTOM_SIZE))
+    g_variant_dict_insert (&options_dict,
+                           EOS_OSTREE_AVAHI_OPTION_TXT_RECORDS_CUSTOM_SIZE_T,
+                           "t",
+                           test_options->txt_records_custom_size);
+
+  return g_variant_dict_end (&options_dict);
+}
+
+typedef struct
+{
+  AvahiOstreeTestOptions options;
+  gboolean success;
+} TestOptions;
+
+const TestOptions test_options[] =
+  {
+    {
+      {SET_NOTHING},
+      TRUE,
+    },
+    {
+      {SET_FORCE_VERSION, .force_version = 1},
+      TRUE,
+    },
+    {
+      {SET_FORCE_VERSION, .force_version = 0},
+      FALSE,
+    },
+    {
+      {SET_FORCE_VERSION, .force_version = 2},
+      FALSE,
+    },
+    {
+      {SET_BLOOM_HASH_ID, .bloom_hash_id = 0},
+      FALSE,
+    },
+    {
+      {SET_BLOOM_HASH_ID, .bloom_hash_id = EOS_OSTREE_AVAHI_BLOOM_HASH_ID_STR},
+      TRUE,
+    },
+    {
+      {SET_BLOOM_HASH_ID, .bloom_hash_id = 2},
+      FALSE,
+    },
+    {
+      {SET_BLOOM_K, .bloom_k = 0},
+      FALSE,
+    },
+    {
+      {SET_BLOOM_K, .bloom_k = 1},
+      TRUE,
+    },
+    {
+      {SET_BLOOM_SIZE, .bloom_size = 0},
+      FALSE,
+    },
+    {
+      {SET_BLOOM_SIZE, .bloom_size = 1},
+      TRUE,
+    },
+    {
+      {SET_BLOOM_SIZE, .bloom_size = 255 - 3 /* rb= */ - 2 /* bloom hash id + bloom k */},
+      TRUE,
+    },
+    {
+      {SET_BLOOM_SIZE, .bloom_size = 255 - 3 /* rb= */ - 2 /* bloom hash id + bloom k */ + 1},
+      FALSE,
+    },
+    {
+      {SET_PORT, .port = 0},
+      FALSE,
+    },
+    {
+      {SET_PORT, .port = 12345},
+      TRUE,
+    },
+    {
+      {SET_TXT_RECORDS_SIZE_LEVEL, .txt_records_size_level = EOS_OSTREE_AVAHI_SIZE_LEVEL_CUSTOM},
+      FALSE,
+    },
+    {
+      {SET_TXT_RECORDS_SIZE_LEVEL | SET_TXT_RECORDS_CUSTOM_SIZE, .txt_records_size_level = EOS_OSTREE_AVAHI_SIZE_LEVEL_CUSTOM, .txt_records_custom_size = 12},
+      TRUE,
+    },
+    {
+      {SET_TXT_RECORDS_SIZE_LEVEL, .txt_records_size_level = EOS_OSTREE_AVAHI_SIZE_LEVEL_SUPPORT_FAULTY_HARDWARE},
+      TRUE,
+    },
+    {
+      {SET_TXT_RECORDS_SIZE_LEVEL, .txt_records_size_level = EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_DNS_MESSAGE},
+      TRUE,
+    },
+    {
+      {SET_TXT_RECORDS_SIZE_LEVEL, .txt_records_size_level = EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_ETHERNET_PACKET},
+      TRUE,
+    },
+    {
+      {SET_TXT_RECORDS_SIZE_LEVEL, .txt_records_size_level = EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_SINGLE_MULTICAST_DNS_PACKET},
+      TRUE,
+    },
+    {
+      {SET_TXT_RECORDS_SIZE_LEVEL, .txt_records_size_level = EOS_OSTREE_AVAHI_SIZE_LEVEL_FIT_16_BIT_LIMIT},
+      TRUE,
+    },
+    {
+      {SET_TXT_RECORDS_SIZE_LEVEL, .txt_records_size_level = EOS_OSTREE_AVAHI_SIZE_LEVEL_ABSOLUTELY_LAX},
+      TRUE,
+    },
+    {
+      {SET_TXT_RECORDS_SIZE_LEVEL, .txt_records_size_level = 7},
+      FALSE,
+    },
+  };
+
+static void
+test_avahi_ostree_options_check (void)
+{
+  gsize idx;
+
+  for (idx = 0; idx < G_N_ELEMENTS (test_options); ++idx)
+    {
+      g_autoptr(GError) error = NULL;
+      const TestOptions *test_data = &test_options[idx];
+      gboolean result = eos_ostree_avahi_service_file_check_options (avahi_ostree_test_options_to_variant (&test_data->options), &error);
+
+      if (test_data->success)
+        {
+          g_assert_no_error (error);
+          g_assert_true (result);
+        }
+      else
+        {
+          g_assert_error (error, G_IO_ERROR, G_IO_ERROR_FAILED);
+          g_assert_false (result);
+        }
+    }
+}
+
+// 01. wrong version
+// 02. wrong bloom filter size
+// 03. wrong bloom filter k
+// 04. wrong hash func id
+// 05. wrong port
+// 06. wrong timestamp
+// 07. too long text record (likely impossible?)
+// 08. too long binary record (likely impossible?)
+// 09. wrong size level
+// 11. too big for a custom size
+// 12. too big for a crappy hardware
+// 13. too big for a single dns message (likely impossible?)
+// 14. too big for a single ethernet packet (likely impossible?)
+// 15. too big for a single multicast dns packet (likely impossible?)
+// 16. too big for a 16 bit limit (likely impossible?)
+// 17. check lax size level (likely impossible?)
+// 18. short bloom filter size
+// 19. long bloom filter size (within limits still)
+//
+// some of the tests are likely impossible to check
+typedef struct
+{
+  AvahiOstreeTestOptions options;
+  gint summary_timestamp_year;
+  gboolean success;
+} AvahiOstreeGenerateTest;
+
+#define GOOD_YEAR 2017
+#define BAD_YEAR 1234
+#define SMALL_BLOOM_SIZE 12
+#define CUSTOM_REPOSITORY_INDEX 6
+
+const AvahiOstreeGenerateTest avahi_ostree_generate_tests[] =
+  {
+    {
+      {SET_FORCE_VERSION, .force_version = 0},
+      GOOD_YEAR,
+      FALSE,
+    },
+    {
+      {SET_FORCE_VERSION, .bloom_size = 0},
+      GOOD_YEAR,
+      FALSE,
+    },
+    {
+      {SET_FORCE_VERSION, .bloom_k = 0},
+      GOOD_YEAR,
+      FALSE,
+    },
+    {
+      {SET_FORCE_VERSION, .bloom_hash_id = 0},
+      GOOD_YEAR,
+      FALSE,
+    },
+    {
+      {SET_FORCE_VERSION, .port = 0},
+      GOOD_YEAR,
+      FALSE,
+    },
+    {
+      {SET_NOTHING},
+      BAD_YEAR,
+      FALSE,
+    },
+    {
+      {SET_TXT_RECORDS_SIZE_LEVEL, .txt_records_size_level = EOS_OSTREE_AVAHI_SIZE_LEVEL_CUSTOM},
+      GOOD_YEAR,
+      FALSE,
+    },
+    {
+      {SET_TXT_RECORDS_SIZE_LEVEL | SET_TXT_RECORDS_CUSTOM_SIZE, .txt_records_size_level = EOS_OSTREE_AVAHI_SIZE_LEVEL_CUSTOM, .txt_records_custom_size = 10},
+      GOOD_YEAR,
+      FALSE,
+    },
+    {
+      {SET_TXT_RECORDS_SIZE_LEVEL, .txt_records_size_level = EOS_OSTREE_AVAHI_SIZE_LEVEL_SUPPORT_FAULTY_HARDWARE},
+      GOOD_YEAR,
+      FALSE,
+    },
+    {
+      {SET_BLOOM_SIZE | SET_TXT_RECORDS_SIZE_LEVEL, .bloom_size = SMALL_BLOOM_SIZE, .txt_records_size_level = EOS_OSTREE_AVAHI_SIZE_LEVEL_SUPPORT_FAULTY_HARDWARE},
+      GOOD_YEAR,
+      TRUE,
+    },
+    {
+      {SET_REPOSITORY_INDEX, .repository_index = CUSTOM_REPOSITORY_INDEX},
+      GOOD_YEAR,
+      TRUE,
+    },
+  };
+
+static void
+test_avahi_ostree_service_file_generate (Fixture       *fixture,
+                                         gconstpointer  user_data G_GNUC_UNUSED)
+{
+  gsize idx;
+  g_autoptr(GTimeZone) utc_tz = g_time_zone_new_utc ();
+
+  for (idx = 0; idx < G_N_ELEMENTS (avahi_ostree_generate_tests); ++idx)
+    {
+      g_autofree gchar *filename = NULL;
+      g_autofree gchar *service_file = NULL;
+      g_autoptr(GError) error = NULL;
+      const AvahiOstreeGenerateTest *test_data = &avahi_ostree_generate_tests[idx];
+      gboolean result;
+      g_autoptr(GDateTime) timestamp = g_date_time_new (utc_tz,
+                                                        test_data->summary_timestamp_year,
+                                                        1, 1, 0, 0, 0);
+
+      g_assert_nonnull (timestamp);
+      result = eos_ostree_avahi_service_file_generate (fixture->tmp_dir,
+                                                       fixture->refs,
+                                                       timestamp,
+                                                       avahi_ostree_test_options_to_variant (&test_data->options),
+                                                       NULL,
+                                                       &error);
+
+      if (CHECK_FLAG (test_data->options.set_flags, SET_REPOSITORY_INDEX))
+        filename = g_strdup_printf ("eos-ostree-updater-%" G_GUINT16_FORMAT ".service",
+                                    test_data->options.repository_index);
+      else
+        filename = g_strdup ("eos-ostree-updater-0.service");
+
+      service_file = g_build_filename (fixture->tmp_dir,
+                                       filename,
+                                       NULL);
+
+      if (test_data->success)
+        {
+          gboolean small_bloom_size;
+          gboolean default_repository_index;
+
+          g_assert_no_error (error);
+          g_assert_true (result);
+
+          small_bloom_size = CHECK_FLAG (test_data->options.set_flags, SET_BLOOM_SIZE) && test_data->options.bloom_size == SMALL_BLOOM_SIZE;
+          default_repository_index = !CHECK_FLAG (test_data->options.set_flags, SET_REPOSITORY_INDEX) || test_data->options.repository_index == 0;
+          assert_ostree_service_file_contents_valid (service_file,
+                                                     small_bloom_size,
+                                                     default_repository_index);
+
+          g_assert_cmpint (g_unlink (service_file), ==, 0);
+        }
+      else
+        {
+          g_assert_nonnull (error); /* no point in checking the domain and code */
+          g_assert_false (result);
+          g_assert_false (g_file_test (service_file, G_FILE_TEST_EXISTS));
+        }
+    }
+}
+
+static void
+create_file (const gchar *path)
+{
+  g_autoptr(GError) error = NULL;
+  gboolean result = g_file_set_contents (path, "foo", -1, &error);
+
+  g_assert_no_error (error);
+  g_assert_true (result);
+  g_assert_true (g_file_test (path, G_FILE_TEST_EXISTS));
+}
+
+static gchar *
+ostree_service_file (const gchar *repo_index)
+{
+  return g_strdup_printf ("eos-ostree-updater-%s.service",
+                          repo_index);
+}
+
+static void
+test_avahi_ostree_cleanup_directory (Fixture       *fixture,
+                                     gconstpointer  user_data G_GNUC_UNUSED)
+{
+  guint idx;
+  guint max = 6;
+  gboolean result;
+  g_autoptr(GPtrArray) valid_files = g_ptr_array_new_with_free_func (g_free);
+  g_autoptr(GPtrArray) invalid_files = g_ptr_array_new_with_free_func (g_free);
+  g_autoptr(GError) error = NULL;
+
+  for (idx = 0; idx < max; ++idx)
+    {
+      const gchar repo_index[] = { '0' + idx, '\0' };
+      g_autofree gchar *filename = ostree_service_file (repo_index);
+
+      g_ptr_array_add (valid_files, g_build_filename (fixture->tmp_dir,
+                                                      filename,
+                                                      NULL));
+    }
+
+  {
+    gchar *filenames[] =
+      {
+        ostree_service_file ("foo"),
+        ostree_service_file ("100000"),
+        g_strdup ("whatever")
+      };
+
+    for (idx = 0; idx < G_N_ELEMENTS (filenames); ++idx)
+      {
+        g_ptr_array_add (invalid_files, g_build_filename (fixture->tmp_dir,
+                                                          filenames[idx],
+                                                          NULL));
+        g_free (filenames[idx]);
+      }
+  }
+
+  for (idx = 0; idx < valid_files->len; ++idx)
+    create_file (g_ptr_array_index (valid_files, idx));
+  for (idx = 0; idx < invalid_files->len; ++idx)
+    create_file (g_ptr_array_index (invalid_files, idx));
+
+  result = eos_ostree_avahi_service_file_cleanup_directory (fixture->tmp_dir,
+                                                            NULL,
+                                                            &error);
+  g_assert_no_error (error);
+  g_assert_true (result);
+
+  for (idx = 0; idx < valid_files->len; ++idx)
+    g_assert_false (g_file_test (g_ptr_array_index (valid_files, idx),
+                                 G_FILE_TEST_EXISTS));
+
+  for (idx = 0; idx < invalid_files->len; ++idx)
+    {
+      const gchar *service_file = g_ptr_array_index (invalid_files, idx);
+      g_assert_true (g_file_test (service_file, G_FILE_TEST_EXISTS));
+      g_assert_cmpint (g_unlink (service_file), ==, 0);
+    }
+}
+
+static void
+test_avahi_ostree_delete (Fixture       *fixture,
+                          gconstpointer  user_data G_GNUC_UNUSED)
+{
+  g_autoptr(GError) error = NULL;
+  gboolean result;
+  guint16 repo_index = 6;
+  g_autofree gchar *repo_index_str = g_strdup_printf ("%" G_GUINT16_FORMAT,
+                                                      repo_index);
+  g_autofree gchar *filename = ostree_service_file (repo_index_str);
+  g_autofree gchar *service_file = g_build_filename (fixture->tmp_dir,
+                                                     filename,
+                                                     NULL);
+
+  g_assert_false (g_file_test (service_file, G_FILE_TEST_EXISTS));
+  result = eos_ostree_avahi_service_file_delete (fixture->tmp_dir,
+                                                 repo_index,
+                                                 NULL,
+                                                 &error);
+  g_assert_no_error (error);
+  g_assert_true (result);
+  g_assert_false (g_file_test (service_file, G_FILE_TEST_EXISTS));
+
+  create_file (service_file);
+  result = eos_ostree_avahi_service_file_delete (fixture->tmp_dir,
+                                                 repo_index,
+                                                 NULL,
+                                                 &error);
+  g_assert_no_error (error);
+  g_assert_true (result);
+  g_assert_false (g_file_test (service_file, G_FILE_TEST_EXISTS));
+}
+
 int
 main (int   argc,
       char *argv[])
@@ -346,6 +886,15 @@ main (int   argc,
               teardown);
   g_test_add ("/avahi-service-file/delete/denied", Fixture, NULL, setup,
               test_avahi_service_file_delete_denied, teardown);
+
+  g_test_add_func ("/avahi-service-file/ostree/check",
+                   test_avahi_ostree_options_check);
+  g_test_add ("/avahi-service-file/ostree/generate", Fixture, NULL, setup,
+              test_avahi_ostree_service_file_generate, teardown);
+  g_test_add ("/avahi-service-file/ostree/cleanup-directory", Fixture, NULL, setup,
+              test_avahi_ostree_cleanup_directory, teardown);
+  g_test_add ("/avahi-service-file/ostree/delete", Fixture, NULL, setup,
+              test_avahi_ostree_delete, teardown);
 
   return g_test_run ();
 }


### PR DESCRIPTION
This is a work in progress, not tested or anything, but can serve as a base for API review. It is based on #94, so please ignore the string to number conversion functions. I still have to review this code against the new IETF drafts.

(Edit: Pressed the submit too quickly)

Added three functions:

- generate an ostree avahi service file
  - it follows a bit an API convention in ostree, so it takes a GVariant being a vardict for options
- delete an ostree avahi service file
  - it deletes it for a specific repository index
- delete all ostree avahi service files but the ones in the whitelist
  - this is to be used in the situation when we change the config in a way that we remove some repositories, so we can also remove all the obsolete files without having to remember what files there were.
  - makes me wonder if this is really necessary - probably we could remove the whitelist, so all the ostree avahi service files would be removed and then we could recreate them based on a new configuration

https://phabricator.endlessm.com/T16589