### PR TITLE
Ensure eos-updater-ctl compiles, by running it

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,6 +31,7 @@ Build-Depends:
  libsystemd-dev,
  ostree (>= 2017.12),
  ostree-tests (>= 2017.6),
+ python3-flake8,
  python3-gi,
 
 Package: eos-updater

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -154,4 +154,8 @@ EXTRA_DIST += \
 	$(eos_updater_resource_deps) \
 	$(NULL)
 
+check-local: eos-updater-ctl.flake8
+%.flake8: %
+	$(AM_V_GEN) python3 -m flake8 $<
+
 -include $(top_srcdir)/git.mk

--- a/src/eos-updater-ctl
+++ b/src/eos-updater-ctl
@@ -60,7 +60,7 @@ EOS_UPDATER_CONFS = [
 current_proxy = None
 
 
-def signal_emitted(proxy, signal, parameters):
+def signal_emitted(proxy, sender, signal, parameters):
     if signal != "StateChanged":
         return
     state = UPDATER_STATES[parameters[0]]
@@ -78,6 +78,10 @@ def dump_daemon_properties(proxy):
     print("")
 
 
+def g_properties_changed_cb(proxy, changed, invalidated):
+    dump_daemon_properties(proxy)
+
+
 def name_appeared_cb(connection, name, name_owner):
     global current_proxy
 
@@ -92,12 +96,8 @@ def name_appeared_cb(connection, name, name_owner):
                                    'com.endlessm.Updater',
                                    None)  # cancellable
 
-    proxy.connect('g-properties-changed',
-                  lambda proxy, changed, invalidated, user_data: \
-                      dump_daemon_properties(proxy), None)
-    proxy.connect('g-signal',
-                  lambda proxy, sender, signal, parameters, user_data: \
-                      signal_emitted(proxy, signal, parameters), None)
+    proxy.connect('g-properties-changed', g_properties_changed_cb)
+    proxy.connect('g-signal', signal_emitted, None)
 
     dump_daemon_properties(proxy)
     current_proxy = proxy

--- a/src/eos-updater-ctl
+++ b/src/eos-updater-ctl
@@ -15,9 +15,9 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU Lesser General Public
-# License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 
 import argparse
 import os

--- a/src/eos-updater-ctl
+++ b/src/eos-updater-ctl
@@ -142,7 +142,8 @@ def command_dbus(command, block, quiet=False, parameters=None):
     # Call the method, wait for the updater to enter the expected in-progress
     # state; then wait for it to leave that state again (either to Error, or
     # the next state corresponding to the method).
-    proxy.call_sync('com.endlessm.Updater.' + function_name, parameters, 0, -1, None)
+    qualified_method_name = 'com.endlessm.Updater.' + function_name
+    proxy.call_sync(qualified_method_name, parameters, 0, -1, None)
 
     cancelled = False
     seen_in_progress_state = False


### PR DESCRIPTION
This is implemented as a build step, not a test, to increase the likelihood of it being run. I looked at adding it as an installed test in tests/ but installed tests are not run at build time.

I also took the liberty of fixing the (very few) warnings raised by flake8, my conservative Python linter of choice. While it does have some (IMO reasonable) opinions about line length and indentation, it can also detect many cases of (for example) referencing variables before they are defined. I'd suggest making `python3-flake8` a build-dependency and running it against `eos-updater-ctl` rather than invoking `eos-updater-ctl --help`, but I have not since this has already been deemed unpopular!