### PR TITLE
debian: Add Python dependencies for tests to build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,9 @@ Build-Depends:
  dh-python,
  dh-systemd,
  eos-metrics-0-dev,
+ gir1.2-flatpak-1.0,
+ gir1.2-glib-2.0,
+ gir1.2-ostree-1.0,
  gnupg,
  gobject-introspection (>= 1.30.0),
  gtk-doc-tools (>= 1.14),
@@ -24,6 +27,7 @@ Build-Depends:
  libsystemd-dev,
  ostree (>= 2017.12),
  ostree-tests (>= 2017.6),
+ python3-gi,
 
 Package: eos-updater
 Section: misc
@@ -43,6 +47,7 @@ Section: misc
 Architecture: any
 Depends:
  eos-updater (= ${binary:Version}),
+ eos-updater-tools (= ${binary:Version}),
  gir1.2-glib-2.0,
  python3-gi,
  ${misc:Depends},


### PR DESCRIPTION
Since the tests are run at build time, we need to depend on the Python
modules they use (primarily gobject-introspection) in order to
successfully build eos-updater.

The eos-updater-tests package additionally needs to depend on
eos-updater-tools for eos-updater-prepare-volume, which it shells out to
at times.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T19293