### PR TITLE
Provide the update version property

### DIFF
--- a/src/com.endlessm.Updater.xml
+++ b/src/com.endlessm.Updater.xml
@@ -21,6 +21,7 @@
     <property name="CurrentID"        type="s" access="read"/>
     <property name="UpdateLabel"      type="s" access="read"/>
     <property name="UpdateMessage"    type="s" access="read"/>
+    <property name="Version"          type="s" access="read"/>
     <property name="DownloadSize"     type="x" access="read"/>
     <property name="DownloadedBytes"  type="x" access="read"/>
     <property name="UnpackedSize"     type="x" access="read"/>

--- a/src/eos-updater-poll-common.h
+++ b/src/eos-updater-poll-common.h
@@ -73,6 +73,7 @@ struct _EosUpdateInfo
   GVariant *commit;
   gchar *new_refspec;
   gchar *old_refspec;
+  gchar *version;
   gchar **urls;
 
   OstreeRepoFinderResult **results;  /* (owned) (array zero-terminated=1) */
@@ -83,6 +84,7 @@ eos_update_info_new (const gchar *csum,
                      GVariant *commit,
                      const gchar *new_refspec,
                      const gchar *old_refspec,
+                     const gchar *version,
                      const gchar * const *urls,
                      OstreeRepoFinderResult **results);
 
@@ -114,6 +116,7 @@ gboolean fetch_latest_commit (OstreeRepo *repo,
                               const gchar *url_override,
                               gchar **out_checksum,
                               gchar **out_new_refspec,
+                              gchar **out_version,
                               GError **error);
 
 gboolean parse_latest_commit (OstreeRepo           *repo,
@@ -122,6 +125,7 @@ gboolean parse_latest_commit (OstreeRepo           *repo,
                               gchar               **out_checksum,
                               gchar               **out_new_refspec,
                               OstreeCollectionRef **out_new_collection_ref,
+                              gchar               **out_version,
                               GCancellable         *cancellable,
                               GError              **error);
 

--- a/src/eos-updater-poll.c
+++ b/src/eos-updater-poll.c
@@ -268,6 +268,7 @@ metadata_fetch_new (OstreeRepo    *repo,
   g_auto(OstreeRepoFinderResultv) results = NULL;
   g_autoptr(EosUpdateInfo) info = NULL;
   g_autofree gchar *checksum = NULL;
+  g_autofree gchar *version = NULL;
   g_autoptr(GVariant) commit = NULL;
   g_autofree gchar *booted_refspec = NULL, *new_refspec = NULL;
   g_autoptr(OstreeCollectionRef) collection_ref_to_upgrade_on_for_booted_deployment = NULL, new_collection_ref = NULL;
@@ -354,7 +355,8 @@ metadata_fetch_new (OstreeRepo    *repo,
 
       /* Parse the commit and check there’s no redirection to a new ref. */
       if (!parse_latest_commit (repo, upgrade_refspec, &redirect_followed,
-                                &checksum, &new_refspec, NULL, cancellable, error))
+                                &checksum, &new_refspec, NULL, &version,
+                                cancellable, error))
         return NULL;
 
       if (new_refspec != NULL)
@@ -372,7 +374,7 @@ metadata_fetch_new (OstreeRepo    *repo,
     return NULL;
 
   info = eos_update_info_new (checksum, commit,
-                              upgrade_refspec, booted_refspec,
+                              upgrade_refspec, booted_refspec, version,
                               NULL, g_steal_pointer (&results));
   metrics_report_successful_poll (info);
 
@@ -390,6 +392,7 @@ metadata_fetch_from_main (OstreeRepo     *repo,
 {
   g_autofree gchar *refspec = NULL;
   g_autofree gchar *new_refspec = NULL;
+  g_autofree gchar *version = NULL;
   g_autoptr(EosUpdateInfo) info = NULL;
   g_autofree gchar *checksum = NULL;
   g_autoptr(GVariant) commit = NULL;
@@ -406,6 +409,7 @@ metadata_fetch_from_main (OstreeRepo     *repo,
                             NULL,
                             &checksum,
                             &new_refspec,
+                            &version,
                             error))
     return FALSE;
 
@@ -417,6 +421,7 @@ metadata_fetch_from_main (OstreeRepo     *repo,
                                 commit,
                                 new_refspec,
                                 refspec,
+                                version,
                                 NULL,
                                 NULL);
 

--- a/test-common/utils.c
+++ b/test-common/utils.c
@@ -2712,3 +2712,40 @@ eos_test_has_ostree_boot_id (void)
   boot_id_file = g_file_new_for_path ("/proc/sys/kernel/random/boot_id");
   return g_file_query_exists (boot_id_file, NULL);
 }
+
+/**
+ * eos_test_add_metadata_for_commit:
+ *
+ * Adds the provided metadata (@key and @value) for the given @commit_number
+ * to the passed @commit_metadata hash table. If the latter is %NULL, it will
+ * create it with the right types and assign it to @commit_metadata.
+ */
+void
+eos_test_add_metadata_for_commit (GHashTable **commit_metadata,
+                                  guint commit_number,
+                                  const gchar *key,
+                                  const gchar *value)
+{
+  GHashTable *metadata = NULL;
+
+  if (*commit_metadata == NULL)
+    *commit_metadata = g_hash_table_new_full (g_direct_hash,
+                                              g_direct_equal,
+                                              NULL,
+                                              (GDestroyNotify) g_hash_table_unref);
+
+  metadata = g_hash_table_lookup (*commit_metadata,
+                                  GUINT_TO_POINTER (commit_number));
+  if (metadata == NULL)
+    {
+      metadata = g_hash_table_new_full (g_str_hash,
+                                        g_str_equal,
+                                        g_free,
+                                        g_free);
+      g_hash_table_insert (*commit_metadata,
+                           GUINT_TO_POINTER (commit_number),
+                           metadata);
+    }
+
+  g_hash_table_insert (metadata, g_strdup (key), g_strdup (value));
+}

--- a/test-common/utils.h
+++ b/test-common/utils.h
@@ -294,4 +294,9 @@ GFile * get_flatpak_autoinstall_override_dir (GFile *client_root);
 
 GFile * eos_test_get_flatpak_build_dir_for_updater_dir (GFile *updater_dir);
 
+void eos_test_add_metadata_for_commit (GHashTable **commit_metadata,
+                                       guint commit_number,
+                                       const gchar *key,
+                                       const gchar *value);
+
 G_END_DECLS


### PR DESCRIPTION
We now have the update version added to the commit metadata, so this
patch retrieves it and also adds the matching property to the dbus
interface.

https://phabricator.endlessm.com/T21610