### PR TITLE
fetch: Output slightly more information on a fetch failure

### DIFF
--- a/src/eos-updater-fetch.c
+++ b/src/eos-updater-fetch.c
@@ -208,7 +208,7 @@ content_fetch (GTask *task,
   goto cleanup;
 
  error:
-  g_message ("Fetch returning ERROR");
+  g_message ("Fetch: error: %s", error->message);
   g_task_return_error (task, error);
 
  cleanup:


### PR DESCRIPTION
This information is reported in the eos-updater D-Bus interface, but
it’s useful to have it in the journal too.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T19272