### PR TITLE
poll: Fail gracefully w/o OstreeRepoFinderAvahi

### DIFF
--- a/src/eos-updater-poll.c
+++ b/src/eos-updater-poll.c
@@ -293,6 +293,12 @@ metadata_fetch_new (OstreeRepo    *repo,
   upgrade_refspec = booted_refspec;
 
   finders = get_finders (config, context, &finder_avahi);
+  if (finders->len == 0)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "All configured update sources failed to initialize.");
+      return NULL;
+    }
 
   /* Check whether the commit is a redirection; if so, fetch the new ref and
    * check again. */


### PR DESCRIPTION
If the OstreeRepoFinderAvahi instance fails to start (which can
happen if libostree is compiled without avahi support), eos-updater hits
an assertion failure when it passes an empty array to
ostree_repo_find_remotes_async. Change it to instead print a meaningful
error message.

https://phabricator.endlessm.com/T19367