### PR TITLE
docs: Drop outdated documentation for pulling from USB sticks

### DIFF
--- a/data/docs/eos-updater.conf.5
+++ b/data/docs/eos-updater.conf.5
@@ -22,9 +22,8 @@ eos\-updater.conf — Endless OS Updater Configuration
 It determines which sources the updater should check for updates from, and
 provides the necessary configuration for sources which need it.
 .PP
-The configuration file contains a mandatory section, \fI[Download]\fP, and an
-optional per\-source section, \fI[Source "volume"]\fP, whose keys are described
-below.
+The configuration file contains a single mandatory section, \fI[Download]\fP,
+whose keys are described below.
 .PP
 Default values are stored in \fI/usr/share/eos\-updater/eos\-updater.conf\fP,
 which must always exist. To override the configuration, copy it to
@@ -42,18 +41,6 @@ important listed first. The available sources are \fImain\fP, \fIlan\fP and
 internet, updates from other computers on the local network (see
 \fBeos\-update\-server\fP(8)) and updates from a connected USB drive (see
 \fBeos\-updater\-prepare\-volume\fP(8)).
-.IP
-If the \fIvolume\fP source is listed, the \fI[Source "volume"]\fP section must
-also be present in the file. Otherwise, it is ignored.
-.\"
-.SH "[Source ""volume""] SECTION OPTIONS"
-.IX Header "[Source ""volume""] SECTION OPTIONS"
-.\"
-.IP "\fIPath=\fP"
-.IX Item "Path="
-Path to the mounted USB drive to fetch updates from. If this does not exist,
-updating from the USB drive will be skipped. This option must be set if the
-\fIvolume\fP source is listed in \fIDownload.Order\fP.
 .\"
 .SH "SEE ALSO"
 .IX Header "SEE ALSO"

--- a/eos-updater-prepare-volume/docs/eos-updater-prepare-volume.8
+++ b/eos-updater-prepare-volume/docs/eos-updater-prepare-volume.8
@@ -72,9 +72,6 @@ Alternatively, to do things manually, copy \fIeos\-updater.conf\fP from
 .RS
 [Download]
 Order=volume;main;  # add the ‘volume’ source
-
-[Source "volume"]
-Path=/run/media/user/some\-volume  # wherever the volume will be mounted
 .RE
 .fi
 .PP


### PR DESCRIPTION
You no longer need a `[Source "volume"]` section, since USB sticks are
detected and enumerated automatically.

Signed-off-by: Philip Withnall <withnall@endlessm.com>