### PR TITLE
Revert "util: Override architecture during testing"

### DIFF
--- a/libeos-updater-util/flatpak.c
+++ b/libeos-updater-util/flatpak.c
@@ -247,13 +247,6 @@ parse_flatpak_ref_from_entry (JsonObject      *entry,
   return TRUE;
 }
 
-static const gchar *
-eos_updater_get_system_architecture_string (void)
-{
-  return eos_updater_get_envvar_or ("EOS_UPDATER_TEST_OVERRIDE_ARCHITECTURE",
-                                    flatpak_get_default_arch ());
-}
-
 /* Parse an @entry of type %EUU_FLATPAK_REMOTE_REF_ACTION_INSTALL to a
  * #EuuFlatpakLocationRef. See flatpak_remote_ref_from_action_entry(). */
 static EuuFlatpakLocationRef *
@@ -284,7 +277,6 @@ flatpak_remote_ref_from_install_action_entry (JsonObject  *entry,
   ref = g_object_new (FLATPAK_TYPE_REF,
                       "name", name,
                       "kind", kind,
-                      "arch", eos_updater_get_system_architecture_string (),
                       NULL);
 
   return euu_flatpak_location_ref_new (ref, remote, collection_id);
@@ -306,7 +298,6 @@ flatpak_remote_ref_from_uninstall_action_entry (JsonObject  *entry,
   ref = g_object_new (FLATPAK_TYPE_REF,
                       "name", name,
                       "kind", kind,
-                      "arch", eos_updater_get_system_architecture_string (),
                       NULL);
 
   return euu_flatpak_location_ref_new (ref, "none", NULL);
@@ -328,7 +319,6 @@ flatpak_remote_ref_from_update_action_entry (JsonObject  *entry,
   ref = g_object_new (FLATPAK_TYPE_REF,
                       "name", name,
                       "kind", kind,
-                      "arch", eos_updater_get_system_architecture_string (),
                       NULL);
 
   return euu_flatpak_location_ref_new (ref, "none", NULL);
@@ -493,6 +483,13 @@ parse_json_from_file (GFile         *file,
     }
 
   return g_steal_pointer (&root_node);
+}
+
+static const gchar *
+eos_updater_get_system_architecture_string (void)
+{
+  return eos_updater_get_envvar_or ("EOS_UPDATER_TEST_OVERRIDE_ARCHITECTURE",
+                                    flatpak_get_default_arch ());
 }
 
 /* Get the elements of the member named @key of @object, which must exist (it’s

--- a/libeos-updater-util/tests/flatpak.c
+++ b/libeos-updater-util/tests/flatpak.c
@@ -405,7 +405,6 @@ test_parse_autoinstall_file_unsorted (void)
   const EuuFlatpakRemoteRefAction *action0, *action1;
   g_autofree gchar *action0_ref = NULL;
   g_autofree gchar *action1_ref = NULL;
-  g_autofree gchar *old_env_arch = g_strdup (g_getenv ("EOS_UPDATER_TEST_OVERRIDE_ARCHITECTURE"));
   const gchar *data =
     "["
       "{ 'action': 'install', 'serial': 2017100100, 'ref-kind': 'app', "
@@ -419,8 +418,6 @@ test_parse_autoinstall_file_unsorted (void)
   g_autoptr(GPtrArray) actions = NULL;
   g_autoptr(GPtrArray) skipped_actions = NULL;
   g_autoptr(GError) error = NULL;
-
-  g_setenv ("EOS_UPDATER_TEST_OVERRIDE_ARCHITECTURE", "arch", TRUE);
 
   actions = euu_flatpak_ref_actions_from_data (data, -1, "test", &skipped_actions,
                                                NULL, &error);
@@ -439,7 +436,7 @@ test_parse_autoinstall_file_unsorted (void)
   g_assert_cmpint (action0->ref_count, >=, 1);
   g_assert_cmpint (action0->type, ==, EUU_FLATPAK_REMOTE_REF_ACTION_INSTALL);
   g_assert_cmpint (action0->ref->ref_count, >=, 1);
-  g_assert_cmpstr (action0_ref, ==, "app/org.example.OtherApp/arch/master");
+  g_assert_cmpstr (action0_ref, ==, "app/org.example.OtherApp/x86_64/master");
   g_assert_cmpstr (action0->ref->remote, ==, "eos-apps");
   g_assert_cmpstr (action0->ref->collection_id, ==, "com.endlessm.Apps");
   g_assert_cmpstr (action0->source, ==, "test");
@@ -448,16 +445,11 @@ test_parse_autoinstall_file_unsorted (void)
   g_assert_cmpint (action1->ref_count, >=, 1);
   g_assert_cmpint (action1->type, ==, EUU_FLATPAK_REMOTE_REF_ACTION_INSTALL);
   g_assert_cmpint (action1->ref->ref_count, >=, 1);
-  g_assert_cmpstr (action1_ref, ==, "app/org.example.MyApp/arch/master");
+  g_assert_cmpstr (action1_ref, ==, "app/org.example.MyApp/x86_64/master");
   g_assert_cmpstr (action1->ref->remote, ==, "eos-apps");
   g_assert_cmpstr (action1->ref->collection_id, ==, "com.endlessm.Apps");
   g_assert_cmpstr (action1->source, ==, "test");
   g_assert_cmpint (action1->serial, ==, 2017100100);
-
-  if (old_env_arch)
-    g_setenv ("EOS_UPDATER_TEST_OVERRIDE_ARCHITECTURE", old_env_arch, TRUE);
-  else
-    g_unsetenv ("EOS_UPDATER_TEST_OVERRIDE_ARCHITECTURE");
 }
 
 /* Test that the filters on autoinstall files work correctly. */


### PR DESCRIPTION
This reverts commit 1f6fb8fcb07f9acf7210f5b6376af6f30fbdc89b.

**Don’t merge this**. I want to test if the failure in https://ci.endlessm-sf.com/job/obs-eos-updater-master/216/console is in eos-updater or ostree.