### PR TITLE
debian: Add missing Python dependencies for eos-updater-prepare-volume

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -59,6 +59,10 @@ Architecture: any
 Multi-arch: no
 Depends:
  eos-updater (= ${binary:Version}),
+ gir1.2-flatpak-1.0,
+ gir1.2-glib-2.0,
+ gir1.2-ostree-1.0,
+ python3-gi,
  ${misc:Depends},
  ${python3:Depends},
  ${shlibs:Depends},


### PR DESCRIPTION
Seems like dh_python is not doing its job and listing the Python
dependencies automatically. List the dependencies for
eos-updater-prepare-volume and eos-updater-ctl manually.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T19293