### PR TITLE
libeos-updater-util: Remove code coverage from unit test code

### DIFF
--- a/libeos-updater-util/tests/Makefile.am
+++ b/libeos-updater-util/tests/Makefile.am
@@ -28,17 +28,14 @@ AM_CPPFLAGS = \
 	$(NULL)
 AM_CFLAGS = \
 	$(STD_CFLAGS) \
-	$(CODE_COVERAGE_CFLAGS) \
 	$(WARN_CFLAGS) \
 	$(EOS_UPDATER_UTIL_TESTS_CFLAGS) \
 	$(NULL)
 AM_LDFLAGS = \
 	$(WARN_LDFLAGS) \
-	$(CODE_COVERAGE_LDFLAGS) \
 	$(NULL)
 LDADD = \
 	$(top_builddir)/libeos-updater-util/libeos-updater-util-@EUU_API_VERSION@.la \
-	$(CODE_COVERAGE_LIBS) \
 	$(EOS_UPDATER_UTIL_TESTS_LIBS) \
 	$(NULL)
 


### PR DESCRIPTION
We don’t care about the coverage of the tests themselves, just the code
they’re testing.

Signed-off-by: Philip Withnall <withnall@endlessm.com>