### PR TITLE
libeuu: Fix using EuuConfigFile with just the GResource

### DIFF
--- a/libeos-updater-util/config.c
+++ b/libeos-updater-util/config.c
@@ -370,7 +370,7 @@ euu_config_file_get_file_for_key (EuuConfigFile  *self,
     }
 
   /* Not found? */
-  if (i >= self->n_paths)
+  if (i > self->n_paths)
     {
       key_file = NULL;
       path = NULL;

--- a/libeos-updater-util/tests/config.c
+++ b/libeos-updater-util/tests/config.c
@@ -240,6 +240,28 @@ test_config_file_nonexistent (Fixture       *fixture,
   g_assert_cmpuint (loaded_file, ==, 1);
 }
 
+/* Test that if none of the files exist, but the GResource does, we successfully
+ * use that.. */
+static void
+test_config_file_resource_only (Fixture       *fixture,
+                                gconstpointer  user_data G_GNUC_UNUSED)
+{
+  g_autoptr(GError) error = NULL;
+  g_autoptr(EuuConfigFile) config = NULL;
+  const gchar * const paths[] =
+    {
+      fixture->key_file_nonexistent_path,
+      NULL
+    };
+  guint loaded_file;
+
+  config = euu_config_file_new (paths, fixture->default_resource, fixture->default_path);
+
+  loaded_file = euu_config_file_get_uint (config, "Test", "File", 0, G_MAXUINT, &error);
+  g_assert_no_error (error);
+  g_assert_cmpuint (loaded_file, ==, 1000);
+}
+
 /* Test that if no configuration files are found, we abort. */
 static void
 test_config_file_fallback_per_file (Fixture       *fixture,
@@ -348,6 +370,8 @@ main (int   argc,
               test_config_file_invalid, teardown);
   g_test_add ("/config/nonexistent", Fixture, NULL, setup,
               test_config_file_nonexistent, teardown);
+  g_test_add ("/config/resource-only", Fixture, NULL, setup,
+              test_config_file_resource_only, teardown);
   g_test_add ("/config/fallback/per-file", Fixture, NULL, setup,
               test_config_file_fallback_per_file, teardown);
   g_test_add ("/config/fallback/per-key", Fixture, NULL, setup,


### PR DESCRIPTION
If loading an EuuConfigFile with a GResource, but none of the listed
files existing on the file system, it would hit an assertion failure.
Fix the special case handling of the GResource so that this works.

Adapted from a patch in https://phabricator.endlessm.com/T21619.

Signed-off-by: Philip Withnall <withnall@endlessm.com>