### PR TITLE
eos-updater-ctl: right-align property names

### DIFF
--- a/src/eos-updater-ctl
+++ b/src/eos-updater-ctl
@@ -69,12 +69,17 @@ def signal_emitted(proxy, signal, parameters):
 
 def dump_daemon_properties(proxy):
     print("======= Properties =======")
+    property_names = proxy.get_cached_property_names()
+    width = max(len(x) for x in property_names)
+
     s = proxy.get_cached_property("State").get_uint32()
-    print("State: " + UPDATER_STATES[s])
+    print("{:>{}}: {}".format("State", width, UPDATER_STATES[s]))
 
     for x in proxy.get_cached_property_names():
         if x != "State":
-            print(" " + x + ": " + str(proxy.get_cached_property(x)))
+            value = proxy.get_cached_property(x)
+            print("{:>{}}: {}".format(x, width, value)
+
     print("")
 
 


### PR DESCRIPTION
Before:

    ======= Properties =======
    State: Ready
     CurrentID: '4b4e0fb003bae61d18152376a597675063c2dd1e3561ffe4eec8cd637f533f62'
     DownloadSize: int64 0
     DownloadedBytes: int64 0
     ErrorCode: uint32 0
     ErrorMessage: ''
     ErrorName: ''
     FullDownloadSize: int64 0
     FullUnpackedSize: int64 0
     OriginalRefspec: ''
     UnpackedSize: int64 0
     UpdateID: ''
     UpdateLabel: ''
     UpdateMessage: ''
     UpdateRefspec: ''

After:

    ======= Properties =======
               State: Ready
           CurrentID: '4b4e0fb003bae61d18152376a597675063c2dd1e3561ffe4eec8cd637f533f62'
        DownloadSize: int64 0
     DownloadedBytes: int64 0
           ErrorCode: uint32 0
        ErrorMessage: ''
           ErrorName: ''
    FullDownloadSize: int64 0
    FullUnpackedSize: int64 0
     OriginalRefspec: ''
        UnpackedSize: int64 0
            UpdateID: ''
         UpdateLabel: ''
       UpdateMessage: ''
       UpdateRefspec: ''

I think this is easier to skim, and in particular makes it a bit easier to eyeball the DownloadedBytes / DownloadSize ratio.