### PR TITLE
fetch: Set schedule entry's priority

### DIFF
--- a/src/eos-updater-fetch.c
+++ b/src/eos-updater-fetch.c
@@ -31,6 +31,8 @@
 #include <libmogwai-schedule-client/schedule-entry.h>
 #include <libmogwai-schedule-client/scheduler.h>
 
+#define APP_CENTER_OS_UPDATES_PRIORITY 30
+
 /* Closure containing the data for the fetch worker thread. The
  * worker thread must not access EosUpdater or EosUpdaterData directly,
  * as they are not thread safe. */
@@ -757,6 +759,9 @@ schedule_download (FetchData     *fetch_data,
 
   /* Schedule the download. Similar reasoning applies to the timeout as above. */
   g_variant_dict_insert (&parameters_dict, "resumable", "b", FALSE);
+  /* Add the highest priority that the App Center uses as this will be compared
+   * at the same level in Mogwai */
+  g_variant_dict_insert (&parameters_dict, "priority", "u", APP_CENTER_OS_UPDATES_PRIORITY);
   parameters = g_variant_ref_sink (g_variant_dict_end (&parameters_dict));
 
   mwsc_scheduler_schedule_async (scheduler, parameters, cancellable,


### PR DESCRIPTION
The value for the OS updates priority is equal to what's expected for
this type of updates in GNOME Software, so it sets the appropriate
priority to app updates (Mogwai's checks eos-updater and GNOME
Software's priorities together).

https://phabricator.endlessm.com/T21327