### PR TITLE
T19388: Fix OSTree bloom hashing (and tests) on ARM (for eos3.3)

### DIFF
--- a/libeos-updater-util/ostree-bloom.c
+++ b/libeos-updater-util/ostree-bloom.c
@@ -275,11 +275,11 @@ ostree_bloom_maybe_contains (OstreeBloom   *bloom,
 
   for (i = 0; i < bloom->k; i++)
     {
-      gsize idx;
+      guint64 idx;
 
       idx = bloom->hash_func (element, i);
 
-      if (!ostree_bloom_get_bit (bloom, idx % (bloom->n_bytes * 8)))
+      if (!ostree_bloom_get_bit (bloom, (gsize) (idx % (bloom->n_bytes * 8))))
         return FALSE;  /* definitely not in the set */
     }
 
@@ -339,8 +339,8 @@ ostree_bloom_add_element (OstreeBloom   *bloom,
 
   for (i = 0; i < bloom->k; i++)
     {
-      gsize idx = bloom->hash_func (element, i);
-      ostree_bloom_set_bit (bloom, idx % (bloom->n_bytes * 8));
+      guint64 idx = bloom->hash_func (element, i);
+      ostree_bloom_set_bit (bloom, (gsize) (idx % (bloom->n_bytes * 8)));
     }
 }
 

--- a/tests/spawn-utils.h
+++ b/tests/spawn-utils.h
@@ -136,7 +136,9 @@ cmd_arg_array_new (void)
 static inline CmdArg *
 cmd_arg_array_raw (GArray *cmd_arg_array)
 {
-  return (CmdArg *) cmd_arg_array->data;
+  /* void* cast needed to avoid -Wcast-align. The allocation should be
+   * sizeof(CmdArg)-aligned as per cmd_arg_array_new(). */
+  return (CmdArg *) ((void *) cmd_arg_array->data);
 }
 
 gchar **


### PR DESCRIPTION
Version of #110 for eos3.3. Doesn’t depend on the GLib fixes which #110 does.

https://phabricator.endlessm.com/T19388