### PR TITLE
src: Improvements to thread safety for apply and fetch operations

### DIFF
--- a/src/eos-updater-poll.c
+++ b/src/eos-updater-poll.c
@@ -513,6 +513,9 @@ handle_poll (EosUpdater            *updater,
         goto bail;
     }
 
+  /* FIXME: Passing the EosUpdaterData *user_data to the worker thread here is
+   * not thread safe.
+   * See: https://phabricator.endlessm.com/T15923 */
   eos_updater_clear_error (updater, EOS_UPDATER_STATE_POLLING);
   task = g_task_new (updater, NULL, metadata_fetch_finished, user_data);
   g_task_set_task_data (task, user_data, NULL);


### PR DESCRIPTION
This does not make things fully thread safe. In particular, the poll
operation is still a complete mess, and the fetch operation still has
some non-thread-safe accesses to the EosUpdaterData struct. The apply
operation should be thread-safe now though.

All the operations (poll, fetch, apply) use a single worker thread each
to do the bulk of their work. These were previously passed pointers to
the EosUpdater and EosUpdaterData structs, which are also used in the
main thread. This was not thread safe.

Fix that by adding a per-operation struct (ApplyData or FetchData) into
which the data needed by the worker thread is copied before the main
thread forks. In the case of the fetch operation, this includes an
OstreeAsyncProgress object, which reports progress data back to the main
thread. This is thread safe, since its callback is scheduled in the main
thread’s default GMainContext.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15923