### PR TITLE
debian: Make eos-updater depend on mogwai-scheduled

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -39,6 +39,7 @@ Architecture: any
 Multi-arch: no
 Depends:
  gir1.2-glib-2.0,
+ mogwai-scheduled,
  python3-gi,
  systemd (>= 200),
  ${misc:Depends},


### PR DESCRIPTION
Since the updater now queries the download scheduler to see if it is
allowed to download, it should require that the scheduler is actually
installed.

Critically, this will pull mogwai-scheduled into the set of packages
installed by default on base images.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T20396