### PR TITLE
flatpak-updater: add eos-extra-settled.target as pre-requisite

### DIFF
--- a/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
+++ b/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Endless OS Post-Boot Flatpak Installer
-Wants=ostree-remount.service
-After=ostree-remount.service
+Wants=ostree-remount.service eos-extra-settled.target
+After=ostree-remount.service eos-extra-settled.target
 ConditionKernelCommandLine=!eos-updater-disable
 DefaultDependencies=no
 Conflicts=shutdown.target


### PR DESCRIPTION
eos-extra-settled.target is generated with a dependency on the SD
card being mounted at /var/endless-extra on "split" systems which
have their Flatpaks on the SD card. Adding this dependency makes
sure that the Flatpak system installation is ready/accessible
before we try and deploy the Flatpaks - although it has the side
effect that this unit won't complete on systems where the SD card
is missing.

https://phabricator.endlessm.com/T20696