### PR TITLE
docs: Fix eos-updater-flatpak-autoinstall.d.5 page

### DIFF
--- a/eos-updater-flatpak-installer/docs/eos-updater-flatpak-autoinstall.d.5
+++ b/eos-updater-flatpak-installer/docs/eos-updater-flatpak-autoinstall.d.5
@@ -51,7 +51,7 @@ increasing counter within the domain of that filename.
 .IP "\fIFlatpak Ref Action\fP"
 .IX Item "Flatpak Ref Action"
 A JSON object containing, at minimum, properties \fBaction\fP,
-\fBserial\fP, \branch\fP and optionally \fBfilters\fP. Valid values for
+\fBserial\fP, \fBbranch\fP and optionally \fBfilters\fP. Valid values for
 \fBaction\fP are \fBinstall\fP, \fBupdate\fP and \fBuninstall\fP,
 each having their own required properties as explained below. The only valid
 type for \fBserial\fP, is an integer, which must be monotonically


### PR DESCRIPTION
The branch addition in 0f5d2770de8bad982187bdaeda69b485a7ba5658 was
supposed to be bolded, but the inline \fB directive was not written
correctly.