### PR TITLE
Minor fixes to eos-updater-ctl

### DIFF
--- a/src/eos-updater-ctl
+++ b/src/eos-updater-ctl
@@ -68,8 +68,11 @@ def signal_emitted(proxy, sender, signal, parameters):
 
 
 def dump_daemon_properties(proxy):
-    print("======= Properties =======")
     property_names = proxy.get_cached_property_names()
+    if not property_names:
+        return
+
+    print("======= Properties =======")
     width = max(len(x) for x in property_names)
 
     s = proxy.get_cached_property("State").get_uint32()

--- a/src/eos-updater-ctl
+++ b/src/eos-updater-ctl
@@ -105,7 +105,7 @@ def name_appeared_cb(connection, name, name_owner):
                                    None)  # cancellable
 
     proxy.connect('g-properties-changed', g_properties_changed_cb)
-    proxy.connect('g-signal', signal_emitted, None)
+    proxy.connect('g-signal', signal_emitted)
 
     dump_daemon_properties(proxy)
     current_proxy = proxy


### PR DESCRIPTION
This fixes a warning which @GeorgesStavracas was seeing when using `eos-updater-ctl monitor`.