### PR TITLE
T21756 preparation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -313,7 +313,7 @@ eos_updater_flatpak_installer_eos_updater_flatpak_installer_LDADD = \
 	$(CODE_COVERAGE_LIBS) \
 	$(EOS_UPDATER_FLATPAK_INSTALLER_LIBS) \
 	$(top_builddir)/libeos-updater-util/libeos-updater-util-@EUU_API_VERSION@.la \
-	$(top_builddir)/libeos-updater-flatpak-installer/libeos-updater-flatpak-installer-@EUFI_API_VERSION@.la
+	$(top_builddir)/libeos-updater-flatpak-installer/libeos-updater-flatpak-installer-@EUFI_API_VERSION@.la \
 	$(NULL)
 eos_updater_flatpak_installer_eos_updater_flatpak_installer_SOURCES = \
 	eos-updater-flatpak-installer/main.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -283,7 +283,7 @@ libeos_updater_flatpak_installer_libeos_updater_flatpak_installer_@EUFI_API_VERS
 libeos_updater_flatpak_installer_libeos_updater_flatpak_installer_@EUFI_API_VERSION@_la_LIBADD = \
 	$(CODE_COVERAGE_LIBS) \
 	$(EOS_UPDATER_FLATPAK_INSTALLER_LIBS) \
-	$(top_builddir)/libeos-updater-util/libeos-updater-util-@EUFI_API_VERSION@.la \
+	$(top_builddir)/libeos-updater-util/libeos-updater-util-@EUU_API_VERSION@.la \
 	$(NULL)
 libeos_updater_flatpak_installer_libeos_updater_flatpak_installer_@EUFI_API_VERSION@_la_SOURCES = \
 	libeos-updater-flatpak-installer/determine-flatpak-actions.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ sysconfexampledir = $(pkgdatadir)
 # Pre-defines to allow appending later
 libexec_PROGRAMS =
 noinst_LTLIBRARIES =
+lib_LTLIBRARIES =
 systemdsystemunit_DATA =
 dist_sysconfexample_DATA =
 dist_bin_SCRIPTS =
@@ -38,7 +39,7 @@ BUILT_SOURCES =
 EXTRA_DIST += README.md
 
 # Ensure systemd units get installed under $(prefix) for distcheck
-AM_DISTCHECK_CONFIGURE_FLAGS = --with-systemdsystemunitdir='$${libdir}/systemd/system' --enable-introspection
+AM_DISTCHECK_CONFIGURE_FLAGS = --with-systemdsystemunitdir='$${libdir}/systemd/system'
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA =
@@ -58,7 +59,7 @@ AM_CPPFLAGS = \
 	$(NULL)
 
 # Utility library
-noinst_LTLIBRARIES += libeos-updater-util/libeos-updater-util-@EUU_API_VERSION@.la
+lib_LTLIBRARIES += libeos-updater-util/libeos-updater-util-@EUU_API_VERSION@.la
 
 enum_header_files = \
 	$(top_srcdir)/libeos-updater-util/flatpak.h \
@@ -264,7 +265,7 @@ dist_bin_SCRIPTS += eos-updater-prepare-volume/eos-updater-prepare-volume
 dist_man8_MANS += eos-updater-prepare-volume/docs/eos-updater-prepare-volume.8
 
 # Flatpak installer utility library
-noinst_LTLIBRARIES += libeos-updater-flatpak-installer/libeos-updater-flatpak-installer-@EUFI_API_VERSION@.la
+lib_LTLIBRARIES += libeos-updater-flatpak-installer/libeos-updater-flatpak-installer-@EUFI_API_VERSION@.la
 
 libeos_updater_flatpak_installer_libeos_updater_flatpak_installer_@EUFI_API_VERSION@_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
@@ -294,6 +295,68 @@ libeos_updater_flatpak_installer_libeos_updater_flatpak_installer_@EUFI_API_VERS
 
 # eos-updater-flatpak-installer program
 libexec_PROGRAMS += eos-updater-flatpak-installer/eos-updater-flatpak-installer
+
+# GObject Introspection
+-include $(INTROSPECTION_MAKEFILE)
+INTROSPECTION_GIRS =
+INTROSPECTION_SCANNER_ARGS =
+INTROSPECTION_COMPILER_ARGS =
+AM_DISTCHECK_CONFIGURE_FLAGS += --enable-introspection
+EXTRA_DIST += m4/introspection.m4
+
+if HAVE_INTROSPECTION
+# GObject Introspection for libeos-updater-util
+libeos-updater-util/EosUpdaterUtil-@EUU_API_VERSION@.gir: libeos-updater-util/libeos-updater-util-@EUU_API_VERSION@.la
+libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_INCLUDES = GObject-2.0 Gio-2.0
+libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_CFLAGS = \
+	$(libeos_updater_util_libeos_updater_util_@EUU_API_VERSION@_la_CPPFLAGS) \
+	$(libeos_updater_util_libeos_updater_util_@EUU_API_VERSION@_la_CFLAGS)
+libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_FILES = \
+	$(libeos_updater_util_libeos_updater_util_@EUU_API_VERSION@_la_SOURCES)
+libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_LIBS = libeos-updater-util/libeos-updater-util-@EUU_API_VERSION@.la
+libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_NAMESPACE = EosUpdaterUtil
+libeos_updater_util_EosUpdaterUtil_@EUU_API_VERSION@_gir_SCANNERFLAGS = \
+	$(WARN_SCANNERFLAGS) \
+	--nsversion=@EUU_API_VERSION@ \
+	--c-include="libeos-updater-util/util.h" \
+	--identifier-prefix=EosUpdater \
+	--identifier-prefix=Euu \
+	--symbol-prefix=euu \
+	--symbol-prefix=eos_updater \
+	$(NULL)
+
+INTROSPECTION_GIRS += libeos-updater-util/EosUpdaterUtil-@EUU_API_VERSION@.gir
+
+# GObject Introspection for libeos-updater-flatpak-installer
+libeos-updater-flatpak-installer/EosUpdaterFlatpakInstaller-@EUFI_API_VERSION@.gir: libeos-updater-flatpak-installer/libeos-updater-flatpak-installer-@EUFI_API_VERSION@.la
+libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_gir_INCLUDES = GObject-2.0 Gio-2.0 Flatpak-1.0
+libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_gir_CFLAGS = \
+	$(STD_CFLAGS) \
+	$(EOS_UPDATER_FLATPAK_INSTALLER_CFLAGS) \
+	$(NULL)
+libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_gir_FILES = \
+	$(libeos_updater_flatpak_installer_libeos_updater_flatpak_installer_@EUFI_API_VERSION@_la_SOURCES)
+libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_gir_LIBS = libeos-updater-flatpak-installer/libeos-updater-flatpak-installer-@EUFI_API_VERSION@.la
+libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_gir_NAMESPACE = EosUpdaterFlatpakInstaller
+libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_gir_SCANNERFLAGS = \
+	$(WARN_SCANNERFLAGS) \
+	--nsversion=@EUFI_API_VERSION@ \
+	--c-include="libeos-updater-flatpak-installer/installer.h" \
+	--identifier-prefix=Eufi \
+	--symbol-prefix=eufi \
+	-I$(top_srcdir) \
+	$(NULL)
+
+INTROSPECTION_GIRS += libeos-updater-flatpak-installer/EosUpdaterFlatpakInstaller-@EUFI_API_VERSION@.gir
+
+girdir = $(datadir)/gir-1.0
+gir_DATA = $(INTROSPECTION_GIRS)
+
+typelibdir = $(libdir)/girepository-1.0
+typelib_DATA = $(INTROSPECTION_GIRS:.gir=.typelib)
+
+CLEANFILES += $(gir_DATA) $(typelib_DATA)
+endif # HAVE_INTROSPECTION
 
 eos_updater_flatpak_installer_eos_updater_flatpak_installer_CPPFLAGS = \
 	$(AM_CPPFLAGS) \

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,8 @@ m4_define([eus_api_version],[0])
 AC_INIT([eos-updater],[1.0])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_USE_SYSTEM_EXTENSIONS
-AM_INIT_AUTOMAKE([1.11.2 dist-xz no-dist-gzip tar-ustar foreign subdir-objects])
+AM_INIT_AUTOMAKE([1.11.2 dist-xz no-dist-gzip tar-ustar foreign subdir-objects
+                  -Wno-portability])
 AM_SILENT_RULES([yes])
 AC_PROG_CC
 AC_CONFIG_MACRO_DIR([m4])

--- a/debian/control
+++ b/debian/control
@@ -106,3 +106,17 @@ Description: Updater for Endless OS - utility tests
  .
  This package contains unit tests for the APIs used by the updater and
  other update packaging tools.
+
+Package: gir1.2-eos-updater-0
+Section: introspection
+Architecture: any
+Multi-arch: same
+Depends:
+ ${gir:Depends},
+ ${misc:Depends},
+Description: Updater for Endless OS - introspection bindings
+ This package contains the components for keeping Endless OS up to date.
+ .
+ This package contains a machine-readable API description for both
+ libeos-updater-util and libeos-updater-flatpak-installer for use by the
+ updater and other update packaging tools.

--- a/debian/eos-updater.install
+++ b/debian/eos-updater.install
@@ -11,6 +11,8 @@ usr/lib/*/eos-autoupdater
 usr/lib/*/eos-updater-avahi
 usr/lib/*/eos-updater-flatpak-installer
 usr/lib/*/eos-update-server
+usr/lib/*/libeos-updater-flatpak-installer-0.so.*
+usr/lib/*/libeos-updater-util-0.so.*
 usr/share/dbus-1/interfaces/com.endlessm.Updater.xml
 usr/share/dbus-1/system.d/com.endlessm.Updater.conf
 usr/share/dbus-1/system-services/com.endlessm.Updater.service

--- a/debian/gir1.2-eos-updater-0.install
+++ b/debian/gir1.2-eos-updater-0.install
@@ -1,1 +1,2 @@
-usr/lib/*/girepository-1.0/EosUpdater-0.*
+usr/lib/*/girepository-1.0/EosUpdaterFlatpakInstaller-0.*
+usr/lib/*/girepository-1.0/EosUpdaterUtil-0.*

--- a/eos-updater-flatpak-installer/docs/eos-updater-flatpak-installer.8
+++ b/eos-updater-flatpak-installer/docs/eos-updater-flatpak-installer.8
@@ -10,6 +10,8 @@ eos\-updater\-flatpak\-installer — Endless OS Updater Flatpak Installer
 .IX Header "SYNOPSIS"
 .\"
 \fBeos\-updater\-flatpak\-installer [\-m \fPmode\fB] [\-p]
+.PP
+\fBeos\-updater\-flatpak\-installer \-\-dry\-run
 .\"
 .SH DESCRIPTION
 .IX Header "DESCRIPTION"
@@ -22,6 +24,10 @@ the old OS deployment is still running.
 .PP
 .SH OPTIONS
 .IX Header "OPTIONS"
+.\"
+.IP "\fB\-\-dry\-run\fP"
+Print the actions that would be taken without this option. The mode used affects
+this output.
 .\"
 .IP "\fB\-m\fP, \fB\-\-mode=\fP"
 Which mode to run the flatpak installer in. (Default: \fBperform\fP.)

--- a/eos-updater-flatpak-installer/main.c
+++ b/eos-updater-flatpak-installer/main.c
@@ -130,8 +130,10 @@ main (int    argc,
 
   g_autofree gchar *mode = NULL;
   gboolean also_pull = FALSE;
+  gboolean dry_run = FALSE;
   GOptionEntry entries[] =
     {
+      { "dry-run", 0, 0, G_OPTION_ARG_NONE, &dry_run, "Print actions without applying them", NULL },
       { "mode", 'm', 0, G_OPTION_ARG_STRING, &mode, "Mode to use (perform, stamp, check) (default: perform)", NULL },
       { "pull", 'p', 0, G_OPTION_ARG_NONE, &also_pull, "Also pull flatpaks", NULL },
       { NULL }
@@ -202,6 +204,9 @@ main (int    argc,
                                                   squashed_ref_actions_to_check);
           g_message ("%s", formatted_ordered_flatpak_ref_actions_to_check);
 
+          if (dry_run)
+            return EXIT_OK;
+
           if (!eufi_check_ref_actions_applied (installation,
                                                pending_flatpak_deployments_state_path,
                                                squashed_ref_actions_to_check,
@@ -238,6 +243,9 @@ main (int    argc,
             euu_format_flatpak_ref_actions_array ("Order in which actions will be applied",
                                                   squashed_ref_actions_to_apply);
           g_message ("%s", formatted_ordered_flatpak_ref_actions_to_apply);
+
+          if (dry_run)
+            return EXIT_OK;
 
           if (!eufi_apply_flatpak_ref_actions (installation,
                                                euu_pending_flatpak_deployments_state_path (),

--- a/libeos-updater-flatpak-installer/determine-flatpak-actions.c
+++ b/libeos-updater-flatpak-installer/determine-flatpak-actions.c
@@ -79,7 +79,18 @@ flatpak_ref_actions_and_progresses (GStrv        directories_to_search,
   return TRUE;
 }
 
-/* See documentation for euu_filter_for_existing_flatpak_ref_actions(). */
+/**
+ * eufi_determine_flatpak_ref_actions_to_check:
+ * @directories_to_search: (nullable): directories to search for JSON files
+ * @error: return location for a #GError, or %NULL
+ *
+ * Search each directory in @directories_to_search for JSON files (as defined
+ * by eos-updater-flatpak-autoinstall.d(5)) and find actions that should
+ * already have been applied.
+ *
+ * Returns: (element-type filename EuuFlatpakRemoteRefAction) (transfer full):
+ * a mapping from file names to actions that should have been applied
+ */
 GHashTable *
 eufi_determine_flatpak_ref_actions_to_check (GStrv    directories_to_search,
                                              GError **error)
@@ -97,7 +108,18 @@ eufi_determine_flatpak_ref_actions_to_check (GStrv    directories_to_search,
                                                       flatpak_ref_actions_progress);
 }
 
-/* See documentation for euu_filter_for_new_flatpak_ref_actions(). */
+/**
+ * eufi_determine_flatpak_ref_actions_to_apply:
+ * @directories_to_search: (nullable): directories to search for JSON files
+ * @error: return location for a #GError, or %NULL
+ *
+ * Search each directory in @directories_to_search for JSON files (as defined
+ * by eos-updater-flatpak-autoinstall.d(5)) and find actions that should
+ * be applied.
+ *
+ * Returns: (element-type filename EuuFlatpakRemoteRefAction) (transfer full):
+ * a mapping from file names to actions that should be applied
+ */
 GHashTable *
 eufi_determine_flatpak_ref_actions_to_apply (GStrv    directories_to_search,
                                              GError **error)

--- a/libeos-updater-util/config.c
+++ b/libeos-updater-util/config.c
@@ -529,7 +529,7 @@ euu_config_file_get_string (EuuConfigFile  *self,
  * in the default configuration file, if not in any others. It will be loaded
  * from the first configuration file which contains it.
  *
- * Returns: (transfer full) (array zero-terminated=1) (array length=n_elements_out):
+ * Returns: (transfer full) (array zero-terminated=1 length=n_elements_out):
  *    the loaded string array, which is guaranteed to be non-%NULL but may be
  *    empty
  * Since: UNRELEASED
@@ -573,7 +573,7 @@ strcmp_p (const void *p1,
  * List the groups from all the configuration files, eliminating duplicates.
  * Empty groups are included in the list. The list is sorted lexicographically.
  *
- * Returns: (transfer full) (array zero-terminated=1) (array length=n_groups_out):
+ * Returns: (transfer full) (array zero-terminated=1 length=n_groups_out):
  *    the groups in the configuration files, which is guaranteed to be non-%NULL
  *    but may be empty
  * Since: UNRELEASED

--- a/libeos-updater-util/flatpak.h
+++ b/libeos-updater-util/flatpak.h
@@ -84,7 +84,7 @@ EuuFlatpakLocationRef *euu_flatpak_location_ref_new (FlatpakRef  *ref,
 EuuFlatpakLocationRef *euu_flatpak_location_ref_ref (EuuFlatpakLocationRef *ref);
 void euu_flatpak_location_ref_unref (EuuFlatpakLocationRef *ref);
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (EuuFlatpakLocationRef, euu_flatpak_location_ref_unref);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (EuuFlatpakLocationRef, euu_flatpak_location_ref_unref)
 
 EuuFlatpakRemoteRefAction *euu_flatpak_remote_ref_action_new (EuuFlatpakRemoteRefActionType  type,
                                                               EuuFlatpakLocationRef         *ref,
@@ -100,7 +100,7 @@ EuuFlatpakRemoteRefActionsFile *euu_flatpak_remote_ref_actions_file_new (GPtrArr
                                                                          gint       priority);
 void euu_flatpak_remote_ref_actions_file_free (EuuFlatpakRemoteRefActionsFile *file);
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (EuuFlatpakRemoteRefActionsFile, euu_flatpak_remote_ref_actions_file_free);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (EuuFlatpakRemoteRefActionsFile, euu_flatpak_remote_ref_actions_file_free)
 
 GPtrArray *euu_flatpak_ref_actions_from_file (GFile         *file,
                                               GPtrArray    **out_skipped_actions,


### PR DESCRIPTION
These commits had to broken off from the other T21756 commits because if I add EosUpdaterUtil-0 to `libeos_updater_flatpak_installer_EosUpdaterFlatpakInstaller_@EUFI_API_VERSION@_gir_INCLUDES` in the same commit that adds `EosUpdaterUtil-0.gir` as a target the build fails because the gir isn't installed at build time. So after this is merged, https://github.com/endlessm/eos-updater/pull/188 will be able to have that dependency.