### PR TITLE
eos-updater-prepare-volume: Handle empty remote name from parse_refspec

### DIFF
--- a/eos-updater-prepare-volume/eos-updater-prepare-volume
+++ b/eos-updater-prepare-volume/eos-updater-prepare-volume
@@ -107,6 +107,8 @@ class VolumePreparer:
             return None
 
         _, remote_name, ref_name = OSTree.parse_refspec(refspec)
+        if not remote_name:
+            return None
         _, collection_id = self._get_collection_id_for_remote(remote_name)
         if not collection_id:
             return None


### PR DESCRIPTION
As with previous commits, this adds robustness to
eos-updater-prepare-volume in case the origin is not configured
correctly (this is not expected to happen).

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T20958