### PR TITLE
installer: Add eos-updater-flatpak-installer

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -291,6 +291,54 @@ libeos_updater_flatpak_installer_libeos_updater_flatpak_installer_@EUFI_API_VERS
 	libeos-updater-flatpak-installer/perform-flatpak-actions.c \
 	$(NULL)
 
+
+# eos-updater-flatpak-installer program
+libexec_PROGRAMS += eos-updater-flatpak-installer/eos-updater-flatpak-installer
+
+eos_updater_flatpak_installer_eos_updater_flatpak_installer_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	-DG_LOG_DOMAIN=\""eos-updater-flatpak-installer"\" \
+	$(NULL)
+eos_updater_flatpak_installer_eos_updater_flatpak_installer_CFLAGS = \
+	$(AM_CFLAGS) \
+	$(STD_CFLAGS) \
+	$(CODE_COVERAGE_CFLAGS) \
+	$(WARN_CFLAGS) \
+	$(EOS_UPDATER_FLATPAK_INSTALLER_CFLAGS) \
+	$(NULL)
+eos_updater_flatpak_installer_eos_updater_flatpak_installer_LDFLAGS = \
+	$(WARN_LDFLAGS) \
+	$(NULL)
+eos_updater_flatpak_installer_eos_updater_flatpak_installer_LDADD = \
+	$(CODE_COVERAGE_LIBS) \
+	$(EOS_UPDATER_FLATPAK_INSTALLER_LIBS) \
+	$(top_builddir)/libeos-updater-util/libeos-updater-util-@EUU_API_VERSION@.la \
+	$(top_builddir)/libeos-updater-flatpak-installer/libeos-updater-flatpak-installer-@EUFI_API_VERSION@.la
+	$(NULL)
+eos_updater_flatpak_installer_eos_updater_flatpak_installer_SOURCES = \
+	eos-updater-flatpak-installer/main.c \
+	$(NULL)
+
+eos_updater_flatpak_installer_in = \
+	eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in \
+	$(NULL)
+
+systemdsystemunit_DATA += $(eos_updater_flatpak_installer_in:%.in=%)
+
+eos_updater_flatpak_installer_schemas = eos-updater-flatpak-installer/eos-updater-autoinstall.schema.json
+flatpakinstallerschemadir = $(datadir)/eos-updater/schemas
+flatpakinstallerschema_DATA = $(eos_updater_flatpak_installer_schemas)
+
+EXTRA_DIST += \
+	$(eos_updater_flatpak_installer_in) \
+	$(eos_updater_flatpak_installer_schemas) \
+	$(NULL)
+
+CLEANFILES += $(eos_updater_flatpak_installer_in:%.in=%)
+
+dist_man5_MANS += eos-updater-flatpak-installer/docs/eos-updater-flatpak-autoinstall.d.5
+dist_man8_MANS += eos-updater-flatpak-installer/docs/eos-updater-flatpak-installer.8
+
 # Test helper library
 noinst_LTLIBRARIES += test-common/libeos-updater-test-common.la
 

--- a/debian/eos-updater-tools.install
+++ b/debian/eos-updater-tools.install
@@ -1,4 +1,5 @@
 usr/bin/eos-updater-prepare-volume
 usr/bin/eos-updater-ctl
+usr/share/eos-updater/schemas/eos-updater-autoinstall.schema.json
 usr/share/man/man8/eos-updater-ctl.8
 usr/share/man/man8/eos-updater-prepare-volume.8

--- a/debian/eos-updater.install
+++ b/debian/eos-updater.install
@@ -4,11 +4,13 @@ lib/systemd/system/eos-update-server.service
 lib/systemd/system/eos-update-server.socket
 lib/systemd/system/eos-updater-avahi.path
 lib/systemd/system/eos-updater-avahi.service
+lib/systemd/system/eos-updater-flatpak-installer.service
 lib/systemd/system/eos-updater.service
 usr/bin/eos-updater
 usr/lib/*/eos-autoupdater
 usr/lib/*/eos-update-server
 usr/lib/*/eos-updater-avahi
+usr/lib/*/eos-updater-flatpak-installer
 usr/share/dbus-1/system-services/com.endlessm.Updater.service
 usr/share/dbus-1/system.d/com.endlessm.Updater.conf
 usr/share/dbus-1/interfaces/com.endlessm.Updater.xml
@@ -17,8 +19,10 @@ usr/share/eos-updater/eos-updater.conf
 usr/share/eos-updater/eos-update-server.conf
 usr/share/man/man5/eos-autoupdater.conf.5
 usr/share/man/man5/eos-updater.conf.5
+usr/share/man/man5/eos-updater-flatpak-autoinstall.d.5
 usr/share/man/man5/eos-update-server.conf.5
 usr/share/man/man8/eos-autoupdater.8
 usr/share/man/man8/eos-updater-avahi.8
 usr/share/man/man8/eos-update-server.8
 usr/share/man/man8/eos-updater.8
+usr/share/man/man8/eos-updater-flatpak-installer.8

--- a/debian/rules
+++ b/debian/rules
@@ -29,8 +29,16 @@ override_dh_strip:
 
 # Don't start the services on install
 override_dh_systemd_start:
-	dh_systemd_start -peos-updater --no-start eos-autoupdater.service eos-update-server.service
-	dh_systemd_start -peos-updater eos-autoupdater.timer eos-update-server.socket eos-updater-avahi.path
+	dh_systemd_start -peos-updater --no-start \
+		eos-autoupdater.service \
+		eos-update-server.service \
+		eos-updater-flatpak-installer.service \
+		$(NULL)
+	dh_systemd_start -peos-updater \
+		eos-autoupdater.timer \
+		eos-update-server.socket \
+		eos-updater-avahi.path \
+		$(NULL)
 
 override_dh_install:
 	rm -f debian/tmp/usr/lib/*/*.la

--- a/eos-updater-flatpak-installer/docs/eos-updater-flatpak-autoinstall.d.5
+++ b/eos-updater-flatpak-installer/docs/eos-updater-flatpak-autoinstall.d.5
@@ -1,0 +1,177 @@
+.\" Manpage for eos-updater-flatpak-autoinstall.d.5.
+.\" Documentation is under the same licence as the eos-updater package.
+.TH man 5 "8 Nov 2017" "1.0" "eos\-updater\-flatpak\-autoinstall.d man page"
+.\"
+.SH NAME
+.IX Header "NAME"
+eos\-updater\-flatpak\-autoinstall.d — Endless OS Configuration for Flatpak Installation on Updates
+.\"
+.SH SYNOPSIS
+.IX Header "SYNOPSIS"
+.\"
+\fB/etc/eos\-application\-tools/flatpak\-autoinstall.d/\fP
+.br
+.\"
+\fB/var/lib/eos\-application\-tools/flatpak\-autoinstall.d/\fP
+.br
+.\"
+\fB/usr/share/eos\-application\-tools/flatpak\-autoinstall.d/\fP
+.\"
+.SH DESCRIPTION
+.IX Header "DESCRIPTION"
+.\"
+\fBeos\-updater\-flatpak\-autoinstall.d\fP provides a list of ‘flatpak ref action’
+files, which specify flatpaks that should be installed, updated and uninstalled
+by \fBeos\-updater\-flatpak\-installer\fP(8) when booting into a new deployment.
+.PP
+Configuration files take priority over each other in the directory descending
+order listed above. If a file in a higher priority directory has the same
+basename as a file in a lower priority directory, only the configuration from
+the higher priority directory is used. The list of actions to apply is
+determined first sorting the new actions in each file ascending by its
+serial number, then by sorting the files in lexicographical order
+and concatenating their sorted contents to each other. This means that the
+most up\-to\-date action in a filename that is lexicographically ordered after
+another filename will take priority in the event that the two
+most up\-to\-date actions conflict, even if the most up\-to\-date action in the
+lower\-priority file has a newer
+serial number.
+.\"
+.SH ACTION SPECIFICATION
+.IX Header "ACTION SPECIFICATION"
+.\"
+The file format of each ‘flatpak ref action’ file in a
+\fBeos\-updater\-flatpak\-autoinstall.d\fP directory is
+RFC\ 7159 compliant JSON. Each file must be a JSON array containing
+objects describing a ‘flatpak ref action’, as described below in
+\fIFlatpak Ref Action\fP. These files are intended to be append\-only
+and the \fBserial\fP property in each object must be a monotonically
+increasing counter within the domain of that filename.
+.\"
+.IP "\fIFlatpak Ref Action\fP"
+.IX Item "Flatpak Ref Action"
+A JSON object containing, at minimum, properties \fBaction\fP,
+\fBserial\fP and optionally \fBfilters\fP. Valid values for
+\fBaction\fP are \fBinstall\fP, \fBupdate\fP and \fBuninstall\fP,
+each having their own required properties as explained below. The only valid
+type for \fBserial\fP, is an integer, which must be monotonically
+increasing as new entries are appended to the file.
+.\"
+.IP "\fIThe \fBfilters\fP entry\fP"
+.IX Item "The filters entry"
+A \fIFlatpak Ref Action\fP may have a \fBfilters\fP entry which is a JSON
+object with optional properties \fBarchitecture\fP, \fB~architecture\fP,
+\fBlocale\fP and \fB~locale\fP. Each filter property takes a JSON
+array of strings containing architectures or locales to apply to the filter.
+.IP
+Where a filter is prefixed with a tilde (\fB~\fP), the action will not be applied
+if the system architecture or locales matches any entry in the array. Otherwise,
+the action will only be applied if the system architecture or locales matches
+at least one entry in the array. It is an error to specify a filter and its
+inverse.
+.IP
+Where an action is filtered out and not applied, it will never be applied
+again, even if the property being filtered on changes. For instance, if the
+system locale changes, the action will not be re\-evaluated to see if it
+matches the new locale.
+.\"
+.IP "\fI\fBinstall\fP actions\fP"
+.IX Item "install actions"
+Where the \fBaction\fP property of a \fIFlatpak Ref Action\fP entry is
+\fBinstall\fP, the action will describe a flatpak that should be
+installed upon the next boot of the deployment in which the action was
+introduced. The entry must have the additional properties \fBapp\fP,
+\fBref\-kind\fP and both \fBcollection\-id\fP and \fBremote\fP,
+which describe the flatpak app ID, whether the flatpak is a
+runtime or an app and either the \fBostree\fP(1) collection ID or remote to
+install the app from. See \fBflatpak\fP(1) and \fBostree\fP(1) for more
+information on flatpak app IDs, ref\-kinds and remotes, and \fBostree\fP(1)
+on collection IDs generally. If the flatpak is already installed when the action
+is applied, \fBeos\-updater\-flatpak\-installer\fP(8) will attempt to upgrade it.
+.IP
+Because both \fBcollection\-id\fP and \fBremote\fP are specified, the
+updater will check that the given remote matches the first remote for
+the given collection ID, otherwise an error occurs. If neither
+\fBcollection\-id\fP nor \fBremote\fP are specified, an error
+occurs.
+.IP
+Note that flatpaks are not pulled from the remote upon booting into
+the deployment, they are instead downloaded by \fBeos\-updater\fP(8) during its
+‘fetch’ step whilst it prepares the commit to be deployed.
+\."
+.IP "\fI\fBupdate\fP actions\fP"
+.IX Item "update actions"
+Where the \fBaction\fP property of a \fIFlatpak Ref Action\fP entry is
+\fBupdate\fP, the action will describe a flatpak that should be
+updated upon the next boot of the deployment in which the action was
+introduced, if (and only if) that flatpak is installed at the time. The entry
+must have the additional properties \fBapp\fP, \fBref\-kind\fP.
+\."
+.IP "\fI\fBuninstall\fP actions\fP"
+.IX Item "uninstall actions"
+Where the \fBaction\fP property of a \fIFlatpak Ref Action\fP entry is
+\fBuninstall\fP, the action will describe a flatpak that should be
+uninstalled upon the next boot of the deployment in which the action was
+introduced. The entry must have the additional properties \fBapp\fP,
+\fBref\-kind\fP. It is not an error if the flatpak is already uninstalled
+when the action is applied.
+\."
+.SH "EXAMPLES"
+.IX Header "EXAMPLES"
+.\"
+[
+    {
+        "action": "install",
+        "serial": 2017100100,
+        "ref\-kind": "app",
+        "name": "org.example.MyApp",
+        "collection\-id": "com.endlessm.Apps"
+    },
+    {
+        "action": "uninstall",
+        "serial": 2017100101,
+        "ref\-kind": "app",
+        "name": "org.example.OutdatedApp",
+        "collection\-id": "com.endlessm.Apps"
+    },
+    {
+        "action": "install",
+        "serial": 2017100500,
+        "ref\-kind": "runtime",
+        "name": "org.example.PreinstalledRuntime",
+        "remote": "eos\-runtimes"
+    },
+    {
+        "action": "install",
+        "serial": 2017110100,
+        "ref\-kind": "runtime",
+        "name": "org.example.NVidiaRuntime",
+        "collection\-id": "com.endlessm.Runtimes"
+    },
+    {
+        "action": "install",
+        "serial": 2017110200,
+        "ref\-kind": "app",
+        "name": "org.example.IndonesiaNonArmGame",
+        "filters": {
+            "locale": ["id_ID"],
+            "~architecture": ["armhf"]
+        }
+    }
+]
+\."
+.SH "SEE ALSO"
+.IX Header "SEE ALSO"
+.\"
+\fBeos\-updater\fP(8),
+\fBeos\-updater\-flatpak\-installer\fP(8)
+.\"
+.SH AUTHOR
+.IX Header "AUTHOR"
+.\"
+Endless Mobile, Inc.
+.\"
+.SH COPYRIGHT
+.IX Header "COPYRIGHT"
+.\"
+Copyright © 2017 Endless Mobile, Inc.

--- a/eos-updater-flatpak-installer/docs/eos-updater-flatpak-installer.8
+++ b/eos-updater-flatpak-installer/docs/eos-updater-flatpak-installer.8
@@ -1,0 +1,140 @@
+.\" Manpage for eos-updater-flatpak-installer.
+.\" Documentation is under the same licence as the eos-updater package.
+.TH man 8 "10 Nov 2017" "1.0" "eos\-updater\-flatpak\-installer man page"
+.\"
+.SH NAME
+.IX Header "NAME"
+eos\-updater\-flatpak\-installer — Endless OS Updater Flatpak Installer
+.\"
+.SH SYNOPSIS
+.IX Header "SYNOPSIS"
+.\"
+\fBeos\-updater\-flatpak\-installer [\-m \fPmode\fB] [\-p]
+.\"
+.SH DESCRIPTION
+.IX Header "DESCRIPTION"
+.\"
+\fBeos\-updater\-flatpak\-installer\fP installs downloaded flatpaks on Endless OS
+updates upon booting into the new OS deployment. It is the part of the system that
+ensures that when new flatpaks are installed on OS updates, they are
+only made available when rebooting into the new OS deployment and not while
+the old OS deployment is still running.
+.PP
+.SH OPTIONS
+.IX Header "OPTIONS"
+.\"
+.IP "\fB\-m\fP, \fB\-\-mode=\fP"
+Which mode to run the flatpak installer in. (Default: \fBperform\fP.)
+\".
+When set to \fBperform\fP, the installer will examine the list of applications
+in the directories specified by \fBeos\-updater\-flatpak\-autoinstall.d\fP(5)
+and the counter state in
+\fI/var/lib/eos\-application\-tools/flatpak\-autoinstall.progress\fP, then for
+each basename, perform only newly updated actions and save the most up to date
+serial number for each file in ther counter state file.
+\".
+When set to \fBstamp\fP, \fBeos\-updater\-flatpak\-installer\fP will only save
+the updated actions to
+\fI/var/lib/eos\-application\-tools/flatpak\-autoinstall.progress\fP.
+\".
+When set to \fBcheck\fP, the tool will check to see if all actions are applied (e.g., that
+applications that should have been installed are installed and every app that
+should have been uninstalled is not installed).
+.\"
+.IP "\fB\-p\fP, \fB\-\-pull\fP"
+Pull flatpaks as well as deploying them. By default, flatpaks are
+not pulled during this step; it is expected that they will be pulled by
+\fBeos\-updater\fP(8) when it fetches and applies system updates.
+.\"
+.SH "ENVIRONMENT"
+.IX Header "ENVIRONMENT"
+.\"
+\fPeos\-updater\-flatpak\-installer\fP supports the standard GLib environment
+variables for debugging. These variables are \fBnot\fP intended to be used in
+production:
+.\"
+.IP \fI$G_MESSAGES_DEBUG\fP 4
+.IX Item "$G_MESSAGES_DEBUG"
+This variable can contain one or more debug domain names to display debug output
+for. The value \fIall\fP will enable all debug output. The default is for no
+debug output to be enabled.
+.\"
+.SH "KERNEL COMMAND LINE"
+.IX Header "KERNEL COMMAND LINE"
+.\"
+If the \fBeos\-updater\-flatpak\-installer.service\fP unit is started when
+the kernel command line contains \fBeos\-updater\-disable\fP, then
+it will exit immediately. If started manually, it will execute as normal,
+regardless of the kernel command line.
+.\"
+.SH "EXIT STATUS"
+.IX Header "EXIT STATUS"
+.\"
+\fBeos\-updater\-flatpak\-installer\fP may return one of several error codes
+if it encounters problems.
+.\"
+.IP "0" 4
+.IX Item "0"
+No problems occurred. The check, stamp or perform operation completed
+successfully.
+.\"
+.IP "1" 4
+.IX Item "1"
+There was an error while loading or manipulating the flatpak installation.
+.\"
+.IP "2" 4
+.IX Item "2"
+An invalid option was passed to \fBeos\-updater\-flatpak\-installer\fP on
+startup.
+.\"
+.IP "3" 4
+.IX Item "3"
+The \fBcheck\fP operation found an inconsistency. Only returned with
+\fB\-\-mode=check\fP.
+.\"
+.IP "4" 4
+.IX Item "4"
+The \fBapply\fP operation failed to apply one or more actions. Only returned
+with \fB\-\-mode=apply\fP.
+.\"
+.SH "FILES"
+.IX Header "FILES"
+.\"
+.IP \fI/var/lib/eos\-application\-tools/flatpak\-autoinstall.d/*\fP 4
+.IX Item "/etc/eos\-application\-tools/flatpak\-autoinstall.d/*"
+.IX Item "/var/lib/eos\-applications\-tools/flatpak\-autoinstall.d/*"
+.IX Item "/usr/share/eos\-application\-tools/flatpak\-autoinstall.d/*"
+Each of the files in this directory contain a list of actions to be applied
+by the installer. Files are also loaded from matching subdirectories in
+\fI/var/lib\fP and \fI/usr/share\fP. See
+\fBeos\-updater\-flatpak\-autoinstall.d\fP(5).
+.\"
+.IP \fI/var/lib/eos\-application\-tools/flatpak\-autoinstall.progress\fP 4
+.IX Item "/etc/eos\-application\-tools/flatpak\-autoinstall.progress"
+Local state file storing the serial numbers of the latest applied actions for
+each basename in the \fIautoinstall.d\fP directories.
+.\"
+.SH "SEE ALSO"
+.IX Header "SEE ALSO"
+.\"
+\fBeos\-updater.service\fP(8),
+\fBeos\-updater\fP(8),
+\fBeos\-updater\-flatpak\-autoinstall.d\fP(5),
+\fBflatpak\fP(1)
+.\"
+.SH BUGS
+.IX Header "BUGS"
+.\"
+Any bugs which are found should be reported on the project website:
+.br
+\fIhttps://support.endlessm.com/\fP
+.\"
+.SH AUTHOR
+.IX Header "AUTHOR"
+.\"
+Endless Mobile, Inc.
+.\"
+.SH COPYRIGHT
+.IX Header "COPYRIGHT"
+.\"
+Copyright © 2017 Endless Mobile, Inc.

--- a/eos-updater-flatpak-installer/eos-updater-autoinstall.schema.json
+++ b/eos-updater-flatpak-installer/eos-updater-autoinstall.schema.json
@@ -1,0 +1,142 @@
+{
+    "$comment": "Copyright (c) 2017 Endless Mobile, Inc. This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version. This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.  You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "type": "object",
+    "title": "Autoinstall Flatpak Entry",
+    "description": "A description of an action to be performed by the system updater when updating to a given OSTree revision",
+    "oneOf": [
+        {
+            "properties": {
+                "action": {
+                    "const": "install",
+                    "description": "The machine-readable type of event",
+                    "type": "string"
+                },
+                "serial": {
+                    "$ref": "#/definitions/serial"
+                },
+                "filters": {
+                    "$ref": "#/definitions/filters"
+                },
+                "ref-kind": {
+                    "$ref": "#/definitions/ref-kind"
+                },
+                "app": {
+                    "description": "The app-id to be installed",
+                    "$ref": "#/definitions/app"
+                },
+                "collection-id": {
+                    "$ref": "#/definitions/collection-id"
+                },
+                "remote": {
+                    "$ref": "#/definitions/remote"
+                }
+            },
+            "required": ["ref-kind", "app", "remote", "collection-id"]
+        },
+        {
+            "properties": {
+                "action": {
+                    "const": "uninstall",
+                    "description": "The machine-readable type of event",
+                    "type": "string"
+                },
+                "serial": {
+                    "$ref": "#/definitions/serial"
+                },
+                "filters": {
+                    "$ref": "#/definitions/filters"
+                },
+                "ref-kind": {
+                    "$ref": "#/definitions/ref-kind"
+                },
+                "app": {
+                    "description": "The app-id to be uninstalled",
+                    "$ref": "#/definitions/app"
+                },
+            },
+            "required": ["ref-kind", "app"]
+        },
+        {
+            "properties": {
+                "action": {
+                    "const": "update",
+                    "description": "The machine-readable type of event",
+                    "type": "string"
+                },
+                "serial": {
+                    "$ref": "#/definitions/serial"
+                },
+                "filters": {
+                    "$ref": "#/definitions/filters"
+                },
+                "ref-kind": {
+                    "$ref": "#/definitions/ref-kind"
+                },
+                "app": {
+                    "description": "The app-id to be updated",
+                    "$ref": "#/definitions/app"
+                },
+            },
+            "required": ["ref-kind", "app"]
+        }
+    ],
+    "required": ["action", "serial"],
+    "definitions": {
+        "filters": {
+            "title": "Filter to apply to action",
+            "description": "Tests to apply to see whether this action should be performed or skipped. If it is skipped, the test to check whether it should be performed or skipped will never run again.",
+            "type": "object",
+            "properties": {
+                "~architectures": {
+                    "description": "Which architectures forbid performing this action on",
+                    "$ref": "#/definitions/filter"
+                },
+                "architectures": {
+                    "description": "Which architectures to only perform this action on",
+                    "$ref": "#/definitions/filter"
+                },
+                "~locales": {
+                    "description": "Which locales forbid performing this action on",
+                    "$ref": "#/definitions/filter"
+                },
+                "locales": {
+                    "description": "Which locales to only perform this action on",
+                    "$ref": "#/definitions/filter"
+                },
+            }
+        },
+        "serial": {
+            "description": "A unique serial number for this event, unique to the domain named after the autoinstall file. Serial numbers must be assigned monotonically increasing values.",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2147483647
+        },
+        "ref-kind": {
+            "description": "The flatpak ref kind",
+            "type": "string",
+            "enum": ["app", "runtime"]
+        },
+        "app": {
+            "description": "The app-id to be installed",
+            "type": "string"
+        },
+        "collection-id": {
+            "description": "The collection-id to install the app from",
+            "type": "string"
+        },
+        "remote": {
+            "description": "The remote to install the app from",
+            "type": "string"
+        },
+        "filter": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        }
+    },
+    "required": ["action", "serial"]
+}

--- a/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
+++ b/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
@@ -1,0 +1,39 @@
+[Unit]
+Description=Endless OS Post-Boot Flatpak Installer
+Wants=local-fs.target
+After=local-fs.target
+ConditionKernelCommandLine=!eos-updater-disable
+
+# Only on updates
+Before=multi-user.target systemd-update-done.service
+ConditionNeedsUpdate=/var
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=@libexecdir@/eos-updater-flatpak-installer
+
+# Sandboxing
+CapabilityBoundingSet=
+Environment=GIO_USE_VFS=local
+Environment=GVFS_DISABLE_FUSE=1
+Environment=GVFS_REMOTE_VOLUME_MONITOR_IGNORE=1
+Environment=GSETTINGS_BACKEND=memory
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateNetwork=yes
+PrivateTmp=yes
+PrivateUsers=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=no
+RestrictAddressFamilies=AF_UNIX
+RestrictRealtime=yes
+SystemCallErrorNumber=EPERM
+SystemCallFilter=@basic-io @io-event @ipc @network-io
+
+[Install]
+WantedBy=multi-user.target

--- a/eos-updater-flatpak-installer/main.c
+++ b/eos-updater-flatpak-installer/main.c
@@ -1,0 +1,264 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2017 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Authors:
+ *  - Sam Spilsbury <sam@endlessm.com>
+ */
+
+#include <flatpak.h>
+#include <glib.h>
+#include <libeos-updater-util/enums.h>
+#include <libeos-updater-util/flatpak.h>
+#include <libeos-updater-util/types.h>
+#include <libeos-updater-util/util.h>
+#include <libeos-updater-flatpak-installer/installer.h>
+#include <locale.h>
+#include <ostree.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sysexits.h>
+
+/* main() exit codes. */
+enum
+{
+  EXIT_OK = EXIT_SUCCESS,
+  EXIT_FAILED = 1,
+  EXIT_INVALID_ARGUMENTS = 2,
+  EXIT_CHECK_FAILED = 3,
+  EXIT_APPLY_FAILED = 4,
+};
+
+static int
+usage (GOptionContext *context,
+       const gchar    *error_message,
+       ...) G_GNUC_PRINTF (2, 3);
+
+static int
+usage (GOptionContext *context,
+       const gchar    *error_message,
+       ...)
+{
+  va_list ap;
+  g_autofree gchar *formatted_message = NULL;
+  g_autofree gchar *help = NULL;
+
+  /* Format the arguments. */
+  va_start (ap, error_message);
+  formatted_message = g_strdup_vprintf (error_message, ap);
+  va_end (ap);
+
+  /* Include the usage. */
+  help = g_option_context_get_help (context, TRUE, NULL);
+  g_printerr ("%s: %s\n\n%s\n", g_get_prgname (), formatted_message, help);
+
+  return EXIT_INVALID_ARGUMENTS;
+}
+
+static gboolean
+parse_installer_mode (const gchar              *mode,
+                      EosUpdaterInstallerMode  *out_mode,
+                      GError                  **error)
+{
+  GEnumClass *enum_class = g_type_class_ref (EOS_TYPE_UPDATER_INSTALLER_MODE);
+  GEnumValue *enum_value = g_enum_get_value_by_nick (enum_class, mode);
+
+  g_type_class_unref (enum_class);
+
+  if (enum_value == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Invalid installer mode ‘%s’", mode);
+      return FALSE;
+    }
+
+  *out_mode = (EosUpdaterInstallerMode) enum_value->value;
+
+  return TRUE;
+}
+
+static int
+fail (int          exit_status,
+      const gchar *error_message,
+      ...) G_GNUC_PRINTF (2, 3);
+
+static int
+fail (int          exit_status,
+      const gchar *error_message,
+      ...)
+{
+  va_list ap;
+  g_autofree gchar *formatted_message = NULL;
+
+  g_return_val_if_fail (exit_status > 0, EXIT_FAILED);
+
+  /* Format the arguments. */
+  va_start (ap, error_message);
+  formatted_message = g_strdup_vprintf (error_message, ap);
+  va_end (ap);
+
+  /* Include the usage. */
+  g_printerr ("%s: %s\n", g_get_prgname (), formatted_message);
+
+  return exit_status;
+}
+
+int
+main (int    argc,
+      char **argv)
+{
+  g_autoptr(GError) error = NULL;
+  g_autoptr(GOptionContext) context = NULL;
+  g_autoptr(GFile) flatpaks_to_export_file = NULL;
+  g_autoptr(GHashTable) flatpak_ref_actions_for_this_boot = NULL;
+  g_autoptr(GHashTable) flatpak_ref_actions_progress = NULL;
+  g_autoptr(FlatpakInstallation) installation = NULL;
+  g_autofree gchar *formatted_flatpak_ref_actions_for_this_boot = NULL;
+  g_autofree gchar *formatted_flatpak_ref_actions_progress_for_this_boot = NULL;
+  const gchar *resolved_mode = NULL;
+  const gchar *pending_flatpak_deployments_state_path = euu_pending_flatpak_deployments_state_path ();
+  EosUpdaterInstallerMode parsed_mode;
+
+  g_autofree gchar *mode = NULL;
+  gboolean also_pull = FALSE;
+  GOptionEntry entries[] =
+    {
+      { "mode", 'm', 0, G_OPTION_ARG_STRING, &mode, "Mode to use (perform, stamp, check) (default: perform)", NULL },
+      { "pull", 'p', 0, G_OPTION_ARG_NONE, &also_pull, "Also pull flatpaks", NULL },
+      { NULL }
+    };
+
+  setlocale (LC_ALL, "");
+
+  context = g_option_context_new ("— Endless OS Updater Flatpak Installer");
+  g_option_context_add_main_entries (context, entries, NULL);
+  g_option_context_set_summary (context,
+                                "Install flatpak packages on system boot");
+
+  if (!g_option_context_parse (context, &argc, &argv, &error))
+    return usage (context, "Failed to parse options: %s", error->message);
+
+  resolved_mode = mode != NULL ? mode : "perform";
+
+  if (!parse_installer_mode (resolved_mode,
+                             &parsed_mode,
+                             &error))
+    return fail (EXIT_INVALID_ARGUMENTS, "%s", error->message);
+
+  installation = eos_updater_get_flatpak_installation (NULL, &error);
+
+  if (installation == NULL)
+    return fail (EXIT_FAILED, "Could not get flatpak installation: %s", error->message);
+
+  g_message ("Running in mode ‘%s’", resolved_mode);
+
+  if (also_pull)
+    g_message ("Will pull flatpaks as well as deploying them");
+
+  /* Check mode is completely different — we need to read in the action
+   * application state and check if there’s a delta between what we expect
+   * and what we have.
+   *
+   * Note that on a user system it might be perfectly legitimate for there
+   * to be a delta, because the user might have uninstalled or installed
+   * an app we marked as auto-install or auto-uninstall. Generally speaking
+   * you would use this mode on the image builder to catch situations where
+   * the apps list is out of sync.
+   */
+  switch (parsed_mode)
+    {
+      case EU_INSTALLER_MODE_CHECK:
+        {
+          g_autoptr(GHashTable) flatpak_ref_actions_to_check = NULL;
+          g_autoptr(GPtrArray) squashed_ref_actions_to_check = NULL;
+          g_autofree gchar *formatted_flatpak_ref_actions_to_check = NULL;
+          g_autofree gchar *formatted_ordered_flatpak_ref_actions_to_check = NULL;
+
+          flatpak_ref_actions_to_check = eufi_determine_flatpak_ref_actions_to_check (NULL, &error);
+
+          if (flatpak_ref_actions_to_check == NULL)
+            return fail (EXIT_FAILED, 
+                         "Could not get information on which flatpak ref actions to check: %s",
+                         error->message);
+
+          squashed_ref_actions_to_check = euu_flatten_flatpak_ref_actions_table (flatpak_ref_actions_to_check);
+
+          formatted_flatpak_ref_actions_to_check =
+            euu_format_all_flatpak_ref_actions ("All flatpak ref actions that should have been applied",
+                                                flatpak_ref_actions_to_check);
+          g_message ("%s", formatted_flatpak_ref_actions_to_check);
+
+          formatted_ordered_flatpak_ref_actions_to_check =
+            euu_format_flatpak_ref_actions_array ("Order in which actions will be checked",
+                                                  squashed_ref_actions_to_check);
+          g_message ("%s", formatted_ordered_flatpak_ref_actions_to_check);
+
+          if (!eufi_check_ref_actions_applied (installation,
+                                               pending_flatpak_deployments_state_path,
+                                               squashed_ref_actions_to_check,
+                                               &error))
+            return fail (EXIT_CHECK_FAILED,
+                         "Flatpak ref actions are not up to date: %s",
+                         error->message);
+
+          break;
+        }
+      case EU_INSTALLER_MODE_PERFORM:
+      case EU_INSTALLER_MODE_STAMP:
+        {
+          g_autoptr(GHashTable) new_flatpak_ref_actions_to_apply = NULL;
+          g_autoptr(GPtrArray) squashed_ref_actions_to_apply = NULL;
+          g_autofree gchar *formatted_flatpak_ref_actions_to_apply = NULL;
+          g_autofree gchar *formatted_ordered_flatpak_ref_actions_to_apply = NULL;
+
+          new_flatpak_ref_actions_to_apply = eufi_determine_flatpak_ref_actions_to_apply (NULL, &error);
+
+          if (new_flatpak_ref_actions_to_apply == NULL)
+            return fail (EXIT_FAILED,
+                         "Could not get information on which flatpak ref actions to check: %s",
+                         error->message);
+
+          squashed_ref_actions_to_apply = euu_flatten_flatpak_ref_actions_table (new_flatpak_ref_actions_to_apply);
+
+          formatted_flatpak_ref_actions_to_apply =
+            euu_format_all_flatpak_ref_actions ("All flatpak ref actions that are not yet applied",
+                                                new_flatpak_ref_actions_to_apply);
+          g_message ("%s", formatted_flatpak_ref_actions_to_apply);
+
+          formatted_ordered_flatpak_ref_actions_to_apply =
+            euu_format_flatpak_ref_actions_array ("Order in which actions will be applied",
+                                                  squashed_ref_actions_to_apply);
+          g_message ("%s", formatted_ordered_flatpak_ref_actions_to_apply);
+
+          if (!eufi_apply_flatpak_ref_actions (installation,
+                                               euu_pending_flatpak_deployments_state_path (),
+                                               squashed_ref_actions_to_apply,
+                                               parsed_mode,
+                                               also_pull ? EU_INSTALLER_FLAGS_ALSO_PULL : EU_INSTALLER_FLAGS_NONE,
+                                               &error))
+            return fail (EXIT_APPLY_FAILED,
+                         "Couldn’t apply some flatpak update actions for this boot: %s",
+                         error->message);
+
+          break;
+        }
+      default:
+        g_assert_not_reached ();
+    }
+
+  return EXIT_OK;
+}


### PR DESCRIPTION
(**This doesn’t really need reviewing; it’s the results of my review of one of the commits on #129, which I’m pushing here to get Jenkins to test run the build.**)

This binary uses the functions in libeos-updater-flatpak-installer
to actually install flatpaks on reboot. It also has a "check" mode
which checks if the flatpak actions we claim to have applied are actually
fully-up-to-date on the system.

(Modified by Philip Withnall to improve formatting on man pages and fix
a few minor bugs found during review.)

https://phabricator.endlessm.com/T16682