### PR TITLE
T19388: Fix OSTree bloom hashing (and tests) on ARM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ AC_SUBST([EUU_API_VERSION],euu_api_version)
 AC_SUBST([EUS_API_VERSION],eus_api_version)
 
 # Compiler warnings and --disable-Werror
-AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS])
+AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS],,,[-Wconversion])
 
 # Enable C99
 AX_APPEND_COMPILE_FLAGS([-std=c99],[STD_CFLAGS])

--- a/eos-update-server/eos-update-server.c
+++ b/eos-update-server/eos-update-server.c
@@ -91,7 +91,7 @@ local_port_goption (const gchar *option_name,
                    "Invalid port number %s: %s", value, local_error->message);
       return FALSE;
     }
-  options->local_port = number;
+  options->local_port = (guint16) number;
   return TRUE;
 }
 
@@ -242,7 +242,7 @@ timeout_data_setup_timeout (TimeoutData *data)
 {
   clear_source (&data->timeout_id);
   if (data->timeout_seconds > 0)
-    data->timeout_id = g_timeout_add_seconds (data->timeout_seconds, timeout_cb, data);
+    data->timeout_id = g_timeout_add_seconds ((guint) data->timeout_seconds, timeout_cb, data);
 }
 
 static const gchar *
@@ -269,7 +269,7 @@ timeout_data_maybe_setup_quit_file (TimeoutData *data,
 {
   const gchar *filename = quit_file_name ();
   g_autoptr(EosQuitFile) quit_file = NULL;
-  gint timeout_seconds = 5;
+  guint timeout_seconds = 5;
 
   if (filename == NULL)
     return TRUE;
@@ -284,7 +284,7 @@ timeout_data_maybe_setup_quit_file (TimeoutData *data,
     return FALSE;
 
   data->quit_file = g_steal_pointer (&quit_file);
-  data->quit_file_timeout_seconds = timeout_seconds;
+  data->quit_file_timeout_seconds = (gint) timeout_seconds;
   return TRUE;
 }
 

--- a/eos-update-server/eos-update-server.c
+++ b/eos-update-server/eos-update-server.c
@@ -102,7 +102,6 @@ serve_remote_goption (const gchar *option_name,
                       GError **error)
 {
   Options* options = options_ptr;
-  g_autoptr(GError) local_error = NULL;
   g_autofree gchar *remote = NULL;
   g_autofree gchar *test_refspec = g_strdup_printf ("%s:test", value);
 

--- a/eos-updater-avahi/eos-updater-avahi.c
+++ b/eos-updater-avahi/eos-updater-avahi.c
@@ -91,8 +91,13 @@ get_raw_summary_timestamp_from_metadata (GBytes    *summary,
       return TRUE;
     }
 
+  /* FIXME: Disable diagnostics for GUINT64_TO_BE():
+   * https://bugzilla.gnome.org/show_bug.cgi?id=788384 */
+_Pragma ("GCC diagnostic push")
+_Pragma ("GCC diagnostic ignored \"-Wsign-conversion\"")
   *out_found = TRUE;
   *out_timestamp = GUINT64_FROM_BE (g_variant_get_uint64 (value));
+_Pragma ("GCC diagnostic pop")
   return TRUE;
 }
 
@@ -222,7 +227,7 @@ update_service_file (gboolean       advertise_updates,
 
   if (commit_checksum != NULL)
     {
-      commit_date_time = g_date_time_new_from_unix_utc (commit_timestamp);
+      commit_date_time = g_date_time_new_from_unix_utc ((gint64) commit_timestamp);
       formatted_commit_date_time = g_date_time_format (commit_date_time,
                                                        "%FT%T%:z");
     }

--- a/libeos-update-server/config.c
+++ b/libeos-update-server/config.c
@@ -77,9 +77,9 @@ eus_repo_config_free (EusRepoConfig *config)
 }
 
 static EusRepoConfig *
-eus_repo_config_new_steal (guint  index,
-                           gchar *path,
-                           gchar *remote_name)
+eus_repo_config_new_steal (guint16  index,
+                           gchar   *path,
+                           gchar   *remote_name)
 {
   g_autoptr(EusRepoConfig) config = NULL;
 
@@ -189,7 +189,8 @@ eus_read_config_file (const gchar  *config_file_path,
 
   for (i = 0; i < n_groups; i++)
     {
-      guint64 index;
+      guint64 index64;
+      guint16 index16;
       g_autofree gchar *repository_path = NULL, *remote_name = NULL;
 
       if (!g_str_has_prefix (groups[i], REPOSITORY_GROUP))
@@ -199,7 +200,7 @@ eus_read_config_file (const gchar  *config_file_path,
                                    10,
                                    0,
                                    G_MAXUINT16,
-                                   &index,
+                                   &index64,
                                    &local_error))
         {
           g_set_error (error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE,
@@ -208,6 +209,7 @@ eus_read_config_file (const gchar  *config_file_path,
 
         }
 
+      index16 = (guint16) index64;
       repository_path = euu_config_file_get_string (config, groups[i], PATH_KEY,
                                                     error);
 
@@ -220,7 +222,7 @@ eus_read_config_file (const gchar  *config_file_path,
       if (remote_name == NULL)
         return FALSE;
 
-      if (repository_configs_contains_index (repository_configs, index))
+      if (repository_configs_contains_index (repository_configs, index16))
         {
           g_set_error (error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_INVALID_VALUE,
                        "Duplicate group name: %s", groups[i]);
@@ -228,7 +230,7 @@ eus_read_config_file (const gchar  *config_file_path,
         }
 
       g_ptr_array_add (repository_configs,
-                       eus_repo_config_new_steal (index,
+                       eus_repo_config_new_steal (index16,
                                                   g_steal_pointer (&repository_path),
                                                   g_steal_pointer (&remote_name)));
     }

--- a/libeos-update-server/repo.c
+++ b/libeos-update-server/repo.c
@@ -361,7 +361,7 @@ load_compressed_file_stream (OstreeRepo *repo,
                              const gchar *checksum,
                              GCancellable *cancellable,
                              GInputStream **out_input,
-                             guint64 *out_uncompressed_size,
+                             goffset *out_uncompressed_size,
                              GError **error)
 {
   g_autoptr(GInputStream) bare = NULL;
@@ -527,7 +527,7 @@ filez_stream_read_chunk_cb (GObject *stream_object,
       soup_message_body_append (read_data->msg->response_body,
                                 SOUP_MEMORY_COPY,
                                 read_data->buffer,
-                                bytes_read);
+                                (gsize) bytes_read);
       soup_server_unpause_message (self->server, read_data->msg);
 
       buffer = read_data->buffer;
@@ -556,7 +556,7 @@ handle_objects_filez (EusRepo     *self,
   g_autofree gchar *checksum = NULL;
   g_autoptr(GInputStream) stream = NULL;
   gpointer buffer;
-  guint64 uncompressed_size;
+  goffset uncompressed_size;
   gsize buflen;
   g_autoptr(EosFilezReadData) read_data = NULL;
 
@@ -587,7 +587,7 @@ handle_objects_filez (EusRepo     *self,
                                      SOUP_ENCODING_CHUNKED);
   soup_message_set_status (msg, SOUP_STATUS_OK);
   read_data = filez_read_data_new (self,
-                                   MIN(2 * 1024 * 1024, uncompressed_size + 1),
+                                   MIN (2 * 1024 * 1024, (gsize) (uncompressed_size + 1)),
                                    msg,
                                    requested_path);
   buffer = read_data->buffer;

--- a/libeos-update-server/repo.c
+++ b/libeos-update-server/repo.c
@@ -404,10 +404,11 @@ load_compressed_file_stream (OstreeRepo *repo,
 }
 
 #define EOS_TYPE_FILEZ_READ_DATA eos_filez_read_data_get_type ()
-EOS_DECLARE_REFCOUNTED (EosFilezReadData,
-                        eos_filez_read_data,
-                        EOS,
-                        FILEZ_READ_DATA)
+G_DECLARE_FINAL_TYPE (EosFilezReadData,
+                      eos_filez_read_data,
+                      EOS,
+                      FILEZ_READ_DATA,
+                      GObject)
 
 struct _EosFilezReadData
 {

--- a/libeos-update-server/repo.c
+++ b/libeos-update-server/repo.c
@@ -426,6 +426,8 @@ struct _EosFilezReadData
 static void
 eos_filez_read_data_disconnect_and_clear_msg (EosFilezReadData *read_data)
 {
+  g_return_if_fail (EOS_IS_FILEZ_READ_DATA (read_data));
+
   if (read_data->finished_signal_id > 0)
     g_signal_handler_disconnect (read_data->msg, read_data->finished_signal_id);
   read_data->finished_signal_id = 0;

--- a/libeos-updater-util/avahi-service-file.c
+++ b/libeos-updater-util/avahi-service-file.c
@@ -1144,7 +1144,6 @@ iterate_and_remove_ostree_service_files (GFileEnumerator  *enumerator,
     {
       GFileInfo *file_info;
       GFile* file;
-      g_autoptr(GError) local_error = NULL;
       g_autoptr(GMatchInfo) match_info = NULL;
       g_autofree gchar *matched_repository_index = NULL;
       const gchar *filename;

--- a/libeos-updater-util/avahi-service-file.c
+++ b/libeos-updater-util/avahi-service-file.c
@@ -99,8 +99,8 @@ handle_text_record (GString      *records_str,
    */
   g_assert (total_size != NULL);
   *total_size += 1 + record_size;
-  escaped_key = g_markup_escape_text (key, key_length);
-  escaped_value = g_markup_escape_text (value_string, value_string_length);
+  escaped_key = g_markup_escape_text (key, (gssize) key_length);
+  escaped_value = g_markup_escape_text (value_string, (gssize) value_string_length);
   g_string_append_printf (records_str,
                           "    <txt-record>%s=%s</txt-record>\n",
                           escaped_key,
@@ -133,7 +133,7 @@ handle_binary_record (GString      *records_str,
    */
   g_assert (total_size != NULL);
   *total_size += 1 + record_size;
-  escaped_key = g_markup_escape_text (key, key_length);
+  escaped_key = g_markup_escape_text (key, (gssize) key_length);
   encoded_value = g_base64_encode (value_data, value_data_length);
   escaped_value = g_markup_escape_text (encoded_value, -1);
   g_string_append_printf (records_str,
@@ -765,7 +765,12 @@ get_version_variant (guint8 version)
 static GVariant *
 get_summary_timestamp_variant (guint64 summary_timestamp)
 {
+  /* FIXME: Disable diagnostics for GUINT64_TO_BE():
+   * https://bugzilla.gnome.org/show_bug.cgi?id=788384 */
+_Pragma ("GCC diagnostic push")
+_Pragma ("GCC diagnostic ignored \"-Wsign-conversion\"")
   GVariant *variant = g_variant_new ("t", GUINT64_TO_BE (summary_timestamp));
+_Pragma ("GCC diagnostic pop")
 
   g_assert (g_variant_is_of_type (variant,
                                   EOS_OSTREE_AVAHI_V1_SUMMARY_TIMESTAMP_VARIANT_TYPE));

--- a/libeos-updater-util/config.c
+++ b/libeos-updater-util/config.c
@@ -321,7 +321,7 @@ euu_config_file_ensure_loaded (EuuConfigFile  *self,
   if (key_file == NULL)
     {
       key_file = g_key_file_new ();
-      g_ptr_array_insert (self->key_files, idx, key_file);
+      g_ptr_array_insert (self->key_files, (gint) idx, key_file);
       g_key_file_load_from_file (key_file, path, G_KEY_FILE_NONE, &local_error);
     }
 
@@ -443,7 +443,7 @@ euu_config_file_get_uint (EuuConfigFile  *self,
       return 0;
     }
 
-  return val;
+  return (guint) val;
 }
 
 /**

--- a/libeos-updater-util/extensions.c
+++ b/libeos-updater-util/extensions.c
@@ -443,7 +443,6 @@ eos_extensions_new_from_repo (OstreeRepo *repo,
                               GError **error)
 {
   g_autoptr(EosExtensions) extensions = NULL;
-  g_autoptr(GPtrArray) refs = NULL;
 
   g_return_val_if_fail (OSTREE_IS_REPO (repo), NULL);
   g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable),

--- a/libeos-updater-util/extensions.h
+++ b/libeos-updater-util/extensions.h
@@ -33,10 +33,11 @@
 G_BEGIN_DECLS
 
 #define EOS_TYPE_REF eos_ref_get_type ()
-EOS_DECLARE_REFCOUNTED (EosRef,
-                        eos_ref,
-                        EOS,
-                        REF)
+G_DECLARE_FINAL_TYPE (EosRef,
+                      eos_ref,
+                      EOS,
+                      REF,
+                      GObject)
 
 struct _EosRef
 {
@@ -64,10 +65,11 @@ gboolean eos_ref_save (EosRef *ref,
                        GError **error);
 
 #define EOS_TYPE_EXTENSIONS eos_extensions_get_type ()
-EOS_DECLARE_REFCOUNTED (EosExtensions,
-                        eos_extensions,
-                        EOS,
-                        EXTENSIONS)
+G_DECLARE_FINAL_TYPE (EosExtensions,
+                      eos_extensions,
+                      EOS,
+                      EXTENSIONS,
+                      GObject)
 
 struct _EosExtensions
 {

--- a/libeos-updater-util/ostree-bloom.c
+++ b/libeos-updater-util/ostree-bloom.c
@@ -248,7 +248,7 @@ ostree_bloom_set_bit (OstreeBloom *bloom,
 {
   g_assert (bloom->is_mutable);
   g_assert (idx / 8 < bloom->n_bytes);
-  bloom->mutable_bytes[idx / 8] |= (1 << (idx % 8));
+  bloom->mutable_bytes[idx / 8] |= (guint8) (1 << (idx % 8));
 }
 
 /**

--- a/libeos-updater-util/ostree-bloom.c
+++ b/libeos-updater-util/ostree-bloom.c
@@ -275,11 +275,11 @@ ostree_bloom_maybe_contains (OstreeBloom   *bloom,
 
   for (i = 0; i < bloom->k; i++)
     {
-      gsize idx;
+      guint64 idx;
 
       idx = bloom->hash_func (element, i);
 
-      if (!ostree_bloom_get_bit (bloom, idx % (bloom->n_bytes * 8)))
+      if (!ostree_bloom_get_bit (bloom, (gsize) (idx % (bloom->n_bytes * 8))))
         return FALSE;  /* definitely not in the set */
     }
 
@@ -339,8 +339,8 @@ ostree_bloom_add_element (OstreeBloom   *bloom,
 
   for (i = 0; i < bloom->k; i++)
     {
-      gsize idx = bloom->hash_func (element, i);
-      ostree_bloom_set_bit (bloom, idx % (bloom->n_bytes * 8));
+      guint64 idx = bloom->hash_func (element, i);
+      ostree_bloom_set_bit (bloom, (gsize) (idx % (bloom->n_bytes * 8)));
     }
 }
 

--- a/libeos-updater-util/ostree-bloom.c
+++ b/libeos-updater-util/ostree-bloom.c
@@ -78,7 +78,7 @@
 struct _OstreeBloom
 {
   guint ref_count;
-  gsize n_bytes;
+  gsize n_bytes;  /* 0 < n_bytes <= G_MAXSIZE / 8 */
   gboolean is_mutable;  /* determines which of [im]mutable_bytes is accessed */
   union
     {
@@ -119,6 +119,7 @@ ostree_bloom_new (gsize               n_bytes,
   g_autoptr(OstreeBloom) bloom = NULL;
 
   g_return_val_if_fail (n_bytes > 0, NULL);
+  g_return_val_if_fail (n_bytes <= G_MAXSIZE / 8, NULL);
   g_return_val_if_fail (k > 0, NULL);
   g_return_val_if_fail (hash_func != NULL, NULL);
 
@@ -161,6 +162,7 @@ ostree_bloom_new_from_bytes (GBytes              *bytes,
 
   g_return_val_if_fail (bytes != NULL, NULL);
   g_return_val_if_fail (g_bytes_get_size (bytes) > 0, NULL);
+  g_return_val_if_fail (g_bytes_get_size (bytes) <= G_MAXSIZE / 8, NULL);
   g_return_val_if_fail (k > 0, NULL);
   g_return_val_if_fail (hash_func != NULL, NULL);
 

--- a/libeos-updater-util/refcounted.h
+++ b/libeos-updater-util/refcounted.h
@@ -26,9 +26,6 @@
 
 G_BEGIN_DECLS
 
-#define EOS_DECLARE_REFCOUNTED(ModuleObjName, module_obj_name, MODULE, OBJ_NAME) \
-  G_DECLARE_FINAL_TYPE (ModuleObjName, module_obj_name, MODULE, OBJ_NAME, GObject)
-
 #define EOS_DEFINE_REFCOUNTED(TYPE_NAME, TypeName, type_name, dispose_impl_func, finalize_impl_func) \
   G_DEFINE_TYPE (TypeName, type_name, G_TYPE_OBJECT)                    \
                                                                         \

--- a/libeos-updater-util/tests/avahi-service-file.c
+++ b/libeos-updater-util/tests/avahi-service-file.c
@@ -583,7 +583,11 @@ test_avahi_ostree_options_check (void)
     {
       g_autoptr(GError) error = NULL;
       const TestOptions *test_data = &test_options[idx];
-      gboolean result = eos_ostree_avahi_service_file_check_options (avahi_ostree_test_options_to_variant (&test_data->options), &error);
+      gboolean result;
+
+      g_test_message ("Test %" G_GSIZE_FORMAT, idx);
+
+      result = eos_ostree_avahi_service_file_check_options (avahi_ostree_test_options_to_variant (&test_data->options), &error);
 
       if (test_data->success)
         {
@@ -706,6 +710,8 @@ test_avahi_ostree_service_file_generate (Fixture       *fixture,
       g_autoptr(GDateTime) timestamp = g_date_time_new (utc_tz,
                                                         test_data->summary_timestamp_year,
                                                         1, 1, 0, 0, 0);
+
+      g_test_message ("Test %" G_GSIZE_FORMAT, idx);
 
       g_assert_nonnull (timestamp);
       result = eos_ostree_avahi_service_file_generate (fixture->tmp_dir,

--- a/libeos-updater-util/tests/avahi-service-file.c
+++ b/libeos-updater-util/tests/avahi-service-file.c
@@ -785,9 +785,10 @@ test_avahi_ostree_cleanup_directory (Fixture       *fixture,
   g_autoptr(GPtrArray) invalid_files = g_ptr_array_new_with_free_func (g_free);
   g_autoptr(GError) error = NULL;
 
+  g_assert (max <= 10);  /* for the (char) conversion below */
   for (idx = 0; idx < max; ++idx)
     {
-      const gchar repo_index[] = { '0' + idx, '\0' };
+      const gchar repo_index[] = { (gchar) ('0' + idx), '\0' };
       g_autofree gchar *filename = ostree_service_file (repo_index);
 
       g_ptr_array_add (valid_files, g_build_filename (fixture->tmp_dir,

--- a/libeos-updater-util/tests/util.c
+++ b/libeos-updater-util/tests/util.c
@@ -128,7 +128,7 @@ test_util_strtonum_usual (void)
                                            data->max,
                                            &value64,
                                            &error);
-            value = value64;
+            value = (gint) value64;
             g_assert_cmpint (value, ==, value64);
             break;
           }
@@ -136,14 +136,16 @@ test_util_strtonum_usual (void)
         case UNSIGNED:
           {
             guint64 value64 = 0;
+            g_assert_cmpint (data->min, >=, 0);
+            g_assert_cmpint (data->max, >=, 0);
             result = eos_string_to_unsigned (data->str,
                                              data->base,
-                                             data->min,
-                                             data->max,
+                                             (guint64) data->min,
+                                             (guint64) data->max,
                                              &value64,
                                              &error);
-            value = value64;
-            g_assert_cmpint (value, ==, value64);
+            value = (gint) value64;
+            g_assert_cmpuint ((guint64) value, ==, value64);
             break;
           }
 
@@ -219,7 +221,7 @@ test_util_strtonum_pathological (void)
                                          &uvalue,
                                          &error));
   g_assert_no_error (error);
-  g_assert_cmpint (uvalue, ==, G_MAXUINT64);
+  g_assert_cmpuint (uvalue, ==, G_MAXUINT64);
 
   g_assert_true (eos_string_to_signed (max_int64,
                                        10,

--- a/libeos-updater-util/util.c
+++ b/libeos-updater-util/util.c
@@ -373,7 +373,7 @@ struct _EosQuitFile
   GObject parent_instance;
 
   GFileMonitor *monitor;
-  guint signal_id;
+  gulong signal_id;
   guint timeout_seconds;
   guint timeout_id;
   EosQuitFileCheckCallback callback;
@@ -395,7 +395,7 @@ quit_clear_user_data (EosQuitFile *quit_file)
 static void
 quit_disconnect_monitor (EosQuitFile *quit_file)
 {
-  guint id = quit_file->signal_id;
+  gulong id = quit_file->signal_id;
 
   quit_file->signal_id = 0;
   if (id > 0)

--- a/libeos-updater-util/util.c
+++ b/libeos-updater-util/util.c
@@ -180,7 +180,6 @@ eos_updater_save_or_delete  (GBytes *contents,
                              GError **error)
 {
   g_autoptr(GFile) target = g_file_get_child (dir, filename);
-  g_autoptr(GFile) target_parent = g_file_get_parent (target);
 
   if (contents == NULL)
     return delete_files_and_empty_parents (dir, target, cancellable, error);

--- a/libeos-updater-util/util.c
+++ b/libeos-updater-util/util.c
@@ -385,7 +385,8 @@ static void
 quit_clear_user_data (EosQuitFile *quit_file)
 {
   gpointer user_data = g_steal_pointer (&quit_file->user_data);
-  GDestroyNotify notify = g_steal_pointer (&quit_file->notify);
+  GDestroyNotify notify = quit_file->notify;
+  quit_file->notify = NULL;
 
   if (notify != NULL)
     notify (user_data);

--- a/libeos-updater-util/util.h
+++ b/libeos-updater-util/util.h
@@ -84,7 +84,7 @@ gboolean eos_updater_read_file_to_bytes (GFile *file,
                                          GError **error);
 
 #define EOS_TYPE_QUIT_FILE eos_quit_file_get_type ()
-EOS_DECLARE_REFCOUNTED (EosQuitFile, eos_quit_file, EOS, QUIT_FILE)
+G_DECLARE_FINAL_TYPE (EosQuitFile, eos_quit_file, EOS, QUIT_FILE, GObject)
 
 typedef enum
 {

--- a/src/eos-autoupdater.c
+++ b/src/eos-autoupdater.c
@@ -58,7 +58,7 @@ typedef enum _UpdateStep {
 #define UPDATE_STEP_FIRST UPDATE_STEP_NONE
 #define UPDATE_STEP_LAST UPDATE_STEP_APPLY
 
-#define SEC_PER_DAY (3600l * 24)
+#define SEC_PER_DAY (3600ul * 24)
 
 /* This file is touched whenever the updater starts */
 static const char *UPDATE_STAMP_DIR = LOCALSTATEDIR "/lib/eos-updater";

--- a/src/eos-autoupdater.c
+++ b/src/eos-autoupdater.c
@@ -121,9 +121,11 @@ log_with_msgid (const gchar *msgid,
   g_autofree gchar *message = NULL;
   /* Apparently the version of GCC in Endless ignores the
    * G_GNUC_PRINTF annotation that has a zero as the second parameter,
-   * so it suggests to use this attribute. */
+   * so it suggests to use this attribute. Similarly, so does Clang 4. */
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wsuggest-attribute=format"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
   gint message_length = g_vasprintf (&message, format, args);
 #pragma GCC diagnostic pop
   const GLogField fields[] = {

--- a/src/eos-autoupdater.c
+++ b/src/eos-autoupdater.c
@@ -47,7 +47,7 @@
  * file to indicate which is the final automatic step before the user
  * needs to intervene.
  */
-typedef enum _UpdateStep {
+typedef enum {
   UPDATE_STEP_NONE = 0,
   UPDATE_STEP_POLL = 1,
   UPDATE_STEP_FETCH = 2,

--- a/src/eos-autoupdater.c
+++ b/src/eos-autoupdater.c
@@ -282,7 +282,7 @@ update_step_callback (GObject *source_object, GAsyncResult *res,
                       gpointer step_data)
 {
   EosUpdater *proxy = (EosUpdater *) source_object;
-  UpdateStep step = GPOINTER_TO_INT (step_data);
+  UpdateStep step = (UpdateStep) GPOINTER_TO_INT (step_data);
   GError *error = NULL;
 
   switch (step) {

--- a/src/eos-prepare-usb-update.c
+++ b/src/eos-prepare-usb-update.c
@@ -107,6 +107,8 @@ ensure_coherency (OstreeRepo *repo,
   g_auto(GStrv) refs = NULL;
   g_autofree gchar *ref_commit_id = NULL;
 
+  g_return_val_if_fail (EOS_IS_REFSPEC (refspec), FALSE);
+
   remotes = ostree_repo_remote_list (repo, NULL);
   if (!strv_contains (remotes, refspec->remote))
     {
@@ -329,7 +331,9 @@ pull_ready (GObject *object,
             GAsyncResult *res,
             gpointer pull_data_ptr)
 {
-  g_autoptr(EosPullData) pull_data = EOS_PULL_DATA (pull_data_ptr);
+  g_autoptr(EosPullData) pull_data = pull_data_ptr;
+
+  g_return_if_fail (EOS_IS_PULL_DATA (pull_data));
 
   g_task_propagate_boolean (G_TASK (res), &pull_data->error);
   g_main_loop_quit (pull_data->loop);

--- a/src/eos-prepare-usb-update.c
+++ b/src/eos-prepare-usb-update.c
@@ -346,7 +346,6 @@ run_pull_task_func (GTask *task,
   g_autoptr(GError) local_error = NULL;
   const gchar *refs[] = { pull_data->refspec->ref };
   const gchar *override_commit_ids[] = { pull_data->commit_id };
-  g_autoptr(ScopedMainContext) context = scoped_main_context_new ();
   OstreeRepoPullFlags pull_flags = OSTREE_REPO_PULL_FLAGS_MIRROR;
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
@@ -412,7 +411,6 @@ do_pull (OstreeRepo *source_repo,
   g_autoptr(ScopedMainContext) context = scoped_main_context_new ();
   g_autoptr(GMainLoop) loop = NULL;
   g_autofree gchar *source_uri = NULL;
-  g_autoptr(GError) local_error = NULL;
   g_autoptr(EosPullData) pull_data = NULL;
 
   source_uri = g_file_get_uri (ostree_repo_get_path (source_repo));

--- a/src/eos-prepare-usb-update.c
+++ b/src/eos-prepare-usb-update.c
@@ -49,10 +49,11 @@ repo_get_raw_path (OstreeRepo *repo)
 }
 
 #define EOS_TYPE_REFSPEC eos_refspec_get_type ()
-EOS_DECLARE_REFCOUNTED (EosRefspec,
-                        eos_refspec,
-                        EOS,
-                        REFSPEC)
+G_DECLARE_FINAL_TYPE (EosRefspec,
+                      eos_refspec,
+                      EOS,
+                      REFSPEC,
+                      GObject)
 
 struct _EosRefspec
 {
@@ -265,10 +266,11 @@ scoped_main_context_free (ScopedMainContext *context)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (ScopedMainContext, scoped_main_context_free)
 
 #define EOS_TYPE_PULL_DATA eos_pull_data_get_type ()
-EOS_DECLARE_REFCOUNTED (EosPullData,
-                        eos_pull_data,
-                        EOS,
-                        PULL_DATA)
+G_DECLARE_FINAL_TYPE (EosPullData,
+                      eos_pull_data,
+                      EOS,
+                      PULL_DATA,
+                      GObject)
 
 struct _EosPullData
 {

--- a/src/eos-updater-avahi-emulator.c
+++ b/src/eos-updater-avahi-emulator.c
@@ -100,7 +100,7 @@ fill_service_from_key_file (EosAvahiService *service,
                    "port number %d is invalid", port);
       return FALSE;
     }
-  service->port = port;
+  service->port = (guint16) port;
 
   service->txt = g_key_file_get_string_list (keyfile,
                                              "service",

--- a/src/eos-updater-avahi.c
+++ b/src/eos-updater-avahi.c
@@ -340,8 +340,10 @@ address_to_string (const AvahiAddress *address,
   switch (address->proto)
     {
     case AVAHI_PROTO_INET6:
-      if (IN6_IS_ADDR_LINKLOCAL (address->data.data) ||
-          IN6_IS_ADDR_LOOPBACK (address->data.data))
+      /* Cast to void* to avoid a -Wcast-align warning. AvahiIPv6Address.address
+       * should be guaranteed to be 16-byte aligned. */
+      if (IN6_IS_ADDR_LINKLOCAL ((void *) address->data.ipv6.address) ||
+          IN6_IS_ADDR_LOOPBACK ((void *) address->data.ipv6.address))
         return g_strdup_printf ("%s%%%d", address_string, interface);
       /* else fall through */
     case AVAHI_PROTO_INET:

--- a/src/eos-updater-avahi.h
+++ b/src/eos-updater-avahi.h
@@ -31,7 +31,7 @@
 G_BEGIN_DECLS
 
 #define EOS_TYPE_AVAHI_SERVICE eos_avahi_service_get_type ()
-EOS_DECLARE_REFCOUNTED (EosAvahiService, eos_avahi_service, EOS, AVAHI_SERVICE)
+G_DECLARE_FINAL_TYPE (EosAvahiService, eos_avahi_service, EOS, AVAHI_SERVICE, GObject)
 
 struct _EosAvahiService
 {
@@ -45,7 +45,7 @@ struct _EosAvahiService
 };
 
 #define EOS_TYPE_AVAHI_DISCOVERER eos_avahi_discoverer_get_type ()
-EOS_DECLARE_REFCOUNTED (EosAvahiDiscoverer, eos_avahi_discoverer, EOS, AVAHI_DISCOVERER)
+G_DECLARE_FINAL_TYPE (EosAvahiDiscoverer, eos_avahi_discoverer, EOS, AVAHI_DISCOVERER, GObject)
 
 typedef void
 (*EosAvahiDiscovererCallback) (EosAvahiDiscoverer *discoverer,

--- a/src/eos-updater-fetch.c
+++ b/src/eos-updater-fetch.c
@@ -77,10 +77,14 @@ update_progress (OstreeAsyncProgress *progress,
   guint64 bytes = ostree_async_progress_get_uint64 (progress,
                                                     "bytes-transferred");
 
+  /* FIXME: Cap to the limit of eos_updater_set_downloaded_bytes(). */
+  if (bytes > G_MAXINT64)
+    bytes = G_MAXINT64;
+
   /* Idle could have been scheduled after the fetch completed, make sure we
    * don't override the downloaded bytes */
   if (eos_updater_get_state (updater) == EOS_UPDATER_STATE_FETCHING)
-    eos_updater_set_downloaded_bytes (updater, bytes);
+    eos_updater_set_downloaded_bytes (updater, (gint64) bytes);
 }
 
 static GVariant *
@@ -185,7 +189,7 @@ content_fetch (GTask *task,
 
   if (data->overridden_urls != NULL && data->overridden_urls[0] != NULL)
     {
-      guint idx = g_random_int_range (0, g_strv_length (data->overridden_urls));
+      guint idx = (guint) g_random_int_range (0, (gint32) g_strv_length (data->overridden_urls));
 
       url_override = data->overridden_urls[idx];
     }

--- a/src/eos-updater-object.c
+++ b/src/eos-updater-object.c
@@ -62,7 +62,7 @@ eos_updater_set_error (EosUpdater *updater,
              error_name, error->code, error->message);
 
   eos_updater_set_error_name (updater, error_name);
-  eos_updater_set_error_code (updater, error->code);
+  eos_updater_set_error_code (updater, (guint) error->code);
   eos_updater_set_error_message (updater, error->message);
   eos_updater_set_state_changed (updater, EOS_UPDATER_STATE_ERROR);
 }

--- a/src/eos-updater-poll-common.c
+++ b/src/eos-updater-poll-common.c
@@ -195,7 +195,7 @@ eos_update_info_get_commit_timestamp (EosUpdateInfo *info)
 {
   g_return_val_if_fail (EOS_IS_UPDATE_INFO (info), NULL);
 
-  return g_date_time_new_from_unix_utc (ostree_commit_get_timestamp (info->commit));
+  return g_date_time_new_from_unix_utc ((gint64) ostree_commit_get_timestamp (info->commit));
 }
 
 static void
@@ -465,7 +465,7 @@ bsearch_variant (GVariant *array,
                  gsize *out_pos)
 {
   gsize imax, imin;
-  gsize imid = -1;
+  gsize imid = (gsize) -1;
   gsize n;
 
   n = g_variant_n_children (array);

--- a/src/eos-updater-poll-common.h
+++ b/src/eos-updater-poll-common.h
@@ -41,10 +41,11 @@ is_checksum_an_update (OstreeRepo *repo,
                        GError **error);
 
 #define EOS_TYPE_METRICS_INFO eos_metrics_info_get_type ()
-EOS_DECLARE_REFCOUNTED (EosMetricsInfo,
-                        eos_metrics_info,
-                        EOS,
-                        METRICS_INFO)
+G_DECLARE_FINAL_TYPE (EosMetricsInfo,
+                      eos_metrics_info,
+                      EOS,
+                      METRICS_INFO,
+                      GObject)
 
 struct _EosMetricsInfo
 {
@@ -59,10 +60,11 @@ EosMetricsInfo *
 eos_metrics_info_new (const gchar *booted_ref);
 
 #define EOS_TYPE_UPDATE_INFO eos_update_info_get_type ()
-EOS_DECLARE_REFCOUNTED (EosUpdateInfo,
-                        eos_update_info,
-                        EOS,
-                        UPDATE_INFO)
+G_DECLARE_FINAL_TYPE (EosUpdateInfo,
+                      eos_update_info,
+                      EOS,
+                      UPDATE_INFO,
+                      GObject)
 
 struct _EosUpdateInfo
 {
@@ -88,10 +90,11 @@ GDateTime *
 eos_update_info_get_commit_timestamp (EosUpdateInfo *info);
 
 #define EOS_TYPE_METADATA_FETCH_DATA eos_metadata_fetch_data_get_type ()
-EOS_DECLARE_REFCOUNTED (EosMetadataFetchData,
-                        eos_metadata_fetch_data,
-                        EOS,
-                        METADATA_FETCH_DATA)
+G_DECLARE_FINAL_TYPE (EosMetadataFetchData,
+                      eos_metadata_fetch_data,
+                      EOS,
+                      METADATA_FETCH_DATA,
+                      GObject)
 
 struct _EosMetadataFetchData
 {

--- a/src/eos-updater-poll-lan.c
+++ b/src/eos-updater-poll-lan.c
@@ -188,10 +188,11 @@ get_unique_txt_record (gchar **txt_records,
 }
 
 #define EOS_TYPE_SERVICE_WITH_METADATA eos_service_with_metadata_get_type ()
-EOS_DECLARE_REFCOUNTED (EosServiceWithMetadata,
-                        eos_service_with_metadata,
-                        EOS,
-                        SERVICE_WITH_METADATA)
+G_DECLARE_FINAL_TYPE (EosServiceWithMetadata,
+                      eos_service_with_metadata,
+                      EOS,
+                      SERVICE_WITH_METADATA,
+                      GObject)
 
 struct _EosServiceWithMetadata
 {

--- a/src/eos-updater-poll-lan.c
+++ b/src/eos-updater-poll-lan.c
@@ -265,6 +265,8 @@ time_check (LanData *lan_data,
 {
   g_autoptr(GDateTime) txt_utc = NULL;
 
+  g_return_val_if_fail (EOS_IS_SERVICE_WITH_METADATA (swm), FALSE);
+
   if (check_dl_time (lan_data, dl_time, &txt_utc))
     {
       swm->declared_head_commit_timestamp = g_steal_pointer (&txt_utc);

--- a/src/eos-updater-poll-lan.c
+++ b/src/eos-updater-poll-lan.c
@@ -327,7 +327,7 @@ parse_txt_version (const gchar *txt_version)
   if (!eos_string_to_unsigned (txt_version, 10, 1, G_MAXUINT, &v, NULL))
     return 0;
 
-  return v;
+  return (guint) v;
 }
 
 static gboolean
@@ -483,7 +483,7 @@ get_update_info_from_swms (LanData *lan_data,
 
           declared_str = g_date_time_format (swm->declared_head_commit_timestamp,
                                              "%FT%T%:z");
-          actual_time = g_date_time_new_from_unix_utc (timestamp);
+          actual_time = g_date_time_new_from_unix_utc ((gint64) timestamp);
           actual_str = g_date_time_format (actual_time, "%FT%T%:z");
 
           g_message ("The commit timestamp (%s) from %s does not match the "

--- a/src/eos-updater.c
+++ b/src/eos-updater.c
@@ -266,9 +266,10 @@ purge_old_config_file (const gchar *etc_path,
       return;
     }
 
-  /* Work out its checksum. */
+  /* Work out its checksum. The @etc_length cast might truncate the file,
+   * but that would only result in it being kept slightly-unnecessarily. */
   checksum = g_checksum_new (G_CHECKSUM_MD5);
-  g_checksum_update (checksum, etc_contents, etc_length);
+  g_checksum_update (checksum, etc_contents, (gssize) etc_length);
 
   /* If the files are the same, delete the @etc_path. */
   if (g_strcmp0 (g_checksum_get_string (checksum), checksum_to_delete) == 0)

--- a/src/eos-updater.c
+++ b/src/eos-updater.c
@@ -81,9 +81,6 @@ on_bus_acquired (GDBusConnection *connection,
   EosUpdater *updater = NULL;
   LocalData *local_data = user_data;
   GError *error = NULL;
-
-  g_autofree gchar *src = NULL;
-  g_autofree gchar *ref = NULL;
   g_autofree gchar *sum = NULL;
 
   g_message ("Acquired a message bus connection");

--- a/tests/eos-test-utils.c
+++ b/tests/eos-test-utils.c
@@ -214,7 +214,12 @@ get_sha256sum_from_strv (const gchar * const *strv)
   const gchar * const *iter;
 
   for (iter = strv; *iter != NULL; ++iter)
-    g_checksum_update (sum, (const guchar *)*iter, strlen (*iter));
+    {
+      const gchar *value = *iter;
+      gsize value_len = strlen (value);
+      g_assert (value_len <= G_MAXSSIZE);
+      g_checksum_update (sum, (const guchar *) value, (gssize) value_len);
+    }
 
   return g_strdup (g_checksum_get_string (sum));
 }
@@ -369,7 +374,7 @@ generate_big_file_for_delta_update (GFile *all_commits_dir,
   g_assert_cmpint (commit_number, <=, max_commit_number);
   data = g_malloc (byte_count);
   memset (data, 'x', byte_count);
-  data[byte_count / 2] = 'a' + commit_number;
+  data[byte_count / 2] = (gchar) ('a' + commit_number);
   big_file = g_file_get_child (all_commits_dir, "bigfile");
   contents = g_bytes_new_take (g_steal_pointer (&data), byte_count);
 
@@ -1905,7 +1910,7 @@ get_head_commit_timestamp (GFile *sysroot_path,
   if (!ostree_repo_load_commit (repo, checksum, &commit, NULL, error))
     return FALSE;
 
-  *out_timestamp = g_date_time_new_from_unix_utc (ostree_commit_get_timestamp (commit));
+  *out_timestamp = g_date_time_new_from_unix_utc ((gint64) ostree_commit_get_timestamp (commit));
 
   return TRUE;
 }
@@ -2315,13 +2320,15 @@ EOS_DEFINE_REFCOUNTED (EOS_TEST_AUTOUPDATER,
 
 static GKeyFile *
 get_autoupdater_config (UpdateStep step,
-                        gint update_interval_in_days,
+                        guint update_interval_in_days,
                         gboolean update_on_mobile)
 {
   g_autoptr(GKeyFile) config = g_key_file_new ();
 
+  g_assert (update_interval_in_days <= G_MAXINT);
+
   g_key_file_set_integer (config, "Automatic Updates", "LastAutomaticStep", step);
-  g_key_file_set_integer (config, "Automatic Updates", "IntervalDays", update_interval_in_days);
+  g_key_file_set_integer (config, "Automatic Updates", "IntervalDays", (gint) update_interval_in_days);
   g_key_file_set_integer (config, "Automatic Updates", "RandomizedDelayDays", 0);
   g_key_file_set_boolean (config, "Automatic Updates", "UpdateOnMobile", update_on_mobile);
 

--- a/tests/eos-test-utils.c
+++ b/tests/eos-test-utils.c
@@ -1255,9 +1255,14 @@ get_updater_config (DownloadSource *order,
                     GVariant **source_variants,
                     gsize n_sources)
 {
-  g_autoptr(GKeyFile) config = g_key_file_new ();
+  g_autoptr(GKeyFile) config = NULL;
   gsize idx;
-  g_autoptr(GPtrArray) source_strs = g_ptr_array_sized_new (n_sources);
+  g_autoptr(GPtrArray) source_strs = NULL;
+
+  g_return_val_if_fail (n_sources <= G_MAXUINT, NULL);
+
+  config = g_key_file_new ();
+  source_strs = g_ptr_array_sized_new ((guint) n_sources);
 
   for (idx = 0; idx < n_sources; ++idx)
     g_ptr_array_add (source_strs, (gpointer)download_source_to_string (order[idx]));

--- a/tests/eos-test-utils.c
+++ b/tests/eos-test-utils.c
@@ -2489,3 +2489,20 @@ eos_test_autoupdater_new (GFile *autoupdater_root,
   autoupdater->cmd = g_steal_pointer (&cmd);
   return g_steal_pointer (&autoupdater);
 }
+
+/**
+ * eos_test_has_ostree_boot_id:
+ *
+ * Check whether the `/proc/sys/kernel/random/boot_id` file is available, which
+ * is needed by #OstreeRepo.
+ *
+ * Returns: %TRUE if it exists, %FALSE otherwise
+ */
+gboolean
+eos_test_has_ostree_boot_id (void)
+{
+  g_autoptr(GFile) boot_id_file = NULL;
+
+  boot_id_file = g_file_new_for_path ("/proc/sys/kernel/random/boot_id");
+  return g_file_query_exists (boot_id_file, NULL);
+}

--- a/tests/eos-test-utils.h
+++ b/tests/eos-test-utils.h
@@ -54,10 +54,11 @@ extern const gchar *const default_ostree_path;
 extern const gchar *const default_remote_name;
 
 #define EOS_TEST_TYPE_DEVICE eos_test_device_get_type ()
-EOS_DECLARE_REFCOUNTED (EosTestDevice,
-                        eos_test_device,
-                        EOS_TEST,
-                        DEVICE)
+G_DECLARE_FINAL_TYPE (EosTestDevice,
+                      eos_test_device,
+                      EOS_TEST,
+                      DEVICE,
+                      GObject)
 
 struct _EosTestDevice
 {
@@ -73,10 +74,11 @@ EosTestDevice *eos_test_device_new (const gchar *vendor,
                                     const gchar *ref);
 
 #define EOS_TEST_TYPE_SUBSERVER eos_test_subserver_get_type ()
-EOS_DECLARE_REFCOUNTED (EosTestSubserver,
-                        eos_test_subserver,
-                        EOS_TEST,
-                        SUBSERVER)
+G_DECLARE_FINAL_TYPE (EosTestSubserver,
+                      eos_test_subserver,
+                      EOS_TEST,
+                      SUBSERVER,
+                      GObject)
 
 struct _EosTestSubserver
 {
@@ -109,10 +111,11 @@ gboolean eos_test_subserver_update (EosTestSubserver *subserver,
                                     GError **error);
 
 #define EOS_TEST_TYPE_SERVER eos_test_server_get_type ()
-EOS_DECLARE_REFCOUNTED (EosTestServer,
-                        eos_test_server,
-                        EOS_TEST,
-                        SERVER)
+G_DECLARE_FINAL_TYPE (EosTestServer,
+                      eos_test_server,
+                      EOS_TEST,
+                      SERVER,
+                      GObject)
 
 struct _EosTestServer
 {
@@ -138,10 +141,11 @@ EosTestServer *eos_test_server_new_quick (GFile *server_root,
                                           GError **error);
 
 #define EOS_TEST_TYPE_CLIENT eos_test_client_get_type ()
-EOS_DECLARE_REFCOUNTED (EosTestClient,
-                        eos_test_client,
-                        EOS_TEST,
-                        CLIENT)
+G_DECLARE_FINAL_TYPE (EosTestClient,
+                      eos_test_client,
+                      EOS_TEST,
+                      CLIENT,
+                      GObject)
 
 struct _EosTestClient
 {
@@ -234,10 +238,11 @@ typedef enum _UpdateStep {
 } UpdateStep;
 
 #define EOS_TEST_TYPE_AUTOUPDATER eos_test_autoupdater_get_type ()
-EOS_DECLARE_REFCOUNTED (EosTestAutoupdater,
-                        eos_test_autoupdater,
-                        EOS_TEST,
-                        AUTOUPDATER)
+G_DECLARE_FINAL_TYPE (EosTestAutoupdater,
+                      eos_test_autoupdater,
+                      EOS_TEST,
+                      AUTOUPDATER,
+                      GObject)
 
 struct _EosTestAutoupdater
 {

--- a/tests/eos-test-utils.h
+++ b/tests/eos-test-utils.h
@@ -258,4 +258,6 @@ EosTestAutoupdater *eos_test_autoupdater_new (GFile *autoupdater_root,
                                               gboolean update_on_mobile,
                                               GError **error);
 
+gboolean eos_test_has_ostree_boot_id (void);
+
 G_END_DECLS

--- a/tests/misc-utils.c
+++ b/tests/misc-utils.c
@@ -249,7 +249,7 @@ get_timestamp_from_when_tests_started_running (void)
 }
 
 GDateTime *
-days_ago (gint days)
+days_ago (guint days)
 {
   g_autoptr(GDateTime) now = get_timestamp_from_when_tests_started_running ();
   g_autoptr(GDateTime) now_fixed = g_date_time_new_utc (g_date_time_get_year (now),
@@ -258,8 +258,9 @@ days_ago (gint days)
                                                         12,
                                                         0,
                                                         0);
+  g_assert (days <= G_MAXINT);
 
-  return g_date_time_add_days (now_fixed, -days);
+  return g_date_time_add_days (now_fixed, -((gint) days));
 }
 
 gboolean
@@ -282,8 +283,9 @@ input_stream_to_string (GInputStream *stream,
       read_data = g_bytes_get_data (bytes, &read_len);
       if (read_len == 0)
         break;
+      g_assert (read_len <= G_MAXSSIZE);
 
-      g_string_append_len (str, read_data, read_len);
+      g_string_append_len (str, read_data, (gssize) read_len);
     }
 
   *out_str = g_string_free (g_steal_pointer (&str), FALSE);
@@ -332,6 +334,6 @@ read_port_file (GFile *port_file,
       return FALSE;
     }
 
-  *out_port = number;
+  *out_port = (guint16) number;
   return TRUE;
 }

--- a/tests/misc-utils.h
+++ b/tests/misc-utils.h
@@ -64,7 +64,7 @@ gboolean save_key_file (GFile *file,
 			GKeyFile *keyfile,
 			GError **error);
 
-GDateTime *days_ago (gint days);
+GDateTime *days_ago (guint days);
 
 gboolean input_stream_to_string (GInputStream *stream,
 				 gchar **out_str,

--- a/tests/spawn-utils.h
+++ b/tests/spawn-utils.h
@@ -136,7 +136,9 @@ cmd_arg_array_new (void)
 static inline CmdArg *
 cmd_arg_array_raw (GArray *cmd_arg_array)
 {
-  return (CmdArg *) cmd_arg_array->data;
+  /* void* cast needed to avoid -Wcast-align. The allocation should be
+   * sizeof(CmdArg)-aligned as per cmd_arg_array_new(). */
+  return (CmdArg *) ((void *) cmd_arg_array->data);
 }
 
 gchar **

--- a/tests/test-update-broken-delta.c
+++ b/tests/test-update-broken-delta.c
@@ -98,6 +98,15 @@ test_update_broken_delta (EosUpdaterFixture *fixture,
 
   g_test_bug ("T17183");
 
+  /* We could get OSTree working by setting OSTREE_BOOTID, but shortly
+   * afterwards we hit unsupported syscalls in qemu-user when running in an
+   * ARM chroot (for example), so just bail. */
+  if (!eos_test_has_ostree_boot_id ())
+    {
+      g_test_skip ("OSTree will not work without a boot ID");
+      return;
+    }
+
   etc_data_init (data, fixture);
   /* Create and set up the server with the commit 0.
    */

--- a/tests/test-update-cleanup-workaround.c
+++ b/tests/test-update-cleanup-workaround.c
@@ -169,6 +169,15 @@ test_update_cleanup_workaround (EosUpdaterFixture *fixture,
 
   g_test_bug ("T16958");
 
+  /* We could get OSTree working by setting OSTREE_BOOTID, but shortly
+   * afterwards we hit unsupported syscalls in qemu-user when running in an
+   * ARM chroot (for example), so just bail. */
+  if (!eos_test_has_ostree_boot_id ())
+    {
+      g_test_skip ("OSTree will not work without a boot ID");
+      return;
+    }
+
   etc_data_init (data, fixture);
   /* Create and set up the server with the commit 0.
    */

--- a/tests/test-update-from-lan.c
+++ b/tests/test-update-from-lan.c
@@ -52,6 +52,15 @@ test_update_from_lan (EosUpdaterFixture *fixture,
   DownloadSource lan_source = DOWNLOAD_LAN;
   g_autoptr(GVariant) lan_source_variant = NULL;
 
+  /* We could get OSTree working by setting OSTREE_BOOTID, but shortly
+   * afterwards we hit unsupported syscalls in qemu-user when running in an
+   * ARM chroot (for example), so just bail. */
+  if (!eos_test_has_ostree_boot_id ())
+    {
+      g_test_skip ("OSTree will not work without a boot ID");
+      return;
+    }
+
   g_test_message ("Setting up server");
 
   server_root = g_file_get_child (fixture->tmpdir, "main");

--- a/tests/test-update-from-main.c
+++ b/tests/test-update-from-main.c
@@ -47,6 +47,15 @@ test_update_from_main (EosUpdaterFixture *fixture,
   DownloadSource main_source = DOWNLOAD_MAIN;
   g_autoptr(GVariant) main_source_variant = NULL;
 
+  /* We could get OSTree working by setting OSTREE_BOOTID, but shortly
+   * afterwards we hit unsupported syscalls in qemu-user when running in an
+   * ARM chroot (for example), so just bail. */
+  if (!eos_test_has_ostree_boot_id ())
+    {
+      g_test_skip ("OSTree will not work without a boot ID");
+      return;
+    }
+
   server_root = g_file_get_child (fixture->tmpdir, "main");
   server = eos_test_server_new_quick (server_root,
                                       default_vendor,

--- a/tests/test-update-from-volume.c
+++ b/tests/test-update-from-volume.c
@@ -49,6 +49,15 @@ test_update_from_volume (EosUpdaterFixture *fixture,
   DownloadSource volume_source = DOWNLOAD_VOLUME;
   g_autoptr(GVariant) volume_source_variant = NULL;
 
+  /* We could get OSTree working by setting OSTREE_BOOTID, but shortly
+   * afterwards we hit unsupported syscalls in qemu-user when running in an
+   * ARM chroot (for example), so just bail. */
+  if (!eos_test_has_ostree_boot_id ())
+    {
+      g_test_skip ("OSTree will not work without a boot ID");
+      return;
+    }
+
   server_root = g_file_get_child (fixture->tmpdir, "main");
   server = eos_test_server_new_quick (server_root,
                                       default_vendor,


### PR DESCRIPTION
T19388 turns out to have been caused by an implicit cast from a 64-bit integer to a 32-bit one. Some of the top 32 bits turned out to actually contain useful information.

https://phabricator.endlessm.com/T19388