### PR TITLE
T20958 Fix NULL remote names in refspecs

### DIFF
--- a/src/eos-updater-poll-common.h
+++ b/src/eos-updater-poll-common.h
@@ -144,10 +144,6 @@ gboolean parse_latest_commit (OstreeRepo           *repo,
                               GCancellable         *cancellable,
                               GError              **error);
 
-gboolean get_origin_refspec (OstreeDeployment *booted_deployment,
-                             gchar **out_refspec,
-                             GError **error);
-
 GHashTable *get_hw_descriptors (void);
 
 void metrics_report_successful_poll (EosUpdateInfo *update);


### PR DESCRIPTION
Potential fix for https://phabricator.endlessm.com/T20958. Only compile tested. See the commit messages for details.