### PR TITLE
Add autoinstall flatpaks to update USBs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -487,7 +487,7 @@ EXTRA_DIST += m4/introspection.m4
 if HAVE_INTROSPECTION
 # GObject Introspection for libeos-updater-util
 libeos-updater-util/EosUpdaterUtil-@EUU_API_VERSION@.gir: libeos-updater-util/libeos-updater-util-@EUU_API_VERSION@.la
-libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_INCLUDES = GObject-2.0 Gio-2.0 Flatpak-1.0
+libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_INCLUDES = GObject-2.0 Gio-2.0 Flatpak-1.0 OSTree-1.0
 libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_CFLAGS = \
 	$(libeos_updater_util_libeos_updater_util_@EUU_API_VERSION@_la_CPPFLAGS) \
 	$(libeos_updater_util_libeos_updater_util_@EUU_API_VERSION@_la_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -487,7 +487,7 @@ EXTRA_DIST += m4/introspection.m4
 if HAVE_INTROSPECTION
 # GObject Introspection for libeos-updater-util
 libeos-updater-util/EosUpdaterUtil-@EUU_API_VERSION@.gir: libeos-updater-util/libeos-updater-util-@EUU_API_VERSION@.la
-libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_INCLUDES = GObject-2.0 Gio-2.0
+libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_INCLUDES = GObject-2.0 Gio-2.0 Flatpak-1.0
 libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_CFLAGS = \
 	$(libeos_updater_util_libeos_updater_util_@EUU_API_VERSION@_la_CPPFLAGS) \
 	$(libeos_updater_util_libeos_updater_util_@EUU_API_VERSION@_la_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -508,8 +508,8 @@ libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_SCANNERFLAGS = \
 INTROSPECTION_GIRS += libeos-updater-util/EosUpdaterUtil-@EUU_API_VERSION@.gir
 
 # GObject Introspection for libeos-updater-flatpak-installer
-libeos-updater-flatpak-installer/EosUpdaterFlatpakInstaller-@EUFI_API_VERSION@.gir: libeos-updater-flatpak-installer/libeos-updater-flatpak-installer-@EUFI_API_VERSION@.la
-libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_gir_INCLUDES = GObject-2.0 Gio-2.0 Flatpak-1.0
+libeos-updater-flatpak-installer/EosUpdaterFlatpakInstaller-@EUFI_API_VERSION@.gir: libeos-updater-flatpak-installer/libeos-updater-flatpak-installer-@EUFI_API_VERSION@.la libeos-updater-util/EosUpdaterUtil-@EUU_API_VERSION@.gir
+libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_gir_INCLUDES = GObject-2.0 Gio-2.0 Flatpak-1.0 EosUpdaterUtil-0
 libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_gir_CFLAGS = \
 	$(STD_CFLAGS) \
 	$(EOS_UPDATER_FLATPAK_INSTALLER_CFLAGS) \
@@ -520,6 +520,7 @@ libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_g
 libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_gir_NAMESPACE = EosUpdaterFlatpakInstaller
 libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_gir_SCANNERFLAGS = \
 	$(WARN_SCANNERFLAGS) \
+	--add-include-path=$(top_builddir)/libeos-updater-util \
 	--nsversion=@EUFI_API_VERSION@ \
 	--c-include="libeos-updater-flatpak-installer/installer.h" \
 	--identifier-prefix=Eufi \
@@ -527,6 +528,7 @@ libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_g
 	-I$(top_srcdir) \
 	$(NULL)
 
+INTROSPECTION_COMPILER_ARGS += --includedir=$(top_builddir)/libeos-updater-util
 INTROSPECTION_GIRS += libeos-updater-flatpak-installer/EosUpdaterFlatpakInstaller-@EUFI_API_VERSION@.gir
 
 girdir = $(datadir)/gir-1.0

--- a/Makefile.am
+++ b/Makefile.am
@@ -492,7 +492,7 @@ libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_CFLAGS = \
 	$(libeos_updater_util_libeos_updater_util_@EUU_API_VERSION@_la_CPPFLAGS) \
 	$(libeos_updater_util_libeos_updater_util_@EUU_API_VERSION@_la_CFLAGS)
 libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_FILES = \
-	$(libeos_updater_util_libeos_updater_util_@EUU_API_VERSION@_la_SOURCES)
+	$(filter-out %-private.h,$(libeos_updater_util_libeos_updater_util_@EUU_API_VERSION@_la_SOURCES))
 libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_LIBS = libeos-updater-util/libeos-updater-util-@EUU_API_VERSION@.la
 libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_NAMESPACE = EosUpdaterUtil
 libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_SCANNERFLAGS = \

--- a/eos-updater-flatpak-installer/main.c
+++ b/eos-updater-flatpak-installer/main.c
@@ -125,7 +125,6 @@ main (int    argc,
   g_autoptr(GOptionContext) context = NULL;
   g_autoptr(FlatpakInstallation) installation = NULL;
   const gchar *resolved_mode = NULL;
-  const gchar *pending_flatpak_deployments_state_path = euu_pending_flatpak_deployments_state_path ();
   EosUpdaterInstallerMode parsed_mode;
 
   g_autofree gchar *mode = NULL;
@@ -208,7 +207,6 @@ main (int    argc,
             return EXIT_OK;
 
           if (!eufi_check_ref_actions_applied (installation,
-                                               pending_flatpak_deployments_state_path,
                                                squashed_ref_actions_to_check,
                                                &error))
             return fail (EXIT_CHECK_FAILED,

--- a/eos-updater-prepare-volume/docs/eos-updater-prepare-volume.8
+++ b/eos-updater-prepare-volume/docs/eos-updater-prepare-volume.8
@@ -19,10 +19,12 @@ copy of the computer’s Endless OS updates and flatpak apps, so those apps and
 updates can be applied to another computer running Endless OS, bringing it up
 to date.
 .PP
-It will always include a copy of the Endless OS. Any flatpak applications listed
-on the command line will be included. Each app must be specified as a
-collection ID and ref, followed by the collection ID and ref of the next app,
-etc.
+It will always include a copy of the Endless OS. Any flatpak applications that
+have been configured to autoinstall upon update will also be included
+unconditionally (see \fBeos\-updater-flatpak-installer\fP(8)). Additionally,
+any apps listed on the command line will be included. Each app must be
+specified as a collection ID and ref, followed by the collection ID and ref of
+the next app, etc.
 .PP
 The updates will be put in an OSTree repository in the \fB.ostree/repo\fP
 directory on the USB drive. The path of the mounted drive must be passed as the

--- a/eos-updater-prepare-volume/eos-updater-prepare-volume
+++ b/eos-updater-prepare-volume/eos-updater-prepare-volume
@@ -90,7 +90,8 @@ class VolumePreparer:
         """Get the collection–ref tuple for the booted OS, or None."""
         deployment = self.sysroot.get_booted_deployment()
         if not deployment:
-            if 'EOS_UPDATER_TEST_UPDATER_DEPLOYMENT_FALLBACK' not in os.environ:
+            if 'EOS_UPDATER_TEST_UPDATER_DEPLOYMENT_FALLBACK' not in \
+               os.environ:
                 return None
 
             deployments = self.sysroot.get_deployments()
@@ -200,7 +201,8 @@ class VolumePreparer:
                                     (collection_id, ref)
                                     for (collection_id, ref) in invalid_refs]))
             return self.__fail(self.EXIT_INVALID_ARGUMENTS,
-                               'Invalid flatpak collection–refs: %s' % refs_list)
+                               'Invalid flatpak collection–refs: %s' %
+                               refs_list)
 
         # FIXME: Do we also want to pull in related refs, like locales?
         # Currently, they can be listed explicitly on the command line.
@@ -246,7 +248,8 @@ def main():
                         help='do not print anything; check exit status '
                              'for success')
     parser.add_argument('flatpak_refs', metavar='COLLECTION-ID REF', nargs='*',
-                        help='collection IDs and refs of flatpaks to put on the USB drive')
+                        help='collection IDs and refs of flatpaks to put on '
+                             'the USB drive')
 
     args = parser.parse_args()
 

--- a/eos-updater-prepare-volume/eos-updater-prepare-volume
+++ b/eos-updater-prepare-volume/eos-updater-prepare-volume
@@ -27,7 +27,9 @@ import gi
 gi.require_version('Flatpak', '1.0')
 gi.require_version('GLib', '2.0')
 gi.require_version('OSTree', '1.0')
+gi.require_version('EosUpdaterUtil', '0')
 from gi.repository import Flatpak, GLib, OSTree  # noqa
+from gi.repository import EosUpdaterUtil  # noqa
 
 
 class VolumePreparer:
@@ -174,6 +176,27 @@ class VolumePreparer:
 
         return runtimes
 
+    def _get_autoinstall_flatpaks(self):
+        """
+        Read all the autoinstall lists (see eos-updater-flatpak-installer(8))
+        and return a set of the flatpaks listed as needing an install or
+        upgrade. Load the set irrespective of the state of the autoinstall
+        counter on this system, since whichever system the USB drive is used on
+        might have a different counter value.
+        """
+        autoinstalls = set()
+
+        applied_actions = EosUpdaterUtil.flatpak_ref_actions_from_paths(None)
+
+        for filename, actions in applied_actions.items():
+            for action in actions:
+                if action.type != \
+                   EosUpdaterUtil.FlatpakRemoteRefActionType.UNINSTALL:
+                    autoinstalls.add((action.ref.collection_id,
+                                      action.ref.ref.format_ref()))
+
+        return autoinstalls
+
     def prepare_volume(self):
         # We need to be root in order to read all the files in the OSTree repo
         # (unless we’re running the unit tests). */
@@ -192,7 +215,7 @@ class VolumePreparer:
         # Work out which collection–refs we want on the USB stick. Each one is
         # a collection ID followed by a ref name.
         refs_iter = iter(self.flatpak_refs)
-        flatpak_collection_refs = list(zip(refs_iter, refs_iter))
+        flatpak_collection_refs = set(zip(refs_iter, refs_iter))
         invalid_refs = [collection_ref
                         for collection_ref in flatpak_collection_refs
                         if not self._validate_flatpak_ref(collection_ref)]
@@ -204,10 +227,20 @@ class VolumePreparer:
                                'Invalid flatpak collection–refs: %s' %
                                refs_list)
 
+        # Add the flatpaks that will be installed by
+        # eos-updater-flatpak-installer.
+        try:
+            autoinstall_collection_refs = self._get_autoinstall_flatpaks()
+        except GLib.Error as e:
+            return self.__fail(self.EXIT_FAILED,
+                               'Failed to list autoinstall flatpaks to add to '
+                               'the USB drive')
+
         # FIXME: Do we also want to pull in related refs, like locales?
         # Currently, they can be listed explicitly on the command line.
         runtime_collection_refs = \
-            self._get_runtimes_for_flatpaks(flatpak_collection_refs)
+            self._get_runtimes_for_flatpaks(flatpak_collection_refs |
+                                            autoinstall_collection_refs)
 
         os_collection_ref = self._get_os_collection_ref()
         if not os_collection_ref:
@@ -218,6 +251,7 @@ class VolumePreparer:
         collection_refs = \
             [os_collection_ref] + \
             list(flatpak_collection_refs) + \
+            list(autoinstall_collection_refs) + \
             list(runtime_collection_refs)
 
         # Eliminate duplicates.

--- a/libeos-updater-flatpak-installer/determine-flatpak-actions.c
+++ b/libeos-updater-flatpak-installer/determine-flatpak-actions.c
@@ -88,7 +88,7 @@ flatpak_ref_actions_and_progresses (GStrv        directories_to_search,
  * by eos-updater-flatpak-autoinstall.d(5)) and find actions that should
  * already have been applied.
  *
- * Returns: (element-type filename EuuFlatpakRemoteRefAction) (transfer full):
+ * Returns: (element-type filename GPtrArray<EuuFlatpakRemoteRefAction>) (transfer container):
  * a mapping from file names to actions that should have been applied
  */
 GHashTable *
@@ -117,7 +117,7 @@ eufi_determine_flatpak_ref_actions_to_check (GStrv    directories_to_search,
  * by eos-updater-flatpak-autoinstall.d(5)) and find actions that should
  * be applied.
  *
- * Returns: (element-type filename EuuFlatpakRemoteRefAction) (transfer full):
+ * Returns: (element-type filename GPtrArray<EuuFlatpakRemoteRefAction>) (transfer container):
  * a mapping from file names to actions that should be applied
  */
 GHashTable *

--- a/libeos-updater-flatpak-installer/installer.h
+++ b/libeos-updater-flatpak-installer/installer.h
@@ -29,7 +29,6 @@
 G_BEGIN_DECLS
 
 gboolean eufi_check_ref_actions_applied (FlatpakInstallation  *installation,
-                                         const gchar          *pending_flatpak_deployments_state_path,
                                          GPtrArray            *actions,
                                          GError              **error);
 

--- a/libeos-updater-flatpak-installer/perform-flatpak-actions.c
+++ b/libeos-updater-flatpak-installer/perform-flatpak-actions.c
@@ -376,7 +376,11 @@ eufi_apply_flatpak_ref_actions (FlatpakInstallation       *installation,
   gsize i;
   g_autoptr(GHashTable) new_progresses = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, NULL);
 
-  g_return_val_if_fail (installation != NULL, FALSE);
+  g_return_val_if_fail (FLATPAK_IS_INSTALLATION (installation), FALSE);
+  g_return_val_if_fail (state_counter_path != NULL, FALSE);
+  g_return_val_if_fail (actions != NULL, FALSE);
+  g_return_val_if_fail (mode != EU_INSTALLER_MODE_CHECK, FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
   for (i = 0; i < actions->len; ++i)
     {

--- a/libeos-updater-flatpak-installer/perform-flatpak-actions.c
+++ b/libeos-updater-flatpak-installer/perform-flatpak-actions.c
@@ -349,10 +349,26 @@ update_counter_complain_on_error (const gchar *failing_name,
                                                                   error);
 }
 
+/**
+ * eufi_apply_flatpak_ref_actions:
+ * @installation: a #FlatpakInstallation
+ * @state_counter_path: (type filename): path to the counter that records what
+ *    actions have been applied
+ * @actions: (element-type EuuFlatpakRemoteRefAction): actions to apply
+ * @mode: the #EosUpdaterInstallerMode
+ * @pull: any #EosUpdaterInstallerFlags
+ * @error: return location for a #GError, or %NULL
+ *
+ * Apply the actions @actions, and update the state counter at
+ * @state_counter_path to the last successfully applied action. The actions are
+ * only actually performed if @mode is set to %EU_INSTALLER_MODE_PERFORM.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ */
 gboolean
 eufi_apply_flatpak_ref_actions (FlatpakInstallation       *installation,
                                 const gchar               *state_counter_path,
-                                GPtrArray                 *actions  /* (element-type EuuFlatpakRemoteRefAction) */,
+                                GPtrArray                 *actions,
                                 EosUpdaterInstallerMode    mode,
                                 EosUpdaterInstallerFlags   flags,
                                 GError                   **error)
@@ -444,9 +460,22 @@ check_if_flatpak_is_installed (FlatpakInstallation        *installation,
   return TRUE;
 }
 
+/**
+ * eufi_check_ref_actions_applied:
+ * @installation: a #FlatpakInstallation
+ * @actions: (element-type EuuFlatpakRemoteRefAction): actions to apply
+ * @error: return location for a #GError, or %NULL
+ *
+ * Check each action in @actions to see if its operation has been applied. In
+ * truth only installs and updates are checked; there's not currently a way to
+ * check update operations. If some of the actions haven't been successfully
+ * applied, @error will be set with a helpful message.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ */
 gboolean
 eufi_check_ref_actions_applied (FlatpakInstallation  *installation,
-                                GPtrArray            *actions  /* (element-type EuuFlatpakRemoteRefAction) */,
+                                GPtrArray            *actions,
                                 GError              **error)
 {
   g_autoptr(GError) local_error = NULL;

--- a/libeos-updater-flatpak-installer/perform-flatpak-actions.c
+++ b/libeos-updater-flatpak-installer/perform-flatpak-actions.c
@@ -446,7 +446,6 @@ check_if_flatpak_is_installed (FlatpakInstallation        *installation,
 
 gboolean
 eufi_check_ref_actions_applied (FlatpakInstallation  *installation,
-                                const gchar          *pending_flatpak_deployments_state_path,
                                 GPtrArray            *actions  /* (element-type EuuFlatpakRemoteRefAction) */,
                                 GError              **error)
 {

--- a/libeos-updater-flatpak-installer/tests/installer.c
+++ b/libeos-updater-flatpak-installer/tests/installer.c
@@ -440,7 +440,6 @@ test_flatpak_check_succeeds_if_actions_are_up_to_date (FlatpakDeploymentsFixture
   /* Run the checker - it should return true because all actions will be
    * up to date */
   eufi_check_ref_actions_applied (installation,
-                                  state_counter_path,
                                   actions,
                                   &error);
   g_assert_no_error (error);
@@ -453,7 +452,6 @@ test_flatpak_check_fails_if_installed_flatpak_is_not_installed (FlatpakDeploymen
   g_autoptr(GError) error = NULL;
   const gchar *flatpaks_to_install[] = { "org.test.Test", NULL };
   g_autoptr(GPtrArray) actions = sample_flatpak_ref_actions ("autoinstall", flatpaks_to_install);
-  g_autofree gchar *state_counter_path = g_file_get_path (fixture->counter_file);
   g_autoptr(FlatpakInstallation) installation = flatpak_installation_new_for_path (fixture->flatpak_installation_directory,
                                                                                    TRUE,
                                                                                    NULL,
@@ -475,7 +473,6 @@ test_flatpak_check_fails_if_installed_flatpak_is_not_installed (FlatpakDeploymen
   /* Run the checker - it should return false because the flatpak that
    * needs to be installed is not yet installed */
   eufi_check_ref_actions_applied (installation,
-                                  state_counter_path,
                                   actions,
                                   &error);
   g_assert_error (error, G_IO_ERROR, G_IO_ERROR_FAILED);
@@ -490,7 +487,6 @@ test_flatpak_check_fails_if_unininstalled_flatpak_is_installed (FlatpakDeploymen
   g_autoptr(GPtrArray) actions = sample_flatpak_ref_actions_of_type ("autoinstall",
                                                                      flatpaks_to_install,
                                                                      EUU_FLATPAK_REMOTE_REF_ACTION_UNINSTALL);
-  g_autofree gchar *state_counter_path = g_file_get_path (fixture->counter_file);
   g_autoptr(FlatpakInstallation) installation = flatpak_installation_new_for_path (fixture->flatpak_installation_directory,
                                                                                    TRUE,
                                                                                    NULL,
@@ -512,7 +508,6 @@ test_flatpak_check_fails_if_unininstalled_flatpak_is_installed (FlatpakDeploymen
   /* Run the checker - it should return false because the preinstalled flatpak
    * is still installed */
   eufi_check_ref_actions_applied (installation,
-                                  state_counter_path,
                                   actions,
                                   &error);
   g_assert_error (error, G_IO_ERROR, G_IO_ERROR_FAILED);

--- a/libeos-updater-util/config.c
+++ b/libeos-updater-util/config.c
@@ -481,7 +481,7 @@ euu_config_file_get_boolean (EuuConfigFile  *self,
 }
 
 /**
- * euu_config_file_get_boolean:
+ * euu_config_file_get_string:
  * @self: an #EuuConfigFile
  * @group_name: name of the configuration group
  * @key_name: name of the configuration key

--- a/libeos-updater-util/flatpak.c
+++ b/libeos-updater-util/flatpak.c
@@ -1191,6 +1191,12 @@ euu_flatpak_ref_actions_append_from_directory (GFile         *directory,
 
       filename = g_file_info_get_name (info);
 
+      if (!g_str_has_suffix (filename, ".json"))
+        {
+          g_debug ("%s: Ignoring non-JSON file ‘%s’", G_STRFUNC, filename);
+          continue;
+        }
+
       /* We may already have a remote_ref_actions_file in the hash table
        * and we cannot just blindly replace it. Replace it only if
        * the incoming directory has a higher priority. */

--- a/libeos-updater-util/flatpak.c
+++ b/libeos-updater-util/flatpak.c
@@ -34,6 +34,8 @@
 #include <string.h>
 
 
+G_DEFINE_BOXED_TYPE (EuuFlatpakLocationRef, euu_flatpak_location_ref, euu_flatpak_location_ref_ref, euu_flatpak_location_ref_unref)
+
 /**
  * euu_flatpak_location_ref_new:
  * @ref: a #FlatpakRef
@@ -89,6 +91,8 @@ euu_flatpak_location_ref_ref (EuuFlatpakLocationRef *location_ref)
   ++location_ref->ref_count;
   return location_ref;
 }
+
+G_DEFINE_BOXED_TYPE (EuuFlatpakRemoteRefAction, euu_flatpak_remote_ref_action, euu_flatpak_remote_ref_action_ref, euu_flatpak_remote_ref_action_unref)
 
 EuuFlatpakRemoteRefAction *
 euu_flatpak_remote_ref_action_new (EuuFlatpakRemoteRefActionType  type,
@@ -1079,6 +1083,15 @@ euu_flatpak_ref_actions_from_data (const gchar   *data,
   return g_steal_pointer (&actions);
 }
 
+/**
+ * euu_flatpak_remote_ref_actions_file_new:
+ * @remote_ref_actions: (element-type EuuFlatpakRemoteRefAction): a potentially
+ *    empty array of actions loaded from a single file
+ * @priority: the priority of the file; lower numeric priority values are more
+ *    important
+ *
+ * Returns: (transfer full): A new #EuuFlatpakRemoteRefActionsFile
+ */
 EuuFlatpakRemoteRefActionsFile *
 euu_flatpak_remote_ref_actions_file_new (GPtrArray *remote_ref_actions,
                                          gint       priority)

--- a/libeos-updater-util/flatpak.c
+++ b/libeos-updater-util/flatpak.c
@@ -82,6 +82,14 @@ euu_flatpak_location_ref_unref (EuuFlatpakLocationRef *location_ref)
   g_slice_free (EuuFlatpakLocationRef, location_ref);
 }
 
+/**
+ * euu_flatpak_location_ref_ref: (skip)
+ * @location_ref: an #EuuFlatpakLocationRef
+ *
+ * Increment the reference count on @location_ref and return the object.
+ *
+ * Returns: (transfer full): @location_ref
+ */
 EuuFlatpakLocationRef *
 euu_flatpak_location_ref_ref (EuuFlatpakLocationRef *location_ref)
 {
@@ -113,6 +121,14 @@ euu_flatpak_remote_ref_action_new (EuuFlatpakRemoteRefActionType  type,
   return action;
 }
 
+/**
+ * euu_flatpak_remote_ref_action_ref: (skip)
+ * @action: an #EuuFlatpakRemoteRefAction
+ *
+ * Increment the reference count on @action and return the object.
+ *
+ * Returns: (transfer full): @action
+ */
 EuuFlatpakRemoteRefAction *
 euu_flatpak_remote_ref_action_ref (EuuFlatpakRemoteRefAction *action)
 {
@@ -2668,6 +2684,24 @@ directories_to_search_from_environment (void)
   return g_strsplit (paths_to_search_string, ";", -1);
 }
 
+/**
+ * euu_flatpak_ref_actions_from_paths:
+ * @directories_to_search: (nullable): potentially empty %NULL-terminated array
+ *    of directories to search, or %NULL to use the default directory list
+ * @error: return location for a #GError, or %NULL
+ *
+ * Load the #EuuFlatpakRemoteRefActions from all the autoinstall JSON files in
+ * the given @directories_to_search.
+ *
+ * @directories_to_search may be %NULL, in which case the default list of
+ * directories is used. Files from lower-indexed directories in
+ * @directories_to_search take priority over files with the same name in later
+ * directories.
+ *
+ * Returns: (transfer container) (element-type filename GPtrArray<EuuFlatpakRemoteRefAction>):
+ *    a potentially empty map of autoinstall filename to array of #EuuFlatpakRemoteRefActions
+ *    in that file
+ */
 GHashTable *
 euu_flatpak_ref_actions_from_paths (GStrv    directories_to_search,
                                     GError **error)

--- a/libeos-updater-util/flatpak.c
+++ b/libeos-updater-util/flatpak.c
@@ -1099,12 +1099,19 @@ euu_flatpak_ref_actions_from_data (const gchar   *data,
   return g_steal_pointer (&actions);
 }
 
+G_DEFINE_BOXED_TYPE (EuuFlatpakRemoteRefActionsFile,
+                     euu_flatpak_remote_ref_actions_file,
+                     euu_flatpak_remote_ref_actions_file_copy,
+                     euu_flatpak_remote_ref_actions_file_free)
+
 /**
  * euu_flatpak_remote_ref_actions_file_new:
  * @remote_ref_actions: (element-type EuuFlatpakRemoteRefAction): a potentially
  *    empty array of actions loaded from a single file
  * @priority: the priority of the file; lower numeric priority values are more
  *    important
+ *
+ * Create a new #EuuFlatpakRemoteRefActionsFile.
  *
  * Returns: (transfer full): A new #EuuFlatpakRemoteRefActionsFile
  */
@@ -1118,6 +1125,15 @@ euu_flatpak_remote_ref_actions_file_new (GPtrArray *remote_ref_actions,
   file->priority = priority;
 
   return file;
+}
+
+EuuFlatpakRemoteRefActionsFile *
+euu_flatpak_remote_ref_actions_file_copy (EuuFlatpakRemoteRefActionsFile *file)
+{
+  g_return_val_if_fail (file != NULL, NULL);
+
+  return euu_flatpak_remote_ref_actions_file_new (file->remote_ref_actions,
+                                                  file->priority);
 }
 
 void

--- a/libeos-updater-util/flatpak.h
+++ b/libeos-updater-util/flatpak.h
@@ -104,8 +104,12 @@ void euu_flatpak_remote_ref_action_unref (EuuFlatpakRemoteRefAction *action);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (EuuFlatpakRemoteRefAction, euu_flatpak_remote_ref_action_unref)
 
+#define EUU_TYPE_FLATPAK_REMOTE_REF_ACTIONS_FILE (euu_flatpak_remote_ref_actions_file_get_type ())
+GType euu_flatpak_remote_ref_actions_file_get_type (void);
+
 EuuFlatpakRemoteRefActionsFile *euu_flatpak_remote_ref_actions_file_new (GPtrArray *remote_ref_actions,
                                                                          gint       priority);
+EuuFlatpakRemoteRefActionsFile *euu_flatpak_remote_ref_actions_file_copy (EuuFlatpakRemoteRefActionsFile *file);
 void euu_flatpak_remote_ref_actions_file_free (EuuFlatpakRemoteRefActionsFile *file);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (EuuFlatpakRemoteRefActionsFile, euu_flatpak_remote_ref_actions_file_free)

--- a/libeos-updater-util/flatpak.h
+++ b/libeos-updater-util/flatpak.h
@@ -40,9 +40,9 @@ typedef enum {
 
 typedef struct {
   gint ref_count;
-  FlatpakRef *ref;
-  const gchar *remote;
-  const gchar *collection_id;
+  FlatpakRef *ref;  /* (owned) (not nullable) */
+  const gchar *remote;  /* (not nullable) */
+  const gchar *collection_id;  /* (nullable) */
 } EuuFlatpakLocationRef;
 
 #define EUU_TYPE_FLATPAK_LOCATION_REF (euu_flatpak_location_ref_get_type ())

--- a/libeos-updater-util/flatpak.h
+++ b/libeos-updater-util/flatpak.h
@@ -45,6 +45,10 @@ typedef struct {
   const gchar *collection_id;
 } EuuFlatpakLocationRef;
 
+#define EUU_TYPE_FLATPAK_LOCATION_REF (euu_flatpak_location_ref_get_type ())
+
+GType euu_flatpak_location_ref_get_type (void);
+
 /**
  * EuuFlatpakRemoteRefActionFlags:
  * @EUU_FLATPAK_REMOTE_REF_ACTION_FLAG_NONE: No flags
@@ -72,6 +76,10 @@ typedef struct {
 
   EuuFlatpakRemoteRefActionFlags flags;
 } EuuFlatpakRemoteRefAction;
+
+#define EUU_TYPE_FLATPAK_REMOTE_REF_ACTION (euu_flatpak_remote_ref_action_get_type ())
+
+GType euu_flatpak_remote_ref_action_get_type (void);
 
 typedef struct {
   GPtrArray *remote_ref_actions;  /* (element-type EuuFlatpakRemoteRefAction) */

--- a/libeos-updater-util/flatpak.h
+++ b/libeos-updater-util/flatpak.h
@@ -89,8 +89,8 @@ typedef struct {
 EuuFlatpakLocationRef *euu_flatpak_location_ref_new (FlatpakRef  *ref,
                                                      const gchar *remote,
                                                      const gchar *collection_id);
-EuuFlatpakLocationRef *euu_flatpak_location_ref_ref (EuuFlatpakLocationRef *ref);
-void euu_flatpak_location_ref_unref (EuuFlatpakLocationRef *ref);
+EuuFlatpakLocationRef *euu_flatpak_location_ref_ref (EuuFlatpakLocationRef *location_ref);
+void euu_flatpak_location_ref_unref (EuuFlatpakLocationRef *location_ref);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (EuuFlatpakLocationRef, euu_flatpak_location_ref_unref)
 

--- a/test-common/utils.c
+++ b/test-common/utils.c
@@ -2932,12 +2932,17 @@ eos_test_client_prepare_volume (EosTestClient *client,
                                                                                "eos-updater-prepare-volume",
                                                                                "eos-updater-prepare-volume",
                                                                                NULL);
+  g_autofree gchar *libeos_updater_util_path = g_test_build_filename (G_TEST_BUILT,
+                                                                      "..",
+                                                                      "libeos-updater-util",
+                                                                      NULL);
   g_autoptr(GFile) sysroot = get_sysroot_for_client (client->root);
   CmdEnvVar envv[] =
     {
       { "EOS_UPDATER_TEST_UPDATER_DEPLOYMENT_FALLBACK", "yes", NULL },
       { "OSTREE_SYSROOT", NULL, sysroot },
       { "OSTREE_SYSROOT_DEBUG", "mutable-deployments", NULL },
+      { "GI_TYPELIB_PATH", libeos_updater_util_path, NULL },
       { NULL, NULL, NULL }
     };
   g_autofree gchar *raw_volume_path = g_file_get_path (volume_path);

--- a/tests/test-update-install-flatpaks.c
+++ b/tests/test-update-install-flatpaks.c
@@ -310,7 +310,7 @@ autoinstall_flatpaks_files (guint                    commit,
                             GHashTable             **out_files_hashtable)
 {
   autoinstall_flatpaks_files_name (commit,
-                                   "autoinstall",
+                                   "autoinstall.json",
                                    flatpaks,
                                    n_flatpaks,
                                    out_directories_hashtable,
@@ -358,7 +358,7 @@ autoinstall_flatpaks_files_override (GFile                   *updater_directory,
                                      GError                 **error)
 {
   return autoinstall_flatpaks_files_override_name (updater_directory,
-                                                   "install.override",
+                                                   "install.override.json",
                                                    flatpaks,
                                                    n_flatpaks,
                                                    error);
@@ -5920,7 +5920,7 @@ test_update_deploy_flatpaks_on_reboot_override_ostree (EosUpdaterFixture *fixtur
   /* Vendor requested to install some flatpaks on the next update
    */
   autoinstall_flatpaks_files_override_name (updater_directory,
-                                            "10-autoinstall",
+                                            "10-autoinstall.json",
                                             flatpaks_to_install_override_high_priority,
                                             G_N_ELEMENTS (flatpaks_to_install_override_high_priority),
                                             &error);
@@ -5929,7 +5929,7 @@ test_update_deploy_flatpaks_on_reboot_override_ostree (EosUpdaterFixture *fixtur
   /* Commit number 1 will install some flatpaks (low priority)
    */
   autoinstall_flatpaks_files_name (1,
-                                   "10-autoinstall",
+                                   "10-autoinstall.json",
                                    flatpaks_to_install_in_ostree_low_priority,
                                    G_N_ELEMENTS (flatpaks_to_install_in_ostree_low_priority),
                                    &data->additional_directories_for_commit,
@@ -5938,7 +5938,7 @@ test_update_deploy_flatpaks_on_reboot_override_ostree (EosUpdaterFixture *fixtur
   /* Commit number 1 will install some flatpaks (high priority)
    */
   autoinstall_flatpaks_files_name (1,
-                                   "20-autoinstall",
+                                   "20-autoinstall.json",
                                    flatpaks_to_install_in_ostree_high_priority,
                                    G_N_ELEMENTS (flatpaks_to_install_in_ostree_high_priority),
                                    &data->additional_directories_for_commit,


### PR DESCRIPTION
When an OS update has flatpak(s) set to be updated or installed along
with it (via eos-updater-flatpak-installer), the flatpaks are required
for the update for succeed. So this commit adds the flatpaks to a USB
being created with eos-updater-prepare-volume so that USB updates work
even when the update in question has flatpaks to be autoinstalled. This
is accomplished by adding a "print" mode to
eos-updater-flatpak-installer and parsing the output from that in
eos-updater-prepare-volume. This way the logic that parses the
configuration files can stay in one place. Since we can't make any
assumptions about the OS version on the client receiving the USB update,
every flatpak configured to be automatically updated or installed on
OS update must be included.

https://phabricator.endlessm.com/T21756