### PR TITLE
Add ostree-tests as a build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Build-Depends:
  libsoup2.4-dev,
  libsystemd-dev,
  ostree,
+ ostree-tests (>= 2017.6)
 
 Package: eos-updater
 Section: misc


### PR DESCRIPTION
The tests of eos-updater package depend on
ostree-trivial-httpd, which is provided by
ostree-test package.

This commit adds ostree-test as a build-time
dependency, so that Jenkins build passes all
the tests.

https://phabricator.endlessm.com/T17204