### PR TITLE
src: Fix crash caused by incorrect number of printf() parameters

### DIFF
--- a/src/eos-updater-poll.c
+++ b/src/eos-updater-poll.c
@@ -300,7 +300,7 @@ metadata_fetch_new (OstreeRepo    *repo,
       g_auto(GVariantBuilder) builder = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE ("a{sv}"));
 
       g_debug ("%s: Finding remotes advertising upgrade_collection_ref: (%s, %s)",
-               upgrade_collection_ref->collection_id, upgrade_collection_ref->ref_name);
+               G_STRFUNC, upgrade_collection_ref->collection_id, upgrade_collection_ref->ref_name);
 
       ostree_repo_find_remotes_async (repo, refs, NULL  /* options */,
                                       (OstreeRepoFinder **) finders->pdata,


### PR DESCRIPTION
There was one more printf placeholder than parameters passed to
g_debug(), and for some reason this wasn’t noticed as a compiler
warning. It could intermittently cause crashes, depending on what’s on
the stack at the time (strlen() would be called on it).

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T19367