### PR TITLE
src/fetch: Fix a double-free of a GError leading to corrupted messages

### DIFF
--- a/src/eos-updater-fetch.c
+++ b/src/eos-updater-fetch.c
@@ -122,7 +122,7 @@ repo_pull (OstreeRepo *self,
 
       if (!g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
         {
-          g_propagate_error (error, local_error);
+          g_propagate_error (error, g_steal_pointer (&local_error));
           return FALSE;
         }
 

--- a/src/eos-updater-fetch.c
+++ b/src/eos-updater-fetch.c
@@ -209,7 +209,7 @@ content_fetch (GTask *task,
 
  error:
   g_message ("Fetch: error: %s", error->message);
-  g_task_return_error (task, error);
+  g_task_return_error (task, g_steal_pointer (&error));
 
  cleanup:
   if (progress)


### PR DESCRIPTION
The GError here is using g_autoptr(), meaning it gets freed
automatically on exit from the function — but g_propagate_error() takes
ownership of it too, resulting in a double-free and some corrupted
failure messages being reported to the user.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

Reported by @wjt on #updater on Slack.