### PR TITLE
flatpak-installer: modify unit to use After/Requires

### DIFF
--- a/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
+++ b/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Endless OS Post-Boot Flatpak Installer
-Wants=ostree-remount.service eos-extra-settled.target
-After=ostree-remount.service eos-extra-settled.target
+Requires=local-fs.target eos-extra-settled.target
+After=local-fs.target eos-extra-settled.target
 ConditionKernelCommandLine=!eos-updater-disable
 DefaultDependencies=no
 Conflicts=shutdown.target


### PR DESCRIPTION
Upgrade Wants to Requires so the unit can't run without the /var/endless-extra
being settled. Use local-fs.target instead of ostree-remount.service.

https://phabricator.endlessm.com/T20696