### PR TITLE
build: Allow declarations after statements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ AC_SUBST([EUFI_API_VERSION],eufi_api_version)
 AC_SUBST([EUS_API_VERSION],eus_api_version)
 
 # Compiler warnings and --disable-Werror
-AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS],,,[-Wconversion])
+AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS],,,[-Wno-declaration-after-statement -Wconversion])
 
 # Enable C99
 AX_APPEND_COMPILE_FLAGS([-std=c99],[STD_CFLAGS])


### PR DESCRIPTION
Welcome to 2018! This works really well with g_autoptr(), which we’ve
been using for a while.

I don’t plan to port the code from -Wdeclaration-after-statement to
-Wno-declaration-after-statement; but any new code or modifications made
after this commit should use declarations after statements where
appropriate.

Signed-off-by: Philip Withnall <withnall@endlessm.com>