### PR TITLE
data: remove non-existent @chown syscall group

### DIFF
--- a/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
+++ b/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
@@ -39,7 +39,7 @@ SystemCallArchitectures=native
 SystemCallErrorNumber=EPERM
 # @network-io is required for logging to the journal to work
 # @privileged is required for certain ostree operations
-SystemCallFilter=~@chown @clock @cpu-emulation @debug @keyring @mount @module @obsolete @raw-io @resources
+SystemCallFilter=~@clock @cpu-emulation @debug @keyring @mount @module @obsolete @raw-io @resources
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I spotted the following in the journal:

    Feb 14 19:33:05 endless systemd[1]:
    [/lib/systemd/system/eos-updater-flatpak-installer.service:42] Don't
    know system call group, ignoring: @chown

The `@` syntax is used to refer to groups of system calls. The list of
known groups is documented in `systemd.exec(5)` and does not include
`@chown`. The `chown` syscall is part of the `@privileged` syscall group,
which per a comment above is deliberately allowed.

The current behaviour is that this service is allowed to invoke `chown`.
I think that's fine given it is also deliberately allowed to invoke much
more serious syscalls.

https://phabricator.endlessm.com/T16682