### PR TITLE
eos-updater-prepare-volume: Improve FlatpakInstallation error handling

### DIFF
--- a/eos-updater-prepare-volume/eos-updater-prepare-volume
+++ b/eos-updater-prepare-volume/eos-updater-prepare-volume
@@ -135,8 +135,21 @@ class VolumePreparer:
         list of collection–refs of flatpaks. Unrecognised flatpaks are ignored.
         """
         runtimes = set()
-        installations = Flatpak.get_system_installations()
-        installations.append(Flatpak.Installation.new_user())
+
+        # Creating installations can fail if they don’t exist on disk and we
+        # don’t have permission to create them. Ignore that, since we want to
+        # run read-only.
+        try:
+            installations = Flatpak.get_system_installations()
+        except GLib.Error:
+            installations = []
+        try:
+            installations.append(Flatpak.Installation.new_user())
+        except GLib.Error:
+            pass
+
+        if not installations:
+            return runtimes
 
         for (collection_id, ref) in flatpak_collection_refs:
             parsed_ref = Flatpak.Ref.parse(ref)


### PR DESCRIPTION
Handle errors in listing the available installations, which can happen
because libflatpak tries to ensure a repository exists for each location
it checks — if the user doesn’t have permission to create the
repository, this can fail. Another error can be returned if
get_system_installations() can’t find *any* accessible system
installations.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T19293