### PR TITLE
eos-updater-ctl: fix syntax

### DIFF
--- a/src/eos-updater-ctl
+++ b/src/eos-updater-ctl
@@ -78,7 +78,7 @@ def dump_daemon_properties(proxy):
     for x in proxy.get_cached_property_names():
         if x != "State":
             value = proxy.get_cached_property(x)
-            print("{:>{}}: {}".format(x, width, value)
+            print("{:>{}}: {}".format(x, width, value))
 
     print("")
 


### PR DESCRIPTION
I broke this in #174. Sorry.

Any preferred way to check this at build time? One way would be to add a test case which just runs s `python3 -m py_compile eos-updater-ctl`. Another way would be to build-depend on a linter and run that. A third way would be to rename to `eos-updater-ctl.in` and do:

    eos-updater-ctl: eos-updater-ctl.in
    	$(AM_V_GEN) python3 -m py_compile $< && cp -a $< $@