### PR TITLE
eos-updater-apply: Workaround failures during sysroot cleanup

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -69,6 +69,7 @@ uninstalled_test_programs = \
 	test-update-from-lan \
 	test-update-from-volume \
 	test-update-cleanup-workaround \
+	test-update-broken-delta \
 	$(NULL)
 
 AM_TESTS_ENVIRONMENT = \
@@ -122,6 +123,12 @@ test_update_cleanup_workaround_CFLAGS = $(test_cflags)
 test_update_cleanup_workaround_LDFLAGS = $(test_ldflags)
 test_update_cleanup_workaround_LDADD = $(test_ldadd)
 test_update_cleanup_workaround_SOURCES = test-update-cleanup-workaround.c
+
+test_update_broken_delta_CPPFLAGS = $(test_cppflags)
+test_update_broken_delta_CFLAGS = $(test_cflags)
+test_update_broken_delta_LDFLAGS = $(test_ldflags)
+test_update_broken_delta_LDADD = $(test_ldadd)
+test_update_broken_delta_SOURCES = test-update-broken-delta.c
 
 dist_uninstalled_test_data = \
 	gpghome/C1EB8F4E.asc \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -68,6 +68,7 @@ uninstalled_test_programs = \
 	test-update-from-main \
 	test-update-from-lan \
 	test-update-from-volume \
+	test-update-cleanup-workaround \
 	$(NULL)
 
 AM_TESTS_ENVIRONMENT = \
@@ -115,6 +116,12 @@ test_update_from_volume_CFLAGS = $(test_cflags)
 test_update_from_volume_LDFLAGS = $(test_ldflags)
 test_update_from_volume_LDADD = $(test_ldadd)
 test_update_from_volume_SOURCES = test-update-from-volume.c
+
+test_update_cleanup_workaround_CPPFLAGS = $(test_cppflags)
+test_update_cleanup_workaround_CFLAGS = $(test_cflags)
+test_update_cleanup_workaround_LDFLAGS = $(test_ldflags)
+test_update_cleanup_workaround_LDADD = $(test_ldadd)
+test_update_cleanup_workaround_SOURCES = test-update-cleanup-workaround.c
 
 dist_uninstalled_test_data = \
 	gpghome/C1EB8F4E.asc \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -49,6 +49,8 @@ libeos_updater_test_la_SOURCES = \
 	ostree-spawn.h \
 	eos-test-utils.c \
 	eos-test-utils.h \
+	eos-test-convenience.c \
+	eos-test-convenience.h \
 	$(NULL)
 
 @VALGRIND_CHECK_RULES@

--- a/tests/eos-test-convenience.c
+++ b/tests/eos-test-convenience.c
@@ -20,10 +20,21 @@
  *  - Krzesimir Nowak <krzesimir@kinvolk.io>
  */
 
+/* Functions here implement the common actions the test implementer
+ * may want to execute (like set up a server or a client or update
+ * either one). These are of a higher level than the functions in
+ * eos-test-utils.
+ */
+
 #include "eos-test-convenience.h"
 
 #include <string.h>
 
+/* This initializes the EtcData structure. In the beginning, nothing
+ * is available. Use etc_set_up_server() and
+ * etc_set_up_client_synced_to_server() to get the server and client
+ * fields filled.
+ */
 void
 etc_data_init (EtcData *data,
                EosUpdaterFixture *fixture)
@@ -37,6 +48,8 @@ etc_data_init (EtcData *data,
   data->client = NULL;
 }
 
+/* Clear all the fields, but do not free the passed data pointer.
+ */
 void
 etc_data_clear (EtcData *data)
 {
@@ -49,6 +62,10 @@ etc_data_clear (EtcData *data)
   g_clear_object (&data->client);
 }
 
+/* Set up a server with a single subserver with the default vendor,
+ * product and ostree path. The subserver will contain one commit
+ * (0). This sets the server and subserver fields in data.
+ */
 void
 etc_set_up_server (EtcData *data)
 {
@@ -78,6 +95,10 @@ etc_set_up_server (EtcData *data)
   data->subserver = g_object_ref (EOS_TEST_SUBSERVER (g_ptr_array_index (data->server->subservers, 0)));
 }
 
+/* Set up a client, that is in sync with the server. Needs to be
+ * called after the server is set up. This sets the client field in
+ * data.
+ */
 void
 etc_set_up_client_synced_to_server (EtcData *data)
 {
@@ -101,6 +122,8 @@ etc_set_up_client_synced_to_server (EtcData *data)
   g_assert_no_error (error);
 }
 
+/* Update the server to the new commit.
+ */
 void
 etc_update_server (EtcData *data,
                    guint commit)
@@ -122,6 +145,8 @@ etc_update_server (EtcData *data,
   g_assert_no_error (error);
 }
 
+/* Pulls the updates from the server using eos-updater and autoupdater.
+ */
 void
 etc_update_client (EtcData *data)
 {
@@ -176,6 +201,13 @@ etc_update_client (EtcData *data)
   g_assert_true (has_commit);
 }
 
+/* Deletes an object from a repositories' objects directory. The repo
+ * should be a GFile pointing to the ostree repository, and the object
+ * should describe what will be removed.  The object string should
+ * look like a filename formatted as <HASH>.<TYPE>, where <HASH> is 64
+ * characters of the object checksum and <TYPE> should describe an
+ * ostree object type (dirtree, dirmeta, commit, file, …).
+ */
 void
 etc_delete_object (GFile *repo,
                    const gchar *object)

--- a/tests/eos-test-convenience.c
+++ b/tests/eos-test-convenience.c
@@ -1,0 +1,202 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2017 Kinvolk GmbH
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Authors:
+ *  - Krzesimir Nowak <krzesimir@kinvolk.io>
+ */
+
+#include "eos-test-convenience.h"
+
+#include <string.h>
+
+void
+etc_data_init (EtcData *data,
+               EosUpdaterFixture *fixture)
+{
+  g_assert_nonnull (data);
+  g_assert_nonnull (fixture);
+
+  data->fixture = fixture;
+  data->server = NULL;
+  data->subserver = NULL;
+  data->client = NULL;
+}
+
+void
+etc_data_clear (EtcData *data)
+{
+  if (data == NULL)
+    return;
+
+  data->fixture = NULL;
+  g_clear_object (&data->server);
+  g_clear_object (&data->subserver);
+  g_clear_object (&data->client);
+}
+
+void
+etc_set_up_server (EtcData *data)
+{
+  g_autoptr(GFile) server_root = NULL;
+  g_autofree gchar *keyid = NULL;
+  g_autoptr(GError) error = NULL;
+
+  g_assert_nonnull (data);
+  g_assert_nonnull (data->fixture);
+  g_assert_null (data->server);
+  g_assert_null (data->subserver);
+
+  server_root = g_file_get_child (data->fixture->tmpdir, "main");
+  keyid = get_keyid (data->fixture->gpg_home);
+  data->server = eos_test_server_new_quick (server_root,
+                                            default_vendor,
+                                            default_product,
+                                            default_ref,
+                                            0,
+                                            data->fixture->gpg_home,
+                                            keyid,
+                                            default_ostree_path,
+                                            &error);
+  g_assert_no_error (error);
+  g_assert_cmpuint (data->server->subservers->len, ==, 1u);
+
+  data->subserver = g_object_ref (EOS_TEST_SUBSERVER (g_ptr_array_index (data->server->subservers, 0)));
+}
+
+void
+etc_set_up_client_synced_to_server (EtcData *data)
+{
+  g_autoptr(GFile) client_root = NULL;
+  g_autoptr(GError) error = NULL;
+
+  g_assert_nonnull (data);
+  g_assert_nonnull (data->fixture);
+  g_assert_nonnull (data->server);
+  g_assert_nonnull (data->subserver);
+  g_assert_null (data->client);
+
+  client_root = g_file_get_child (data->fixture->tmpdir, "client");
+  data->client = eos_test_client_new (client_root,
+                                      default_remote_name,
+                                      data->subserver,
+                                      default_ref,
+                                      default_vendor,
+                                      default_product,
+                                      &error);
+  g_assert_no_error (error);
+}
+
+void
+etc_update_server (EtcData *data,
+                   guint commit)
+{
+  g_autoptr(GError) error = NULL;
+  guint current_commit;
+
+  g_assert_nonnull (data);
+  g_assert_nonnull (data->subserver);
+
+  current_commit = GPOINTER_TO_UINT (g_hash_table_lookup (data->subserver->ref_to_commit, default_ref));
+  g_assert_cmpint (current_commit, <, commit);
+
+  g_hash_table_insert (data->subserver->ref_to_commit,
+                       g_strdup (default_ref),
+                       GUINT_TO_POINTER (commit));
+  eos_test_subserver_update (data->subserver,
+                             &error);
+  g_assert_no_error (error);
+}
+
+void
+etc_update_client (EtcData *data)
+{
+  DownloadSource main_source = DOWNLOAD_MAIN;
+  g_autoptr(GVariant) main_source_variant = NULL;
+  g_auto(CmdAsyncResult) updater_cmd = CMD_ASYNC_RESULT_CLEARED;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GFile) autoupdater_root = NULL;
+  g_autoptr(EosTestAutoupdater) autoupdater = NULL;
+  g_auto(CmdResult) reaped_updater = CMD_RESULT_CLEARED;
+  g_autoptr(GPtrArray) cmds = NULL;
+  gboolean has_commit = FALSE;
+
+  g_assert_nonnull (data);
+  g_assert_nonnull (data->client);
+  g_assert_nonnull (data->fixture);
+
+  // update the client
+  eos_test_client_run_updater (data->client,
+                               &main_source,
+                               &main_source_variant,
+                               1,
+                               &updater_cmd,
+                               &error);
+  g_assert_no_error (error);
+
+  autoupdater_root = g_file_get_child (data->fixture->tmpdir, "autoupdater");
+  autoupdater = eos_test_autoupdater_new (autoupdater_root,
+                                          UPDATE_STEP_APPLY,
+                                          1,
+                                          TRUE,
+                                          &error);
+  g_assert_no_error (error);
+
+  eos_test_client_reap_updater (data->client,
+                                &updater_cmd,
+                                &reaped_updater,
+                                &error);
+  g_assert_no_error (error);
+
+  cmds = g_ptr_array_sized_new (2);
+  g_ptr_array_add (cmds, &reaped_updater);
+  g_ptr_array_add (cmds, autoupdater->cmd);
+  g_assert_true (cmd_result_ensure_all_ok_verbose (cmds));
+
+  eos_test_client_has_commit (data->client,
+                              default_remote_name,
+                              1,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_true (has_commit);
+}
+
+void
+etc_delete_object (GFile *repo,
+                   const gchar *object)
+{
+  g_autoptr(GFile) objects_dir = NULL;
+  gchar prefix[3] = { '\0', '\0', '\0' };
+  g_autofree gchar *rest = NULL;
+  g_autoptr(GFile) prefix_dir = NULL;
+  g_autoptr(GFile) object_file = NULL;
+  g_autoptr(GError) error = NULL;
+
+  g_assert_nonnull (repo);
+  g_assert_nonnull (object);
+  g_assert_true (strlen (object) > 64);
+
+  objects_dir = g_file_get_child (repo, "objects");
+  prefix[0] = object[0];
+  prefix[1] = object[1];
+  rest = g_strdup (object + 2);
+  prefix_dir = g_file_get_child (objects_dir, prefix);
+  object_file = g_file_get_child (prefix_dir, rest);
+  g_file_delete (object_file, NULL, &error);
+  g_assert_no_error (error);
+}

--- a/tests/eos-test-convenience.h
+++ b/tests/eos-test-convenience.h
@@ -1,0 +1,56 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2017 Kinvolk GmbH
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Authors:
+ *  - Krzesimir Nowak <krzesimir@kinvolk.io>
+ */
+
+#pragma once
+
+#include "eos-test-utils.h"
+
+G_BEGIN_DECLS
+
+typedef struct
+{
+  EosUpdaterFixture *fixture;
+  EosTestServer *server;
+  EosTestSubserver *subserver;
+  EosTestClient *client;
+} EtcData;
+
+void etc_data_init (EtcData *data,
+                    EosUpdaterFixture *fixture);
+
+void etc_data_clear (EtcData *data);
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(EtcData, etc_data_clear);
+
+void etc_set_up_server (EtcData *data);
+
+void etc_set_up_client_synced_to_server (EtcData *data);
+
+void etc_update_server (EtcData *data,
+                        guint commit);
+
+void etc_update_client (EtcData *data);
+
+void etc_delete_object (GFile *repo,
+                        const gchar *object);
+
+G_END_DECLS

--- a/tests/eos-test-convenience.h
+++ b/tests/eos-test-convenience.h
@@ -26,6 +26,10 @@
 
 G_BEGIN_DECLS
 
+/* Holds the single server and client, used by the functions
+ * below. Normally you define a variable of this type on the stack and
+ * pass an address to it to the etc_ functions.
+ */
 typedef struct
 {
   EosUpdaterFixture *fixture;

--- a/tests/eos-test-utils.c
+++ b/tests/eos-test-utils.c
@@ -2082,6 +2082,19 @@ eos_test_client_has_commit (EosTestClient *client,
 }
 
 gboolean
+eos_test_client_get_deployments (EosTestClient *client,
+                                 const gchar *osname,
+                                 gchar ***out_ids,
+                                 GError **error)
+{
+  g_autoptr(GFile) sysroot = get_sysroot_for_client (client->root);
+
+  g_assert_nonnull (out_ids);
+
+  return get_deploy_ids (sysroot, osname, out_ids, error);
+}
+
+gboolean
 eos_test_client_prepare_volume (EosTestClient *client,
                                 GFile *volume_path,
                                 GError **error)
@@ -2148,6 +2161,20 @@ eos_test_client_prepare_volume (EosTestClient *client,
     }
 
   return TRUE;
+}
+
+GFile *
+eos_test_client_get_repo (EosTestClient *client)
+{
+  g_autoptr(GFile) sysroot = get_sysroot_for_client (client->root);
+
+  return get_repo_for_sysroot (sysroot);
+}
+
+GFile *
+eos_test_client_get_sysroot (EosTestClient *client)
+{
+  return get_sysroot_for_client (client->root);
 }
 
 static void

--- a/tests/eos-test-utils.c
+++ b/tests/eos-test-utils.c
@@ -496,7 +496,7 @@ prepare_commit (GFile *repo,
                 const gchar *ref,
                 GFile *gpg_home,
                 const gchar *keyid,
-                gchar **checksum,
+                gchar **out_checksum,
                 GError **error)
 {
   g_auto(CmdResult) cmd = CMD_RESULT_CLEARED;
@@ -556,8 +556,8 @@ prepare_commit (GFile *repo,
   if (!cmd_result_ensure_ok (&cmd, error))
     return FALSE;
 
-  if (checksum != NULL)
-    return get_current_commit_checksum (repo, ref, checksum, error);
+  if (out_checksum != NULL)
+    return get_current_commit_checksum (repo, ref, out_checksum, error);
 
   return TRUE;
 }

--- a/tests/eos-test-utils.c
+++ b/tests/eos-test-utils.c
@@ -692,33 +692,24 @@ update_commits (EosTestSubserver *subserver,
                                             &old_checksum,
                                             error))
             return FALSE;
+        }
 
-          if (!prepare_commit (subserver->repo,
-                               subserver->tree,
-                               commit_number,
-                               ref,
-                               subserver->gpg_home,
-                               subserver->keyid,
-                               &checksum,
-                               error))
-            return FALSE;
+      if (!prepare_commit (subserver->repo,
+                           subserver->tree,
+                           commit_number,
+                           ref,
+                           subserver->gpg_home,
+                           subserver->keyid,
+                           &checksum,
+                           error))
+        return FALSE;
 
+      if (commit_number > 0)
+        {
           if (!generate_delta_files (subserver->repo,
                                      old_checksum,
                                      checksum,
                                      error))
-            return FALSE;
-        }
-      else
-        {
-          if (!prepare_commit (subserver->repo,
-                               subserver->tree,
-                               commit,
-                               ref,
-                               subserver->gpg_home,
-                               subserver->keyid,
-                               &checksum,
-                               error))
             return FALSE;
         }
 

--- a/tests/eos-test-utils.h
+++ b/tests/eos-test-utils.h
@@ -211,9 +211,18 @@ gboolean eos_test_client_has_commit (EosTestClient *client,
                                      gboolean *out_has_commit,
                                      GError **error);
 
+gboolean eos_test_client_get_deployments (EosTestClient *client,
+                                          const gchar *osname,
+                                          gchar ***out_ids,
+                                          GError **error);
+
 gboolean eos_test_client_prepare_volume (EosTestClient *client,
                                          GFile *volume_path,
                                          GError **error);
+
+GFile *eos_test_client_get_repo (EosTestClient *client);
+
+GFile *eos_test_client_get_sysroot (EosTestClient *client);
 
 typedef enum _UpdateStep {
   UPDATE_STEP_NONE,

--- a/tests/eos-test-utils.h
+++ b/tests/eos-test-utils.h
@@ -131,7 +131,7 @@ EosTestServer *eos_test_server_new_quick (GFile *server_root,
                                           const gchar *vendor,
                                           const gchar *product,
                                           const gchar *ref,
-                                          guint commit,
+                                          guint commit_number,
                                           GFile *gpg_home,
                                           const gchar *keyid,
                                           const gchar *ostree_path,
@@ -207,7 +207,7 @@ gboolean eos_test_client_store_definition (EosTestClient *client,
 
 gboolean eos_test_client_has_commit (EosTestClient *client,
                                      const gchar *osname,
-                                     guint commit_no,
+                                     guint commit_number,
                                      gboolean *out_has_commit,
                                      GError **error);
 

--- a/tests/eos-test-utils.h
+++ b/tests/eos-test-utils.h
@@ -224,6 +224,8 @@ GFile *eos_test_client_get_repo (EosTestClient *client);
 
 GFile *eos_test_client_get_sysroot (EosTestClient *client);
 
+const gchar *eos_test_client_get_big_file_path (void);
+
 typedef enum _UpdateStep {
   UPDATE_STEP_NONE,
   UPDATE_STEP_POLL,

--- a/tests/ostree-spawn.c
+++ b/tests/ostree-spawn.c
@@ -288,6 +288,73 @@ ostree_prune (GFile *repo,
                                     error);
 }
 
+gboolean
+ostree_static_delta_generate (GFile *repo,
+                              const gchar *from,
+                              const gchar *to,
+                              CmdResult *cmd,
+                              GError **error)
+{
+  CmdArg args[] =
+    {
+      { NULL, "static-delta" },
+      { NULL, "generate" },
+      { "from", from },
+      { "to", to },
+      { NULL, NULL }
+    };
+
+  return spawn_ostree_in_repo_args (repo,
+                                    args,
+                                    cmd,
+                                    error);
+}
+
+gboolean
+ostree_ls (GFile *repo,
+           OstreeLsFlags flags,
+           const gchar *ref,
+           const gchar * const *paths,
+           CmdResult *cmd,
+           GError **error)
+{
+  g_autoptr(GArray) args = cmd_arg_array_new ();
+  CmdArg ls = { NULL, "ls" };
+  CmdArg dir_only = { "dironly", NULL };
+  CmdArg recursive = { "recursive", NULL };
+  CmdArg checksum = { "checksum", NULL };
+  CmdArg xattrs = { "xattrs", NULL };
+  CmdArg nul_filenames_only = { "nul-filenames-only", NULL };
+  CmdArg ref_arg = { NULL, ref };
+  CmdArg terminator = { NULL, NULL };
+  const gchar * const * iter;
+
+  g_array_append_val (args, ls);
+  if ((flags & OSTREE_LS_DIR_ONLY) == OSTREE_LS_DIR_ONLY)
+    g_array_append_val (args, dir_only);
+  if ((flags & OSTREE_LS_RECURSIVE) == OSTREE_LS_RECURSIVE)
+    g_array_append_val (args, recursive);
+  if ((flags & OSTREE_LS_CHECKSUM) == OSTREE_LS_CHECKSUM)
+    g_array_append_val (args, checksum);
+  if ((flags & OSTREE_LS_XATTRS) == OSTREE_LS_XATTRS)
+    g_array_append_val (args, xattrs);
+  if ((flags & OSTREE_LS_NUL_FILENAMES_ONLY) == OSTREE_LS_NUL_FILENAMES_ONLY)
+    g_array_append_val (args, nul_filenames_only);
+  g_array_append_val (args, ref_arg);
+  for (iter = paths; *iter != NULL; ++iter)
+    {
+      CmdArg path_arg = { NULL, *iter };
+
+      g_array_append_val (args, path_arg);
+    }
+  g_array_append_val (args, terminator);
+
+  return spawn_ostree_in_repo_args (repo,
+                                    cmd_arg_array_raw (args),
+                                    cmd,
+                                    error);
+}
+
 static gboolean
 ostree_admin_spawn_in_sysroot (GFile *sysroot,
                                const gchar *admin_subcommand,

--- a/tests/ostree-spawn.h
+++ b/tests/ostree-spawn.h
@@ -69,6 +69,30 @@ gboolean ostree_remote_add (GFile *repo,
                             CmdResult *cmd,
                             GError **error);
 
+gboolean ostree_ref_create (GFile *repo,
+                            const gchar *ref_name,
+                            const gchar *commit_id,
+                            CmdResult *cmd,
+                            GError **error);
+
+gboolean ostree_ref_delete (GFile *repo,
+                            const gchar *ref_name,
+                            CmdResult *cmd,
+                            GError **error);
+
+typedef enum
+  {
+    OSTREE_PRUNE_REFS_ONLY = 1 << 0,
+    OSTREE_PRUNE_NO_PRUNE  = 1 << 1,
+    OSTREE_PRUNE_VERBOSE   = 1 << 2,
+  } OstreePruneFlags;
+
+gboolean ostree_prune (GFile *repo,
+                       OstreePruneFlags flags,
+                       gint depth_opt,
+                       CmdResult *cmd,
+                       GError **error);
+
 gboolean ostree_deploy (GFile *sysroot,
                         const gchar *osname,
                         const gchar *refspec,
@@ -87,6 +111,11 @@ gboolean ostree_os_init (GFile *sysroot,
 gboolean ostree_status (GFile *sysroot,
                         CmdResult *cmd,
                         GError **error);
+
+gboolean ostree_undeploy (GFile *sysroot,
+                          int deployment_index,
+                          CmdResult *cmd,
+                          GError **error);
 
 /* due to some bug I don't know where (either my fault, or ostree
  * trivial-httpd's in lackluster or just cursory daemonizing or

--- a/tests/ostree-spawn.h
+++ b/tests/ostree-spawn.h
@@ -93,6 +93,28 @@ gboolean ostree_prune (GFile *repo,
                        CmdResult *cmd,
                        GError **error);
 
+gboolean ostree_static_delta_generate (GFile *repo,
+                                       const gchar *from,
+                                       const gchar *to,
+                                       CmdResult *cmd,
+                                       GError **error);
+
+typedef enum
+  {
+    OSTREE_LS_DIR_ONLY,
+    OSTREE_LS_RECURSIVE,
+    OSTREE_LS_CHECKSUM,
+    OSTREE_LS_XATTRS,
+    OSTREE_LS_NUL_FILENAMES_ONLY,
+  } OstreeLsFlags;
+
+gboolean ostree_ls (GFile *repo,
+                    OstreeLsFlags flags,
+                    const gchar *ref,
+                    const gchar * const *paths,
+                    CmdResult *cmd,
+                    GError **error);
+
 gboolean ostree_deploy (GFile *sysroot,
                         const gchar *osname,
                         const gchar *refspec,

--- a/tests/spawn-utils.c
+++ b/tests/spawn-utils.c
@@ -69,6 +69,17 @@ cmd_result_ensure_ok (CmdResult *cmd,
 }
 
 gboolean
+cmd_result_ensure_ok_verbose (CmdResult *cmd)
+{
+  g_autoptr(GError) error = NULL;
+
+  if (cmd_result_ensure_ok (cmd, &error))
+    return TRUE;
+
+  return FALSE;
+}
+
+gboolean
 cmd_result_ensure_all_ok_verbose (GPtrArray *cmds)
 {
   guint idx;
@@ -77,15 +88,9 @@ cmd_result_ensure_all_ok_verbose (GPtrArray *cmds)
   for (idx = 0; idx < cmds->len; ++idx)
     {
       CmdResult *cmd = g_ptr_array_index (cmds, idx);
-      g_autoptr(GError) error = NULL;
-      g_autofree gchar *msg = NULL;
 
-      if (cmd_result_ensure_ok (cmd, &error))
-        continue;
-
-      msg = g_strdup_printf ("%s failure:\n%s", cmd->cmdline, error->message);
-      g_test_message ("%s", msg);
-      ok = FALSE;
+      if (!cmd_result_ensure_ok_verbose (cmd))
+        ok = FALSE;
     }
 
   return ok;

--- a/tests/spawn-utils.c
+++ b/tests/spawn-utils.c
@@ -144,13 +144,24 @@ test_spawn_cwd_async (const gchar *cwd,
   g_auto(GStrv) merged_env = merge_parent_and_child_env (envp);
   g_autofree gchar *argv_joined = g_strjoinv (" ", (gchar **) argv);
   g_autofree gchar *envp_joined = join_envp_for_logging ((const gchar * const *) merged_env);
+  g_autofree gchar *wd = NULL;
+  const gchar *real_cwd;
 
   if (!autoreap && cmd != NULL)
     flags |= G_SPAWN_DO_NOT_REAP_CHILD;
 
+  if (cwd == NULL)
+    {
+      wd = g_get_current_dir ();
+      real_cwd = wd;
+    }
+  else
+    {
+      real_cwd = cwd;
+    }
   g_test_message ("Spawning ‘%s’ in ‘%s’ with environment:\n%s",
                   argv_joined,
-                  cwd,
+                  real_cwd,
                   envp_joined);
 
   if (cmd != NULL)

--- a/tests/spawn-utils.h
+++ b/tests/spawn-utils.h
@@ -45,6 +45,8 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (CmdResult, cmd_result_free)
 gboolean cmd_result_ensure_ok (CmdResult *cmd,
                                GError **error);
 
+gboolean cmd_result_ensure_ok_verbose (CmdResult *cmd);
+
 gboolean cmd_result_ensure_all_ok_verbose (GPtrArray *cmds);
 
 gchar *cmd_result_dump (CmdResult *cmd);

--- a/tests/spawn-utils.h
+++ b/tests/spawn-utils.h
@@ -125,6 +125,20 @@ typedef struct
   const gchar *value;
 } CmdArg;
 
+static inline GArray *
+cmd_arg_array_new (void)
+{
+  return g_array_new (/* zero-terminated: */ FALSE,
+                      /* cleared: */ FALSE,
+                      sizeof (CmdArg));
+}
+
+static inline CmdArg *
+cmd_arg_array_raw (GArray *cmd_arg_array)
+{
+  return (CmdArg *) cmd_arg_array->data;
+}
+
 gchar **
 build_cmd_args (CmdArg *args);
 

--- a/tests/test-update-broken-delta.c
+++ b/tests/test-update-broken-delta.c
@@ -30,6 +30,9 @@
 #include <locale.h>
 #include <string.h>
 
+/* Finds the big file in the deployment to figure out its checksum, so
+ * it can then remove it from client's repository.
+ */
 static void
 delete_big_file_object_from_client_repo (EtcData *data)
 {
@@ -82,6 +85,10 @@ delete_big_file_object_from_client_repo (EtcData *data)
   etc_delete_object (client_repo, object);
 }
 
+/* Corrupt a repository on the client side, so that using static delta
+ * files is impossible and make sure that eos-updater can cope with
+ * it.
+ */
 static void
 test_update_broken_delta (EosUpdaterFixture *fixture,
                           gconstpointer user_data)

--- a/tests/test-update-broken-delta.c
+++ b/tests/test-update-broken-delta.c
@@ -1,0 +1,130 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2017 Kinvolk GmbH
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Authors:
+ *  - Krzesimir Nowak <krzesimir@kinvolk.io>
+ */
+
+#include "misc-utils.h"
+#include "spawn-utils.h"
+#include "ostree-spawn.h"
+#include "eos-test-utils.h"
+#include "eos-test-convenience.h"
+
+#include <gio/gio.h>
+#include <locale.h>
+#include <string.h>
+
+static void
+delete_big_file_object_from_client_repo (EtcData *data)
+{
+  const gchar *bigfile_path = eos_test_client_get_big_file_path ();
+  const gchar *paths[] =
+    {
+      bigfile_path,
+      NULL
+    };
+  g_autoptr(GFile) client_repo = NULL;
+  OstreeLsFlags flags = OSTREE_LS_CHECKSUM;
+  g_auto(CmdResult) listed = CMD_RESULT_CLEARED;
+  g_autoptr(GError) error = NULL;
+  g_autofree gchar *escaped_bigfile_path = NULL;
+  g_autofree gchar *regex = NULL;
+  g_autoptr(GRegex) gregex = NULL;
+  gboolean matched;
+  g_autoptr(GMatchInfo) match_info = NULL;
+  g_autofree gchar *checksum = NULL;
+  g_autofree gchar *object = NULL;
+
+  g_assert_nonnull (data);
+  g_assert_nonnull (data->client);
+
+  client_repo = eos_test_client_get_repo (data->client);
+  ostree_ls (client_repo,
+             flags,
+             default_ref,
+             paths,
+             &listed,
+             &error);
+  g_assert_no_error (error);
+  g_assert_true (cmd_result_ensure_ok_verbose (&listed));
+
+  escaped_bigfile_path = g_regex_escape_string (bigfile_path, -1);
+  regex = g_strdup_printf ("\\s+([0-9a-zA-Z]{64})\\s+%s", escaped_bigfile_path);
+  gregex = g_regex_new (regex,
+                        /* compile flags: */ 0,
+                        /* match flags: */ 0,
+                        &error);
+  g_assert_no_error (error);
+  matched = g_regex_match (gregex,
+                           listed.standard_output,
+                           /* match flags: */ 0,
+                           &match_info);
+  g_assert_true (matched);
+  checksum = g_match_info_fetch (match_info,
+                                 /* match group: */ 1);
+  object = g_strdup_printf ("%s.file", checksum);
+  etc_delete_object (client_repo, object);
+}
+
+static void
+test_update_broken_delta (EosUpdaterFixture *fixture,
+                          gconstpointer user_data)
+{
+  g_auto(EtcData) real_data = { NULL, };
+  EtcData *data = &real_data;
+
+  g_test_bug ("T17183");
+
+  etc_data_init (data, fixture);
+  /* Create and set up the server with the commit 0.
+   */
+  etc_set_up_server (data);
+  /* Create and set up the client, that pulls the update from the
+   * server, so it should have also a commit 0 and a deployment based
+   * on this commit.
+   */
+  etc_set_up_client_synced_to_server (data);
+  /* Update the server, so it has a new commit (1), and the delta
+   * files between commits 0 and 1.
+   */
+  etc_update_server (data, 1);
+  /* Delete an object in repository objects directory which serves as
+   * a base for generating a new version of the object with the static
+   * delta files.
+   */
+  delete_big_file_object_from_client_repo (data);
+  /* Try to update the client - during the "fetch" step, it should
+   * fallback to fetching objects instead of using delta files.
+   */
+  etc_update_client (data);
+}
+
+int
+main (int argc,
+      char **argv)
+{
+  setlocale (LC_ALL, "");
+
+  g_test_init (&argc, &argv, NULL);
+  g_test_bug_base ("https://phabricator.endlessm.com/");
+
+  eos_test_add ("/updater/update-cleanup-broken-delta", NULL, test_update_broken_delta);
+
+  return g_test_run ();
+}

--- a/tests/test-update-cleanup-workaround.c
+++ b/tests/test-update-cleanup-workaround.c
@@ -30,6 +30,10 @@
 #include <locale.h>
 #include <string.h>
 
+/* Finds an old deployment to figure out the commit id on which the
+ * deployment was based on and creates a ref that references the
+ * commit id.
+ */
 static void
 save_old_deployment_commit_in_ref (EtcData *data,
                                    const gchar *ref)
@@ -107,6 +111,10 @@ delete_ref (EtcData *data,
   g_assert_true (cmd_result_ensure_ok_verbose (&ref_deleted));
 }
 
+/* Runs the "ostree prune" with a mode that does no pruning, but
+ * prints what items would be pruned if it could do it. Then remove
+ * some of the dirtree objects from that list (at most 3).
+ */
 static void
 delete_some_old_dirtree_objects (EtcData *data)
 {
@@ -148,6 +156,9 @@ delete_some_old_dirtree_objects (EtcData *data)
   g_assert_cmpint (removed, >, 0);
 }
 
+/* Corrupt a repository on the client side, so that pruning may fail
+ * and make sure that eos-updater can cope with it.
+ */
 static void
 test_update_cleanup_workaround (EosUpdaterFixture *fixture,
                                 gconstpointer user_data)

--- a/tests/test-update-cleanup-workaround.c
+++ b/tests/test-update-cleanup-workaround.c
@@ -1,0 +1,219 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2017 Kinvolk GmbH
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Authors:
+ *  - Krzesimir Nowak <krzesimir@kinvolk.io>
+ */
+
+#include "misc-utils.h"
+#include "spawn-utils.h"
+#include "ostree-spawn.h"
+#include "eos-test-utils.h"
+#include "eos-test-convenience.h"
+
+#include <gio/gio.h>
+#include <locale.h>
+#include <string.h>
+
+static void
+save_old_deployment_commit_in_ref (EtcData *data,
+                                   const gchar *ref)
+{
+  g_auto(GStrv) deployment_ids = NULL;
+  g_autoptr(GError) error = NULL;
+  g_autofree gchar *old_commit_id = NULL;
+  gchar *dot_ptr;
+  g_autoptr(GFile) client_repo = NULL;
+  g_auto(CmdResult) ref_created = CMD_RESULT_CLEARED;
+
+  g_assert_nonnull (data);
+  g_assert_nonnull (data->client);
+  g_assert_nonnull (ref);
+
+  eos_test_client_get_deployments (data->client,
+                                   default_remote_name,
+                                   &deployment_ids,
+                                   &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (g_strv_length (deployment_ids), ==, 2);
+
+  /* Index 1 is always guaranteed to be the old deployment.
+   */
+  old_commit_id = g_strdup (deployment_ids[1]);
+  dot_ptr = strchr (old_commit_id, '.');
+  g_assert_nonnull (dot_ptr);
+  *dot_ptr = '\0';
+
+  client_repo = eos_test_client_get_repo (data->client);
+  ostree_ref_create (client_repo,
+                     ref,
+                     old_commit_id,
+                     &ref_created,
+                     &error);
+  g_assert_no_error (error);
+  g_assert_true (cmd_result_ensure_ok_verbose (&ref_created));
+}
+
+static void
+undeploy_old_deployment (EtcData *data)
+{
+  g_auto(CmdResult) undeployed = CMD_RESULT_CLEARED;
+  g_autoptr(GFile) client_sysroot = NULL;
+  g_autoptr(GError) error = NULL;
+
+  g_assert_nonnull (data);
+  g_assert_nonnull (data->client);
+
+  client_sysroot = eos_test_client_get_sysroot (data->client);
+  ostree_undeploy (client_sysroot,
+                   1,
+                   &undeployed,
+                   &error);
+
+  g_assert_no_error (error);
+  g_assert_true (cmd_result_ensure_ok_verbose (&undeployed));
+}
+
+static void
+delete_ref (EtcData *data,
+            const gchar *ref)
+{
+  g_autoptr(GFile) client_repo = NULL;
+  g_auto(CmdResult) ref_deleted = CMD_RESULT_CLEARED;
+  g_autoptr(GError) error = NULL;
+
+  g_assert_nonnull (data);
+  g_assert_nonnull (ref);
+  g_assert_nonnull (data->client);
+
+  client_repo = eos_test_client_get_repo (data->client);
+  ostree_ref_delete (client_repo, ref, &ref_deleted, &error);
+  g_assert_no_error (error);
+  g_assert_true (cmd_result_ensure_ok_verbose (&ref_deleted));
+}
+
+static void
+delete_some_old_dirtree_objects (EtcData *data)
+{
+  g_autoptr(GFile) client_repo = NULL;
+  OstreePruneFlags prune_flags = OSTREE_PRUNE_REFS_ONLY | OSTREE_PRUNE_NO_PRUNE | OSTREE_PRUNE_VERBOSE;
+  g_auto(CmdResult) listed = CMD_RESULT_CLEARED;
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GRegex) gregex = NULL;
+  g_autoptr(GMatchInfo) match_info = NULL;
+  guint removed;
+
+  g_assert_nonnull (data);
+  g_assert_nonnull (data->client);
+
+  client_repo = eos_test_client_get_repo (data->client);
+  ostree_prune (client_repo, prune_flags, 0, &listed, &error);
+  g_assert_no_error (error);
+  g_assert_true (cmd_result_ensure_ok_verbose (&listed));
+
+  gregex = g_regex_new ("Pruning\\s+unneeded\\s+object\\s+([0-9a-zA-Z]{64}.dirtree)",
+                        /* compile flags: */ 0,
+                        /* match flags: */ 0,
+                        &error);
+  g_assert_no_error (error);
+  g_regex_match (gregex,
+                 listed.standard_error,
+                 /* match flags: */ 0,
+                 &match_info);
+  for (removed = 0;
+       g_match_info_matches (match_info) && (removed < 3);
+       ++removed)
+    {
+      g_autofree gchar *object = g_match_info_fetch (match_info,
+                                                     /* match group: */ 1);
+      etc_delete_object (client_repo, object);
+      g_match_info_next (match_info, &error);
+      g_assert_no_error (error);
+    }
+  g_assert_cmpint (removed, >, 0);
+}
+
+static void
+test_update_cleanup_workaround (EosUpdaterFixture *fixture,
+                                gconstpointer user_data)
+{
+  g_auto(EtcData) real_data = { NULL, };
+  EtcData *data = &real_data;
+  const gchar *save_ref_name = "save-old-commit";
+
+  g_test_bug ("T16958");
+
+  etc_data_init (data, fixture);
+  /* Create and set up the server with the commit 0.
+   */
+  etc_set_up_server (data);
+  /* Create and set up the client, that pulls the update from the
+   * server, so it should have also a commit 0 and a deployment based
+   * on this commit.
+   */
+  etc_set_up_client_synced_to_server (data);
+  /* Update the server, so it has a new commit (1).
+   */
+  etc_update_server (data, 1);
+  /* Update the client, so it also has a new commit (1); and, at this
+   * point, two deployments - old one pointing to commit 0 and a new
+   * one pointing to commit 1.
+   */
+  etc_update_client (data);
+  /* We save the commit used for the old deployment in some temporary
+   * ref, so the contents of the commit will not be pruned, when we
+   * undeploy the old deployment in the followup step, because the
+   * commit will still be referenced by our temporary ref.
+   */
+  save_old_deployment_commit_in_ref (data, save_ref_name);
+  /* Remove old deployment, so the only thing that references the old
+   * commit is our temporary ref. This also performs pruning, but here
+   * it should be a noop.
+   */
+  undeploy_old_deployment (data);
+  /* Remove the temporary ref, so the commit becomes unreferenced and
+   * thus a candidate for pruning. This step does not invoke pruning.
+   */
+  delete_ref (data, save_ref_name);
+  /* We remove some dirtree objects referenced by the old commit, so
+   * we can trigger an error during pruning.
+   */
+  delete_some_old_dirtree_objects (data);
+  /* Let's advertise another update on the server.
+   */
+  etc_update_server (data, 2);
+  /* Try to update the client - the final, "apply", step should emit a
+   * warning about an error that happened during pruning, but
+   * otherwise the operation should be successful.
+   */
+  etc_update_client (data);
+}
+
+int
+main (int argc,
+      char **argv)
+{
+  setlocale (LC_ALL, "");
+
+  g_test_init (&argc, &argv, NULL);
+  g_test_bug_base ("https://phabricator.endlessm.com/");
+
+  eos_test_add ("/updater/update-cleanup-workaround", NULL, test_update_cleanup_workaround);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
The sysroot cleanup happens after the successful deployment. The
failures are likely the result of the concurrent prunes that happened
earlier.

So tell ostree to skip cleanup and perform it ourselves later, so we
can simply log an error, but still report a success as the "apply"
command is mostly about creating a new deployment, not doing the
cleanup.

https://phabricator.endlessm.com/T16958