### PR TITLE
docs: Fix an erroneous reference to --mode=apply

### DIFF
--- a/eos-updater-flatpak-installer/docs/eos-updater-flatpak-installer.8
+++ b/eos-updater-flatpak-installer/docs/eos-updater-flatpak-installer.8
@@ -94,8 +94,8 @@ The \fBcheck\fP operation found an inconsistency. Only returned with
 .\"
 .IP "4" 4
 .IX Item "4"
-The \fBapply\fP operation failed to apply one or more actions. Only returned
-with \fB\-\-mode=apply\fP.
+The \fBperform\fP operation failed to apply one or more actions. Only returned
+with \fB\-\-mode=perform\fP.
 .\"
 .SH "FILES"
 .IX Header "FILES"


### PR DESCRIPTION
In eos-updater-flatpak-installer.8, there's a reference to an "apply"
mode but the mode is actually called "perform".