### PR TITLE
docs: Clarify command line format for eos-updater-prepare-volume

### DIFF
--- a/eos-updater-prepare-volume/docs/eos-updater-prepare-volume.8
+++ b/eos-updater-prepare-volume/docs/eos-updater-prepare-volume.8
@@ -9,7 +9,7 @@ eos\-updater\-prepare\-volume — Endless OS Updater USB Drive Preparation Tool
 .SH SYNOPSIS
 .IX Header "SYNOPSIS"
 .\"
-\fBeos\-updater\-prepare\-volume [\-q] \fPvolume-directory\fB [\fPflatpak-ref\fB …]
+\fBeos\-updater\-prepare\-volume [\-q] \fPvolume-directory\fB [\fPcollection\-id ref\fB …]
 .\"
 .SH DESCRIPTION
 .IX Header "DESCRIPTION"
@@ -18,6 +18,11 @@ eos\-updater\-prepare\-volume — Endless OS Updater USB Drive Preparation Tool
 copy of the computer’s Endless OS updates and flatpak apps, so those apps and
 updates can be applied to another computer running Endless OS, bringing it up
 to date.
+.PP
+It will always include a copy of the Endless OS. Any flatpak applications listed
+on the command line will be included. Each app must be specified as a
+collection ID and ref, followed by the collection ID and ref of the next app,
+etc.
 .PP
 The updates will be put in an OSTree repository in the \fB.ostree/repo\fP
 directory on the USB drive. The path of the mounted drive must be passed as the

--- a/eos-updater-prepare-volume/eos-updater-prepare-volume
+++ b/eos-updater-prepare-volume/eos-updater-prepare-volume
@@ -243,8 +243,8 @@ def main():
     parser.add_argument('--quiet', action='store_const', const=True,
                         help='do not print anything; check exit status '
                              'for success')
-    parser.add_argument('flatpak_refs', metavar='FLATPAK-REF', nargs='*',
-                        help='refs of flatpaks to put on the USB drive')
+    parser.add_argument('flatpak_refs', metavar='COLLECTION-ID REF', nargs='*',
+                        help='collection IDs and refs of flatpaks to put on the USB drive')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Hopefully make it a little clearer what format the flatpak refs are
expected in for the apps to copy to the USB stick.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T20926