### PR TITLE
systemd: Remove the @chown system call group from the blacklist

### DIFF
--- a/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
+++ b/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
@@ -41,8 +41,8 @@ RestrictRealtime=yes
 SystemCallArchitectures=native
 SystemCallErrorNumber=EPERM
 # @network-io is required for logging to the journal to work
-# @privileged is required for certain ostree operations
-SystemCallFilter=~@chown @clock @cpu-emulation @debug @keyring @mount @module @obsolete @raw-io @resources
+# @privileged and @chown are required for certain ostree operations
+SystemCallFilter=~@clock @cpu-emulation @debug @keyring @mount @module @obsolete @raw-io @resources
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As identified, this is required for certain ostree operations
to work.

https://phabricator.endlessm.com/T21751