### PR TITLE
libeos-update-server: Fix serving mirror refs from non-default remotes

### DIFF
--- a/libeos-update-server/repo.c
+++ b/libeos-update-server/repo.c
@@ -933,7 +933,7 @@ handle_refs_mirrors (EusRepo     *self,
           raw_path = g_build_filename (self->cached_repo_root,
                                        "refs",
                                        "remotes",
-                                       self->remote_name,
+                                       remotes[i],
                                        collection_ref,
                                        NULL);
 


### PR DESCRIPTION
Serving mirror refs from a remote other than the one set as
EusRepo:served-remote was broken due to passing the wrong remote name
around. Fix that.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T18718