### PR TITLE
eos-updater-flatpak-installer: run after systemd-tmpfiles-setup

### DIFF
--- a/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
+++ b/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
@@ -1,7 +1,10 @@
 [Unit]
 Description=Endless OS Post-Boot Flatpak Installer
-Requires=local-fs.target eos-extra-settled.target
-After=local-fs.target eos-extra-settled.target
+# /home is a symlink to /var/home; /var/home is a symlink to /sysroot/home. The
+# second symlink is created by systemd-tmpfiles. Since we use ProtectHome=yes,
+# we must explicitly order this unit after tmpfiles are created.
+Requires=local-fs.target eos-extra-settled.target systemd-tmpfiles-setup.service
+After=local-fs.target eos-extra-settled.target systemd-tmpfiles-setup.service
 ConditionKernelCommandLine=!eos-updater-disable
 DefaultDependencies=no
 Conflicts=shutdown.target


### PR DESCRIPTION
On unconverted systems, /home is a symlink to /var/home; /var/home is a
symlink to /sysroot/home. The /home -> /var/home symlink is part of the
ostree; the /var/home -> /sysroot/home symlink is managed by
systemd-tmpfiles:

    /usr/lib/tmpfiles.d/ostree.conf:L /var/home - - - - ../sysroot/home
    /usr/lib/tmpfiles.d/home.conf:Q /home 0755 - - -

(The home.conf line for /home comes from the systemd package, and causes the
"already exists and is not a directory" warning below.)

With the current ordering constraints, these two services may (and do)
run concurrently. This, in combination with ProtectHome=yes in this
unit, causes launching this service to fail:

    systemd[1]: Starting Endless OS Post-Boot Flatpak Installer...
    systemd[1]: Starting Create Volatile Files and Directories...
    systemd-tmpfiles[392]: "/home" already exists and is not a directory.
    systemd[386]: eos-updater-flatpak-installer.service: Failed at step NAMESPACE spawning /usr/lib/x86_64-linux-gnu/eos-updater-flatpak-installer: No such file or directory
    systemd[1]: eos-updater-flatpak-installer.service: Main process exited, code=exited, status=226/NAMESPACE
    systemd[1]: Failed to start Endless OS Post-Boot Flatpak Installer.
    systemd[1]: eos-updater-flatpak-installer.service: Unit entered failed state.
    systemd[1]: eos-updater-flatpak-installer.service: Failed with result 'exit-code'.
    systemd-tmpfiles[392]: Cannot set file attribute for '/var/log/journal', value=0x00800000, mask=0x00800000: Operation not supported
    systemd-tmpfiles[392]: Cannot set file attribute for '/var/log/journal/b6636faad27b47d8a8c9b50f359b9b7e', value=0x00800000, mask=0x00800000: Operation not supported
    systemd[1]: Started Create Volatile Files and Directories.

On my test system, this is reproducible on 100% of boots: this service
never successfully runs after an upgrade. (A process of bisecting all
the sandboxing flags in this file confirms that it is ProtectHome=yes
that triggers this problem.)

Avoid this issue by forcing this service to start after
systemd-tmpfiles-setup.

https://phabricator.endlessm.com/T21221