### PR TITLE
T22295: Check booted branch first before following update refspec

### DIFF
--- a/src/eos-updater-poll.c
+++ b/src/eos-updater-poll.c
@@ -257,6 +257,197 @@ async_result_cb (GObject      *source_object,
   *result_out = g_object_ref (result);
 }
 
+typedef struct {
+  gchar *refspec;
+  gchar *remote;
+  gchar *ref;
+  OstreeCollectionRef *collection_ref;
+  gchar *new_refspec;
+  gchar *checksum;
+  gchar *version;
+  GVariant *commit;
+} UpdateRefInfo;
+
+static void
+update_ref_info_init (UpdateRefInfo *update_ref_info)
+{
+  update_ref_info->refspec = NULL;
+  update_ref_info->remote = NULL;
+  update_ref_info->ref = NULL;
+  update_ref_info->collection_ref = NULL;
+  update_ref_info->new_refspec = NULL;
+  update_ref_info->checksum = NULL;
+  update_ref_info->version = NULL;
+  update_ref_info->commit = NULL;
+}
+
+static void
+update_ref_info_clear (UpdateRefInfo *update_ref_info)
+{
+  g_clear_pointer (&update_ref_info->refspec, g_free);
+  g_clear_pointer (&update_ref_info->remote, g_free);
+  g_clear_pointer (&update_ref_info->ref, g_free);
+  g_clear_pointer (&update_ref_info->collection_ref, ostree_collection_ref_free);
+  g_clear_pointer (&update_ref_info->new_refspec, g_free);
+  g_clear_pointer (&update_ref_info->checksum, g_free);
+  g_clear_pointer (&update_ref_info->version, g_free);
+  g_clear_pointer (&update_ref_info->commit, g_variant_unref);
+}
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (UpdateRefInfo, update_ref_info_clear)
+
+static gboolean
+check_for_update_using_booted_branch (OstreeRepo           *repo,
+                                      gboolean             *out_is_update,
+                                      UpdateRefInfo        *out_update_ref_info,
+                                      GCancellable         *cancellable,
+                                      GError              **error)
+{
+  g_autofree gchar *booted_refspec = NULL;
+  g_autofree gchar *remote = NULL;
+  g_autofree gchar *ref = NULL;
+  g_autoptr(OstreeCollectionRef) collection_ref = NULL;
+  g_autofree gchar *new_refspec = NULL;
+  g_autofree gchar *version = NULL;
+  gboolean is_update = FALSE;
+  g_autofree gchar *checksum = NULL;
+  g_autoptr(GVariant) commit = NULL;
+  g_autoptr(OstreeSysroot) sysroot = ostree_sysroot_new_default ();
+  g_autoptr(OstreeDeployment) booted_deployment = NULL;
+
+  g_return_val_if_fail (out_is_update != NULL, FALSE);
+  g_return_val_if_fail (out_update_ref_info != NULL, FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+  if (!ostree_sysroot_load (sysroot, NULL, error))
+    return FALSE;
+
+  booted_deployment = eos_updater_get_booted_deployment_from_loaded_sysroot (sysroot,
+                                                                             error);
+
+  if (booted_deployment == NULL)
+    return FALSE;
+
+  if (!get_booted_refspec (booted_deployment,
+                           &booted_refspec,
+                           &remote,
+                           &ref,
+                           &collection_ref, error))
+    return FALSE;
+
+  if (!fetch_latest_commit (repo,
+                            cancellable,
+                            booted_refspec,
+                            NULL,
+                            &checksum,
+                            &new_refspec,
+                            &version,
+                            error))
+    return FALSE;
+
+  if (!is_checksum_an_update (repo, checksum, &commit, error))
+    return FALSE;
+
+  is_update = (commit != NULL);
+  *out_is_update = is_update;
+
+  if (is_update)
+    {
+      out_update_ref_info->refspec = g_steal_pointer (&booted_refspec);
+      out_update_ref_info->remote = g_steal_pointer (&remote);
+      out_update_ref_info->ref = g_steal_pointer (&ref);
+      out_update_ref_info->collection_ref = g_steal_pointer (&collection_ref);
+      out_update_ref_info->new_refspec = g_steal_pointer (&new_refspec);
+      out_update_ref_info->checksum = g_steal_pointer (&checksum);
+      out_update_ref_info->version = g_steal_pointer (&version);
+      out_update_ref_info->commit = g_steal_pointer (&commit);
+    }
+  else
+    {
+      update_ref_info_clear (out_update_ref_info);
+    }
+
+  return TRUE;
+}
+
+static gboolean
+check_for_update_following_checkpoint_commits (OstreeRepo     *repo,
+                                               UpdateRefInfo  *out_update_ref_info,
+                                               GCancellable   *cancellable,
+                                               GError        **error)
+{
+  g_autofree gchar *upgrade_refspec = NULL;
+  g_autofree gchar *remote = NULL;
+  g_autofree gchar *ref = NULL;
+  g_autoptr(OstreeCollectionRef) collection_ref = NULL;
+  g_autofree gchar *new_refspec = NULL;
+  g_autofree gchar *version = NULL;
+  g_autofree gchar *checksum = NULL;
+  g_autoptr(GVariant) commit = NULL;
+
+  g_return_val_if_fail (out_update_ref_info != NULL, FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+  if (!get_refspec_to_upgrade_on (&upgrade_refspec, NULL, NULL, NULL, error))
+    return FALSE;
+
+  if (!fetch_latest_commit (repo,
+                            cancellable,
+                            upgrade_refspec,
+                            NULL,
+                            &checksum,
+                            &new_refspec,
+                            &version,
+                            error))
+    return FALSE;
+
+  out_update_ref_info->refspec = g_steal_pointer (&upgrade_refspec);
+  out_update_ref_info->remote = g_steal_pointer (&remote);
+  out_update_ref_info->ref = g_steal_pointer (&ref);
+  out_update_ref_info->collection_ref = g_steal_pointer (&collection_ref);
+  out_update_ref_info->new_refspec = g_steal_pointer (&new_refspec);
+  out_update_ref_info->checksum = g_steal_pointer (&checksum);
+  out_update_ref_info->version = g_steal_pointer (&version);
+  out_update_ref_info->commit = g_steal_pointer (&commit);
+
+  return TRUE;
+}
+
+static gboolean
+check_for_update_following_checkpoint_if_allowed (OstreeRepo     *repo,
+                                                  UpdateRefInfo  *out_update_ref_info,
+                                                  GCancellable   *cancellable,
+                                                  GError        **error)
+{
+  gboolean had_update_on_branch = FALSE;
+
+  g_return_val_if_fail (out_update_ref_info != NULL, FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+  /* First, check for an update on the booted refspec. If one exists,
+   * use that, since it may mean that we did some emergency fixes
+   * on the booted refspec after the checkpoint and we don't want
+   * to transition users on to the new branch just yet */
+  if (!check_for_update_using_booted_branch (repo,
+                                             &had_update_on_branch,
+                                             out_update_ref_info,
+                                             cancellable,
+                                             error))
+    return FALSE;
+
+  /* Did we have an update? If not, we can follow the checkpoint */
+  if (!had_update_on_branch)
+    {
+      if (!check_for_update_following_checkpoint_commits (repo,
+                                                          out_update_ref_info,
+                                                          cancellable,
+                                                          error))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
 /* May return NULL without setting an error if no updates were found. */
 static EosUpdateInfo *
 metadata_fetch_new (OstreeRepo    *repo,
@@ -270,30 +461,35 @@ metadata_fetch_new (OstreeRepo    *repo,
   g_autofree gchar *checksum = NULL;
   g_autofree gchar *version = NULL;
   g_autoptr(GVariant) commit = NULL;
-  g_autofree gchar *booted_refspec = NULL, *new_refspec = NULL;
-  g_autoptr(OstreeCollectionRef) collection_ref_to_upgrade_on_for_booted_deployment = NULL, new_collection_ref = NULL;
+  g_autofree gchar *new_refspec = NULL;
+  g_autoptr(OstreeCollectionRef) new_collection_ref = NULL;
   const gchar *upgrade_refspec;
   const OstreeCollectionRef *upgrade_collection_ref;
+  g_auto(UpdateRefInfo) update_ref_info;
   g_autoptr(GPtrArray) finders = NULL;  /* (element-type OstreeRepoFinder) */
   g_autoptr(RepoFinderAvahiRunning) finder_avahi = NULL;
   gboolean redirect_followed = FALSE;
 
-  if (!get_refspec_to_upgrade_on (&booted_refspec,
-                                  NULL,
-                                  NULL,
-                                  &collection_ref_to_upgrade_on_for_booted_deployment,
-                                  error))
-    return NULL;
+  update_ref_info_init (&update_ref_info);
 
-  if (collection_ref_to_upgrade_on_for_booted_deployment == NULL)
+  /* The upgrade refspec here is either the booted refspec if
+   * there were new commits on the branch of the booted refspec, or
+   * the checkpoint refspec. */
+  if (!check_for_update_following_checkpoint_if_allowed (repo,
+                                                         &update_ref_info,
+                                                         cancellable,
+                                                         error))
+    return FALSE;
+
+  if (update_ref_info.collection_ref == NULL)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
                    "No collection ID set for currently booted deployment.");
       return NULL;
     }
 
-  upgrade_collection_ref = collection_ref_to_upgrade_on_for_booted_deployment;
-  upgrade_refspec = booted_refspec;
+  upgrade_collection_ref = update_ref_info.collection_ref;
+  upgrade_refspec = update_ref_info.refspec;
 
   finders = get_finders (config, context, &finder_avahi);
   if (finders->len == 0)
@@ -374,7 +570,9 @@ metadata_fetch_new (OstreeRepo    *repo,
     return NULL;
 
   info = eos_update_info_new (checksum, commit,
-                              upgrade_refspec, booted_refspec, version,
+                              upgrade_refspec,
+                              update_ref_info.refspec,
+                              version,
                               NULL, g_steal_pointer (&results));
   metrics_report_successful_poll (info);
 
@@ -390,38 +588,37 @@ metadata_fetch_from_main (OstreeRepo     *repo,
                           GCancellable   *cancellable,
                           GError        **error)
 {
-  g_autofree gchar *refspec = NULL;
-  g_autofree gchar *new_refspec = NULL;
-  g_autofree gchar *version = NULL;
-  g_autoptr(EosUpdateInfo) info = NULL;
-  g_autofree gchar *checksum = NULL;
+  g_auto(UpdateRefInfo) update_ref_info;
   g_autoptr(GVariant) commit = NULL;
+  g_autoptr(EosUpdateInfo) info = NULL;
+
+  update_ref_info_init (&update_ref_info);
 
   g_return_val_if_fail (out_info != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
-  if (!get_refspec_to_upgrade_on (&refspec, NULL, NULL, NULL, error))
+  if (!check_for_update_following_checkpoint_if_allowed (repo,
+                                                         &update_ref_info,
+                                                         cancellable,
+                                                         error))
     return FALSE;
 
-  if (!fetch_latest_commit (repo,
-                            cancellable,
-                            refspec,
-                            NULL,
-                            &checksum,
-                            &new_refspec,
-                            &version,
-                            error))
-    return FALSE;
-
-  if (!is_checksum_an_update (repo, checksum, &commit, error))
+  /* The checksum that is being checked here is either the
+   * most recent commit on the branch (following
+   * eol-rebase redirects) or the checkpoint commit if we have
+   * that. */
+  if (!is_checksum_an_update (repo,
+                              update_ref_info.checksum,
+                              &commit,
+                              error))
     return FALSE;
 
   if (commit != NULL)
-    info = eos_update_info_new (checksum,
+    info = eos_update_info_new (update_ref_info.checksum,
                                 commit,
-                                new_refspec,
-                                refspec,
-                                version,
+                                update_ref_info.new_refspec,
+                                update_ref_info.refspec,
+                                update_ref_info.version,
                                 NULL,
                                 NULL);
 

--- a/test-common/utils.c
+++ b/test-common/utils.c
@@ -162,7 +162,7 @@ get_keyid (GFile *gpg_home)
 static void
 eos_test_subserver_dispose_impl (EosTestSubserver *subserver)
 {
-  g_clear_pointer (&subserver->ref_to_commit, g_hash_table_unref);
+  g_clear_pointer (&subserver->commit_graph, g_hash_table_unref);
   g_clear_pointer (&subserver->additional_files_for_commit, g_hash_table_unref);
   g_clear_pointer (&subserver->additional_directories_for_commit, g_hash_table_unref);
   g_clear_pointer (&subserver->additional_metadata_for_commit, g_hash_table_unref);
@@ -191,7 +191,7 @@ eos_test_subserver_new (const gchar *collection_id,
                         GFile *gpg_home,
                         const gchar *keyid,
                         const gchar *ostree_path,
-                        GHashTable *ref_to_commit,
+                        GHashTable *commit_graph,
                         GHashTable *additional_directories_for_commit,
                         GHashTable *additional_files_for_commit,
                         GHashTable *additional_metadata_for_commit)
@@ -202,7 +202,11 @@ eos_test_subserver_new (const gchar *collection_id,
   subserver->gpg_home = g_object_ref (gpg_home);
   subserver->keyid = g_strdup (keyid);
   subserver->ostree_path = g_strdup (ostree_path);
-  subserver->ref_to_commit = g_hash_table_ref (ref_to_commit);
+  subserver->commit_graph = g_hash_table_ref (commit_graph);
+  subserver->commits_in_repo = g_hash_table_new_full (g_direct_hash,
+                                                      g_direct_equal,
+                                                      NULL,
+                                                      g_free);
   subserver->additional_directories_for_commit = additional_directories_for_commit ? g_hash_table_ref (additional_directories_for_commit) : NULL;
   subserver->additional_files_for_commit = additional_files_for_commit ? g_hash_table_ref (additional_files_for_commit) : NULL;
   subserver->additional_metadata_for_commit = additional_metadata_for_commit ? g_hash_table_ref (additional_metadata_for_commit) : NULL;
@@ -579,14 +583,176 @@ maybe_hashtable_lookup (GHashTable *table,
   return g_hash_table_lookup (table, key);
 }
 
-/* Prepare a commit. It will prepare a sysroot environment and commits
- * from 0 to the given commit_number.
+EosTestUpdaterCommitInfo *
+eos_test_updater_commit_info_new (guint                      sequence_number,
+                                  guint                      parent,
+                                  const OstreeCollectionRef *collection_ref)
+{
+  EosTestUpdaterCommitInfo *commit_info = g_new0 (EosTestUpdaterCommitInfo, 1);
+
+  commit_info->sequence_number = sequence_number;
+  commit_info->parent = parent;
+  commit_info->collection_ref = ostree_collection_ref_dup (collection_ref);
+
+  return commit_info;
+}
+
+void
+eos_test_updater_commit_info_free (EosTestUpdaterCommitInfo *info)
+{
+  g_clear_pointer (&info->collection_ref, ostree_collection_ref_free);
+
+  g_free (info);
+}
+
+typedef gpointer (*CopyFunc) (gpointer);
+
+static gpointer
+no_copy (gpointer value)
+{
+  return value;
+}
+
+/* Flip keys to values and vice versa */
+static GHashTable *
+reverse_hashtable (GHashTable     *ht,
+                   GHashFunc       hash_func,
+                   GEqualFunc      equal_func,
+                   GDestroyNotify  key_destroy,
+                   GDestroyNotify  value_destroy,
+                   CopyFunc        key_copy,
+                   CopyFunc        value_copy)
+{
+  g_autoptr(GHashTable) reversed_ht = g_hash_table_new_full (hash_func,
+                                                             equal_func,
+                                                             key_destroy,
+                                                             value_destroy);
+  gpointer key, value;
+  GHashTableIter iter;
+
+  g_hash_table_iter_init (&iter, ht);
+  while (g_hash_table_iter_next (&iter, &key, &value))
+    g_hash_table_insert (reversed_ht,
+                         (*key_copy) (value),
+                         (*value_copy) (key));
+
+  return g_steal_pointer (&reversed_ht);
+}
+
+void
+eos_test_updater_insert_commit_steal_info (GHashTable               *commit_graph,
+                                           EosTestUpdaterCommitInfo *commit_info)
+{
+  g_hash_table_insert (commit_graph,
+                       GUINT_TO_POINTER (commit_info->sequence_number),
+                       commit_info);
+}
+
+static void
+populate_commit_chain (GHashTable                *commit_graph,
+                       guint                      commit,
+                       const OstreeCollectionRef *collection_ref,
+                       GHashTable                *commit_to_ref)
+{
+  /* Recurse down first until we either hit a commit that is known
+   * in the commit_to_ref table or the zeroeth commit */
+  guint parent_commit = commit == 0 ? commit : commit - 1;
+  gboolean has_parent =
+    (commit > 0 && !g_hash_table_lookup (commit_to_ref, GUINT_TO_POINTER (parent_commit)));
+
+  if (has_parent)
+    populate_commit_chain (commit_graph, parent_commit, collection_ref, commit_to_ref);
+
+  /* Populate commit info now */
+  eos_test_updater_insert_commit_steal_info (commit_graph,
+                                             eos_test_updater_commit_info_new (commit,
+                                                                               parent_commit,
+                                                                               collection_ref));
+}
+
+static gint
+sort_commits (gconstpointer lhs, gconstpointer rhs)
+{
+  /* Technically this is playing games with casting -
+   * we should not have commits larger than G_MAXINT here */
+  gint lhs_commit = GPOINTER_TO_INT (lhs);
+  gint rhs_commit = GPOINTER_TO_INT (rhs);
+
+  /* Descending */
+  return rhs_commit - lhs_commit;
+}
+
+/**
+ * eos_test_updater_populate_commit_graph_from_leaf_nodes:
+ * @commit_graph: A #GHashTable
+ * @leaf_nodes: (element-type guint OstreeCollectionRef) A #GHashTable mapping
+ *              leaf commit ids to OstreeCollectionRef.
+ *
+ * "Fill in" the rest of the commit graph from the @leaf_nodes down. Each
+ * parent of a leaf node will use the same #OstreeCollectionRef, unless another
+ * entry was specified in @leaf_nodes with that commit id, at which point parents
+ * of that commit will use that #OstreeCollectionRef instead.
+ *
+ * This function destroys any existing graph structure and populates the graph
+ * from scratch.
+ *
  */
+void
+eos_test_updater_populate_commit_graph_from_leaf_nodes (GHashTable *commit_graph,
+                                                        GHashTable *leaf_nodes)
+{
+  g_autoptr(GHashTable) commit_to_ref = reverse_hashtable (leaf_nodes,
+                                                           g_direct_hash,
+                                                           g_direct_equal,
+                                                           NULL,
+                                                           (GDestroyNotify) ostree_collection_ref_free,
+                                                           no_copy,
+                                                           (CopyFunc) ostree_collection_ref_dup);
+
+  /* Each of the key-value pairs in leaf_nodes points to a candidate
+   * leaf node for a given refspec. From there we recursively go down the
+   * tree and create new EosTestUpdaterCommitInfo objects, unless we
+   * see an entry for that commit in commit_to_ref (we'll start from
+   * that key the next time around */
+  g_autoptr(GList) commit_keys = g_list_sort (g_hash_table_get_keys (commit_to_ref),
+                                              sort_commits);
+
+  /* Clear the hash-table first */
+  g_hash_table_remove_all (commit_graph);
+
+  for (GList *iter = commit_keys; iter != NULL; iter = iter->next)
+    {
+      guint commit = GPOINTER_TO_UINT (iter->data);
+      const OstreeCollectionRef *collection_ref =
+        g_hash_table_lookup (commit_to_ref, GUINT_TO_POINTER (commit));
+      populate_commit_chain (commit_graph,
+                             commit,
+                             collection_ref,
+                             commit_to_ref);
+    }
+}
+
+GHashTable *
+eos_test_updater_commit_graph_new_from_leaf_nodes (GHashTable *leaf_nodes)
+{
+  GHashTable *commit_graph = g_hash_table_new_full (g_direct_hash,
+                                                    g_direct_equal,
+                                                    NULL,
+                                                    (GDestroyNotify) eos_test_updater_commit_info_free);
+
+  if (leaf_nodes != NULL)
+    eos_test_updater_populate_commit_graph_from_leaf_nodes (commit_graph,
+                                                            leaf_nodes);
+
+  return commit_graph;
+}
+
+/* Prepare a commit. This function no longer recursively
+ * prepares commits, that is now the responsibility of the caller */
 static gboolean
 prepare_commit (GFile *repo,
                 GFile *tree_root,
-                guint commit_number,
-                const OstreeCollectionRef *collection_ref,
+                EosTestUpdaterCommitInfo *commit_info,
                 GFile *gpg_home,
                 const gchar *keyid,
                 GHashTable *additional_directories_for_commit,
@@ -598,6 +764,8 @@ prepare_commit (GFile *repo,
   g_auto(CmdResult) cmd = CMD_RESULT_CLEARED;
   g_autoptr(GDateTime) timestamp = NULL;
   g_autofree gchar *subject = NULL;
+  guint commit_number = commit_info->sequence_number;
+  const OstreeCollectionRef *collection_ref = commit_info->collection_ref;
 
   if (commit_number > max_commit_number)
     {
@@ -623,27 +791,27 @@ prepare_commit (GFile *repo,
       }
   }
 
-  if (commit_number > 0)
+  /* Only need to prepare sysroot contents on the first commit */
+  if (commit_number == 0)
     {
-      if (!prepare_commit (repo,
-                           tree_root,
-                           commit_number - 1,
-                           collection_ref,
-                           gpg_home,
-                           keyid,
-                           additional_directories_for_commit,
-                           additional_files_for_commit,
-                           additional_metadata_for_commit,
-                           NULL,
-                           error))
+      if (!prepare_sysroot_contents (repo,
+                                     tree_root,
+                                     error))
         return FALSE;
     }
-  else
-    if (!prepare_sysroot_contents (repo,
-                                   tree_root,
-                                   error))
-      return FALSE;
 
+  /* FIXME: Right now this unconditionally puts all the files for a given
+   * commit into the tree and does not clean up afterwards. This is fine
+   * for linear histories, but could have some unexpected results for non-linear
+   * histories.
+   *
+   * At the moment this does not negatively impact the tests as the tests which
+   * test non-linear histories don't test the actual files in a commit.
+   *
+   * We could clean all this up between commits, however, that would probably make
+   * test performance worse since it would mean that we would have to delete
+   * and recreate files (especially large ones!) on each commit.
+   */
   if (!create_commit_files_and_directories (tree_root, commit_number, error))
     return FALSE;
 
@@ -665,7 +833,7 @@ prepare_commit (GFile *repo,
   if (!ostree_commit (repo,
                       tree_root,
                       subject,
-                      collection_ref->ref_name,
+                      commit_info->collection_ref->ref_name,
                       gpg_home,
                       keyid,
                       timestamp,
@@ -679,7 +847,10 @@ prepare_commit (GFile *repo,
     return FALSE;
 
   if (out_checksum != NULL)
-    return get_current_commit_checksum (repo, collection_ref, out_checksum, error);
+    return get_current_commit_checksum (repo,
+                                        commit_info->collection_ref,
+                                        out_checksum,
+                                        error);
 
   return TRUE;
 }
@@ -699,105 +870,144 @@ generate_delta_files (GFile *repo,
 }
 
 /**
- * get_last_ref:
- * @ref_to_commit: (element-type utf8 uint): a #GHashTable mapping refs to commit numbers.
- * @wanted_commit_number: the commit number to count down from.
+ * eos_test_updater_commit_graph_walk:
+ * @commit_graph: A #GHashTable
+ * @walk_func: A #EosTestUpdaterCommitGraphWalkFunc called on each node in level order
+ * @walk_func_data: Closure for @walk_func
+ * @error: A #GError
  *
- * Look through the ref_to_commit hashtable (which maps refs to
- * commit numbers) to try and find the last known ref before
- * wanted_commit_number. It handles the case where we have commits
- * N, N - J and don't have (N - 1)..(N - J) in the hashtable.
+ * Walk the commit graph in a breadth-first fashion, traversing
+ * in a level order. walk_func will be called on each commit with
+ * the #EosTestUpdaterCommitInfo for each commit as well as its parent.
  *
- * Returns: the last known ref before wanted_commit_number
+ * @walk_func may mutate outer state and may fail.
+ *
+ * The implementation here is a little awkward since we need to do
+ * an O(V) linear scan to expand children for each node, making the
+ * walk cost O(V^2).
+ *
+ * Returns: %TRUE if no @walk_func invocation failed on the graph, %FALSE with
+ *          @error set otherwise.
  */
-static OstreeCollectionRef *
-get_last_ref (GHashTable *ref_to_commit,
-              guint       wanted_commit_number)
+gboolean
+eos_test_updater_commit_graph_walk (GHashTable                         *commit_graph,
+                                    EosTestUpdaterCommitGraphWalkFunc   walk_func,
+                                    gpointer                            walk_func_data,
+                                    GError                            **error)
 {
-  gpointer key = NULL;
-  gpointer value = NULL;
+  GQueue queue = G_QUEUE_INIT;
 
-  g_assert (wanted_commit_number > 0);
+  g_queue_init (&queue);
+  g_queue_push_tail (&queue, GUINT_TO_POINTER (0));
 
-  /* Decrement at least once, since we want to find a commit
-   * before this one */
-  wanted_commit_number--;
-
-  for (; wanted_commit_number > 0; wanted_commit_number--)
+  while (!g_queue_is_empty (&queue))
     {
+      guint commit = GPOINTER_TO_UINT (g_queue_pop_head (&queue));
       GHashTableIter iter;
+      gpointer key, value;
+      EosTestUpdaterCommitInfo *commit_info =
+        g_hash_table_lookup (commit_graph,
+                             GUINT_TO_POINTER (commit));
+      EosTestUpdaterCommitInfo *parent_commit_info =
+        g_hash_table_lookup (commit_graph,
+                             GUINT_TO_POINTER (commit_info->parent));
 
-      g_hash_table_iter_init (&iter, ref_to_commit);
+      /* Process node */
+      if (!((*walk_func) (commit_info,
+                          commit == commit_info->parent ? NULL : parent_commit_info,
+                          walk_func_data,
+                          error)))
+        {
+          g_queue_clear (&queue);
+          return FALSE;
+        }
+
+      g_hash_table_iter_init (&iter, commit_graph);
       while (g_hash_table_iter_next (&iter, &key, &value))
         {
-          guint commit_number = GPOINTER_TO_UINT (value);
+          guint candidate_child = GPOINTER_TO_UINT (key);
+          guint candidate_parent = ((EosTestUpdaterCommitInfo *) value)->parent;
 
-          if (commit_number == wanted_commit_number)
-            return key;
+          /* Special case - root node has self as parent, ignore this */
+          if (candidate_parent == commit &&
+              candidate_parent != candidate_child)
+            g_queue_push_tail (&queue, GUINT_TO_POINTER (candidate_child));
         }
     }
 
-  return NULL;
+  g_queue_clear (&queue);
+  return TRUE;
 }
 
-/* Updates the subserver to a new commit number in the ref_to_commit
- * hash table.  This involves creating the commits, generating ref
- * files and delta files, and updating the summary.
+static gboolean
+make_commit_if_not_available (EosTestUpdaterCommitInfo  *commit_info,
+                              EosTestUpdaterCommitInfo  *parent_commit_info,
+                              gpointer                   user_data,
+                              GError                   **error)
+{
+  EosTestSubserver *subserver = user_data;
+  g_autofree gchar *checksum = NULL;
+
+  /* Commit is already in the repo, ignore.
+   *
+   * We can't insert the commit into this table just yet, we
+   * need to make it first in order to get the checksum.
+   */
+  if (g_hash_table_contains (subserver->commits_in_repo,
+                             GUINT_TO_POINTER (commit_info->sequence_number)))
+    return TRUE;
+
+  /* Make the commit */
+  if (!prepare_commit (subserver->repo,
+                       subserver->tree,
+                       commit_info,
+                       subserver->gpg_home,
+                       subserver->keyid,
+                       subserver->additional_directories_for_commit,
+                       subserver->additional_files_for_commit,
+                       subserver->additional_metadata_for_commit,
+                       &checksum,
+                       error))
+    return FALSE;
+
+  if (parent_commit_info != NULL)
+    {
+      const gchar *old_checksum = g_hash_table_lookup (subserver->commits_in_repo,
+                                                       GUINT_TO_POINTER (parent_commit_info->sequence_number));
+
+      g_assert_nonnull (old_checksum);
+
+      if (!generate_delta_files (subserver->repo,
+                                 old_checksum,
+                                 checksum,
+                                 error))
+        return FALSE;
+    }
+
+  /* Insert commit checksum into hashtable */
+  g_hash_table_insert (subserver->commits_in_repo,
+                       GUINT_TO_POINTER (commit_info->sequence_number),
+                       g_strdup (checksum));
+
+  return TRUE;
+}
+
+/* Updates the subserver to reflect the state of
+ * the internal commit graph.  This involves
+ * creating the commits, generating ref files and
+ * delta files, and updating the summary.
  */
 static gboolean
 update_commits (EosTestSubserver *subserver,
                 GError **error)
 {
-  GHashTableIter iter;
-  gpointer collection_ref_ptr;
-  gpointer commit_ptr;
   g_auto(CmdResult) cmd = CMD_RESULT_CLEARED;
 
-  g_hash_table_iter_init (&iter, subserver->ref_to_commit);
-  while (g_hash_table_iter_next (&iter, &collection_ref_ptr, &commit_ptr))
-    {
-      const OstreeCollectionRef *collection_ref = collection_ref_ptr;
-      guint commit_number = GPOINTER_TO_UINT (commit_ptr);
-      g_autofree gchar *checksum = NULL;
-      g_autofree gchar *old_checksum = NULL;
-
-
-      if (commit_number > 0)
-        {
-          /* O(N^2), sadly */
-          const OstreeCollectionRef *last_ref = get_last_ref (subserver->ref_to_commit,
-                                                              commit_number);
-          /* Get the checksum of the commit on the last ref, since
-           * it may have changed in the meantime */
-          if (!get_current_commit_checksum (subserver->repo,
-                                            (last_ref != NULL) ? last_ref : collection_ref,
-                                            &old_checksum,
-                                            error))
-            return FALSE;
-        }
-
-      if (!prepare_commit (subserver->repo,
-                           subserver->tree,
-                           commit_number,
-                           collection_ref,
-                           subserver->gpg_home,
-                           subserver->keyid,
-                           subserver->additional_directories_for_commit,
-                           subserver->additional_files_for_commit,
-                           subserver->additional_metadata_for_commit,
-                           &checksum,
-                           error))
-        return FALSE;
-
-      if (commit_number > 0)
-        {
-          if (!generate_delta_files (subserver->repo,
-                                     old_checksum,
-                                     checksum,
-                                     error))
-            return FALSE;
-        }
-    }
+  if (!eos_test_updater_commit_graph_walk (subserver->commit_graph,
+                                           make_commit_if_not_available,
+                                           subserver,
+                                           error))
+    return FALSE;
 
   if (!ostree_summary (subserver->repo,
                        subserver->gpg_home,
@@ -815,6 +1025,14 @@ repo_config_exists (GFile *repo)
   g_autoptr(GFile) config = g_file_get_child (repo, "config");
 
   return g_file_query_exists (config, NULL);
+}
+
+void
+eos_test_subserver_populate_commit_graph_from_leaf_nodes (EosTestSubserver *subserver,
+                                                          GHashTable       *leaf_nodes)
+{
+  eos_test_updater_populate_commit_graph_from_leaf_nodes (subserver->commit_graph,
+                                                          leaf_nodes);
 }
 
 gboolean
@@ -1008,16 +1226,19 @@ eos_test_server_new_quick (GFile *server_root,
                            GError **error)
 {
   g_autoptr(GPtrArray) subservers = object_array_new ();
-  g_autoptr(GHashTable) ref_to_commit = eos_test_subserver_ref_to_commit_new ();
+  g_autoptr(GHashTable) leaf_commit_nodes = eos_test_subserver_ref_to_commit_new ();
+  g_autoptr(GHashTable) commit_graph = NULL;
 
-  g_hash_table_insert (ref_to_commit,
+  g_hash_table_insert (leaf_commit_nodes,
                        ostree_collection_ref_dup (collection_ref),
                        GUINT_TO_POINTER (commit_number));
+  commit_graph = eos_test_updater_commit_graph_new_from_leaf_nodes (leaf_commit_nodes);
+
   g_ptr_array_add (subservers, eos_test_subserver_new (collection_ref->collection_id,
                                                        gpg_home,
                                                        keyid,
                                                        ostree_path,
-                                                       ref_to_commit,
+                                                       commit_graph,
                                                        additional_directories_for_commit,
                                                        additional_files_for_commit,
                                                        additional_metadata_for_commit));
@@ -1611,7 +1832,21 @@ static gboolean
 ensure_ref_in_subserver (const OstreeCollectionRef *collection_ref,
                          EosTestSubserver *subserver)
 {
-  return g_hash_table_lookup_extended (subserver->ref_to_commit, collection_ref, NULL, NULL);
+  /* Linear scan of commit infos to check if the ref is
+   * in the commit_graph */
+  GHashTableIter iter;
+  gpointer value;
+
+  g_hash_table_iter_init (&iter, subserver->commit_graph);
+  while (g_hash_table_iter_next (&iter, NULL, &value))
+    {
+      EosTestUpdaterCommitInfo *commit_info = value;
+
+      if (ostree_collection_ref_equal (commit_info->collection_ref, collection_ref))
+        return TRUE;
+    }
+
+  return FALSE;
 }
 
 EosTestClient *

--- a/test-common/utils.c
+++ b/test-common/utils.c
@@ -1861,7 +1861,15 @@ eos_test_client_new (GFile *client_root,
   g_autoptr(EosTestClient) client = NULL;
 
   if (!ensure_ref_in_subserver (collection_ref, subserver))
-    return FALSE;
+    {
+      g_set_error (error,
+                   G_IO_ERROR,
+                   G_IO_ERROR_FAILED,
+                   "Could not find collection ref %s:%s in subserver commits",
+                   collection_ref->collection_id,
+                   collection_ref->ref_name);
+      return FALSE;
+    }
 
   if (!prepare_client_sysroot (client_root,
                                remote_name,

--- a/tests/test-update-direct.c
+++ b/tests/test-update-direct.c
@@ -222,6 +222,8 @@ test_cancel_update (EosUpdaterFixture *fixture,
   g_autoptr(EosTestClient) client = NULL;
   g_autoptr(EosUpdater) updater = NULL;
   g_autoptr(GMainLoop) loop = g_main_loop_new (NULL, FALSE);
+  g_autoptr(GHashTable) leaf_commit_nodes =
+    eos_test_subserver_ref_to_commit_new ();
   DownloadSource main_source = DOWNLOAD_MAIN;
   gboolean has_commit;
   gulong state_change_handler = 0;
@@ -235,9 +237,11 @@ test_cancel_update (EosUpdaterFixture *fixture,
                                   &local_error);
   g_assert_no_error (local_error);
 
-  g_hash_table_insert (subserver->ref_to_commit,
+  g_hash_table_insert (leaf_commit_nodes,
                        ostree_collection_ref_dup (default_collection_ref),
                        GUINT_TO_POINTER (1));
+  eos_test_subserver_populate_commit_graph_from_leaf_nodes (subserver,
+                                                            leaf_commit_nodes);
   eos_test_subserver_update (subserver,
                              &local_error);
   g_assert_no_error (local_error);
@@ -306,6 +310,8 @@ test_update_version (EosUpdaterFixture *fixture,
   g_autoptr(EosTestClient) client = NULL;
   g_autoptr(EosUpdater) updater = NULL;
   g_autoptr(GMainLoop) loop = g_main_loop_new (NULL, FALSE);
+  g_autoptr(GHashTable) leaf_commit_nodes =
+    eos_test_subserver_ref_to_commit_new ();
   DownloadSource main_source = DOWNLOAD_MAIN;
   const gchar *version = (user_data != NULL) ? (const gchar *) user_data : "";
 
@@ -315,13 +321,15 @@ test_update_version (EosUpdaterFixture *fixture,
   setup_basic_test_server_client (fixture, &server, &subserver, &client, &error);
   g_assert_no_error (error);
 
-  g_hash_table_insert (subserver->ref_to_commit,
+  g_hash_table_insert (leaf_commit_nodes,
                        ostree_collection_ref_dup (default_collection_ref),
                        GUINT_TO_POINTER (1));
   if (version != NULL)
     eos_test_add_metadata_for_commit (&subserver->additional_metadata_for_commit,
                                       1, "version", version);
 
+  eos_test_subserver_populate_commit_graph_from_leaf_nodes (subserver,
+                                                            leaf_commit_nodes);
   eos_test_subserver_update (subserver, &error);
   g_assert_no_error (error);
 

--- a/tests/test-update-from-lan.c
+++ b/tests/test-update-from-lan.c
@@ -53,6 +53,8 @@ test_update_from_lan (EosUpdaterFixture *fixture,
   gboolean has_commit;
   DownloadSource lan_source = DOWNLOAD_LAN;
   g_autoptr(GPtrArray) override_uris = NULL;
+  g_autoptr(GHashTable) leaf_commit_nodes =
+    eos_test_subserver_ref_to_commit_new ();
 
   /* We could get OSTree working by setting OSTREE_BOOTID, but shortly
    * afterwards we hit unsupported syscalls in qemu-user when running in an
@@ -105,9 +107,11 @@ test_update_from_lan (EosUpdaterFixture *fixture,
 
       g_test_message ("Updating subserver %u", idx);
 
-      g_hash_table_insert (subserver->ref_to_commit,
+      g_hash_table_insert (leaf_commit_nodes,
                            ostree_collection_ref_dup (default_collection_ref),
                            GUINT_TO_POINTER (1 + idx));
+      eos_test_subserver_populate_commit_graph_from_leaf_nodes (subserver,
+                                                                leaf_commit_nodes);
       eos_test_subserver_update (subserver,
                                  &error);
       g_assert_no_error (error);

--- a/tests/test-update-from-main.c
+++ b/tests/test-update-from-main.c
@@ -45,6 +45,8 @@ test_update_from_main (EosUpdaterFixture *fixture,
   g_autoptr(GPtrArray) cmds = NULL;
   gboolean has_commit;
   DownloadSource main_source = DOWNLOAD_MAIN;
+  g_autoptr(GHashTable) leaf_commit_nodes =
+    eos_test_subserver_ref_to_commit_new ();
 
   /* We could get OSTree working by setting OSTREE_BOOTID, but shortly
    * afterwards we hit unsupported syscalls in qemu-user when running in an
@@ -80,9 +82,11 @@ test_update_from_main (EosUpdaterFixture *fixture,
                                 &error);
   g_assert_no_error (error);
 
-  g_hash_table_insert (subserver->ref_to_commit,
+  g_hash_table_insert (leaf_commit_nodes,
                        ostree_collection_ref_dup (default_collection_ref),
                        GUINT_TO_POINTER (1));
+  eos_test_subserver_populate_commit_graph_from_leaf_nodes (subserver,
+                                                            leaf_commit_nodes);
   eos_test_subserver_update (subserver,
                              &error);
   g_assert_no_error (error);

--- a/tests/test-update-from-volume.c
+++ b/tests/test-update-from-volume.c
@@ -50,6 +50,8 @@ test_update_from_volume (EosUpdaterFixture *fixture,
   gboolean has_commit;
   DownloadSource volume_source = DOWNLOAD_VOLUME;
   g_autoptr(GPtrArray) override_uris = NULL;
+  g_autoptr(GHashTable) leaf_commit_nodes =
+    eos_test_subserver_ref_to_commit_new ();
 
   /* We could get OSTree working by setting OSTREE_BOOTID, but shortly
    * afterwards we hit unsupported syscalls in qemu-user when running in an
@@ -85,9 +87,11 @@ test_update_from_volume (EosUpdaterFixture *fixture,
                                  &error);
   g_assert_no_error (error);
 
-  g_hash_table_insert (subserver->ref_to_commit,
+  g_hash_table_insert (leaf_commit_nodes,
                        ostree_collection_ref_dup (default_collection_ref),
                        GUINT_TO_POINTER (1));
+  eos_test_subserver_populate_commit_graph_from_leaf_nodes (subserver,
+                                                            leaf_commit_nodes);
   eos_test_subserver_update (subserver,
                              &error);
   g_assert_no_error (error);

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -215,6 +215,351 @@ test_update_refspec_checkpoint (EosUpdaterFixture *fixture,
   g_assert_true (has_commit);
 }
 
+/* Start with a commit, and then make a final commit on the first refspec
+ * which adds a new marker, such that when that commit is deployed, the updater
+ * will know to use a new refspec to upgrade with. However, say we screwed
+ * up and need to do a maintenance fix on the old branch. The commit from the
+ * old branch should be preferred on the next update such that the
+ * old refspec is still in use on reboot.
+ *
+ *  REFv2              (4)
+ *                    /
+ *                   /
+ *  REF (0)--(1)--(2)--(3)
+ *
+ * (2) is a checkpoint. (3) is a maintenance commit on the original
+ * "REF" refspec.
+ */
+static void
+test_update_refspec_checkpoint_continue_old_branch (EosUpdaterFixture *fixture,
+                                                    gconstpointer user_data)
+{
+  g_autoptr(GFile) server_root = NULL;
+  g_autoptr(EosTestServer) server = NULL;
+  g_autofree gchar *keyid = get_keyid (fixture->gpg_home);
+  g_autoptr(GError) error = NULL;
+  g_autoptr(EosTestSubserver) subserver = NULL;
+  g_autoptr(GFile) client_root = NULL;
+  g_autoptr(EosTestClient) client = NULL;
+  g_autoptr(GHashTable) additional_metadata_for_commit = NULL;
+  gboolean has_commit;
+
+  /* We could get OSTree working by setting OSTREE_BOOTID, but shortly
+   * afterwards we hit unsupported syscalls in qemu-user when running in an
+   * ARM chroot (for example), so just bail. */
+  if (!eos_test_has_ostree_boot_id ())
+    {
+      g_test_skip ("OSTree will not work without a boot ID");
+      return;
+    }
+
+  insert_update_refspec_metadata_for_commit (1,
+                                             next_refspec,
+                                             &additional_metadata_for_commit);
+
+  server_root = g_file_get_child (fixture->tmpdir, "main");
+  server = eos_test_server_new_quick (server_root,
+                                      default_vendor,
+                                      default_product,
+                                      default_collection_ref,
+                                      0,
+                                      fixture->gpg_home,
+                                      keyid,
+                                      default_ostree_path,
+                                      NULL,
+                                      NULL,
+                                      additional_metadata_for_commit,
+                                      &error);
+  g_assert_no_error (error);
+  g_assert_cmpuint (server->subservers->len, ==, 1u);
+
+  subserver = g_object_ref (EOS_TEST_SUBSERVER (g_ptr_array_index (server->subservers, 0)));
+  client_root = g_file_get_child (fixture->tmpdir, "client");
+  client = eos_test_client_new (client_root,
+                                default_remote_name,
+                                subserver,
+                                default_collection_ref,
+                                default_vendor,
+                                default_product,
+                                &error);
+  g_assert_no_error (error);
+
+  eos_test_updater_insert_commit_steal_info (subserver->commit_graph,
+                                             eos_test_updater_commit_info_new (1,
+                                                                               0,
+                                                                               default_collection_ref));
+
+  /* Also insert a commit (2) for the refspec "REMOTE:REFv2". The first time we
+   * update, we should only update to commit 1, but when we switch over
+   * the ref we pull from, we should have commit 2. */
+  eos_test_updater_insert_commit_steal_info (subserver->commit_graph,
+                                             eos_test_updater_commit_info_new (2,
+                                                                               1,
+                                                                               next_collection_ref));
+  eos_test_subserver_update (subserver,
+                             &error);
+  g_assert_no_error (error);
+
+  /* Now update the client. We stopped making commits on this
+   * ref, so it is effectively a "checkpoint" and we should only have
+   * the first commit. */
+  update_client (fixture, client);
+
+  eos_test_client_has_commit (client,
+                              default_remote_name,
+                              1,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_true (has_commit);
+
+  eos_test_client_has_commit (client,
+                              default_remote_name,
+                              2,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_false (has_commit);
+
+  /* Now, let's say we screw up something and need to do an update on
+   * the old branch. Insert another commit, but this time without the
+   * metadata. */
+  eos_test_updater_insert_commit_steal_info (subserver->commit_graph,
+                                             eos_test_updater_commit_info_new (3,
+                                                                               1,
+                                                                               default_collection_ref));
+  /* For completeness insert a new commit on the checkpoint branch */
+  eos_test_updater_insert_commit_steal_info (subserver->commit_graph,
+                                             eos_test_updater_commit_info_new (4,
+                                                                               2,
+                                                                               next_collection_ref));
+  eos_test_subserver_update (subserver,
+                             &error);
+  g_assert_no_error (error);
+
+  /* Update the client again. Even though we deployed
+   * the checkpoint, we should not have the new commit that
+   * came from the checkpoint branch. Instead we should
+   * have the newest commit on the non-checkpoint branch */
+  update_client (fixture, client);
+
+  eos_test_client_has_commit (client,
+                              default_remote_name,
+                              4,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_false (has_commit);
+
+  eos_test_client_has_commit (client,
+                              default_remote_name,
+                              3,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_true (has_commit);
+}
+
+/* Start with a commit, and then make a final commit on the first refspec
+ * which adds a new marker, such that when that commit is deployed, the updater
+ * will know to use a new refspec to upgrade with. However, say we screwed
+ * up and need to do a maintenance fix on the old branch. The commit from the
+ * old branch should be preferred on the next update such that the
+ * old refspec is still in use on reboot. However, later on we create
+ * another checkpoint commit on the newest commit in the old branch. That
+ * should take us to our new branch.
+ *
+ *  REFv2             (4)      (6)
+ *                   /         /
+ *                  /         /
+ *  REF (0)--(1)--(2)--(3)--(5)
+ *
+ * (2) is a checkpoint. (3) is a maintenance commit on the original
+ * "REF" refspec. (5) is another checkpoint. Note that (2) is the parent
+ * of (4) and (5) is the parent of (6) in the sense that static deltas
+ * will be generated between those two.
+ *
+ */
+static void
+test_update_refspec_checkpoint_continue_old_branch_then_new_branch (EosUpdaterFixture *fixture,
+                                                                    gconstpointer user_data)
+{
+  g_autoptr(GFile) server_root = NULL;
+  g_autoptr(EosTestServer) server = NULL;
+  g_autofree gchar *keyid = get_keyid (fixture->gpg_home);
+  g_autoptr(GError) error = NULL;
+  g_autoptr(EosTestSubserver) subserver = NULL;
+  g_autoptr(GFile) client_root = NULL;
+  g_autoptr(EosTestClient) client = NULL;
+  g_autoptr(GHashTable) additional_metadata_for_commit = NULL;
+  gboolean has_commit;
+
+  /* We could get OSTree working by setting OSTREE_BOOTID, but shortly
+   * afterwards we hit unsupported syscalls in qemu-user when running in an
+   * ARM chroot (for example), so just bail. */
+  if (!eos_test_has_ostree_boot_id ())
+    {
+      g_test_skip ("OSTree will not work without a boot ID");
+      return;
+    }
+
+  insert_update_refspec_metadata_for_commit (1,
+                                             next_refspec,
+                                             &additional_metadata_for_commit);
+  insert_update_refspec_metadata_for_commit (5,
+                                             next_refspec,
+                                             &additional_metadata_for_commit);
+
+  server_root = g_file_get_child (fixture->tmpdir, "main");
+  server = eos_test_server_new_quick (server_root,
+                                      default_vendor,
+                                      default_product,
+                                      default_collection_ref,
+                                      0,
+                                      fixture->gpg_home,
+                                      keyid,
+                                      default_ostree_path,
+                                      NULL,
+                                      NULL,
+                                      additional_metadata_for_commit,
+                                      &error);
+  g_assert_no_error (error);
+  g_assert_cmpuint (server->subservers->len, ==, 1u);
+
+  subserver = g_object_ref (EOS_TEST_SUBSERVER (g_ptr_array_index (server->subservers, 0)));
+  client_root = g_file_get_child (fixture->tmpdir, "client");
+  client = eos_test_client_new (client_root,
+                                default_remote_name,
+                                subserver,
+                                default_collection_ref,
+                                default_vendor,
+                                default_product,
+                                &error);
+  g_assert_no_error (error);
+
+  eos_test_updater_insert_commit_steal_info (subserver->commit_graph,
+                                             eos_test_updater_commit_info_new (1,
+                                                                               0,
+                                                                               default_collection_ref));
+
+  /* Also insert a commit (2) for the refspec "REMOTE:REFv2". The first time we
+   * update, we should only update to commit 1, but when we switch over
+   * the ref we pull from, we should have commit 2. */
+  eos_test_updater_insert_commit_steal_info (subserver->commit_graph,
+                                             eos_test_updater_commit_info_new (2,
+                                                                               1,
+                                                                               next_collection_ref));
+  eos_test_subserver_update (subserver,
+                             &error);
+  g_assert_no_error (error);
+
+  /* Now update the client. We stopped making commits on this
+   * ref, so it is effectively a "checkpoint" and we should only have
+   * the first commit. */
+  update_client (fixture, client);
+
+  eos_test_client_has_commit (client,
+                              default_remote_name,
+                              1,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_true (has_commit);
+
+  eos_test_client_has_commit (client,
+                              default_remote_name,
+                              2,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_false (has_commit);
+
+  /* Now, let's say we screw up something and need to do an update on
+   * the old branch. Insert another commit, but this time without the
+   * metadata. */
+  eos_test_updater_insert_commit_steal_info (subserver->commit_graph,
+                                             eos_test_updater_commit_info_new (3,
+                                                                               1,
+                                                                               default_collection_ref));
+  /* For completeness insert a new commit on the checkpoint branch */
+  eos_test_updater_insert_commit_steal_info (subserver->commit_graph,
+                                             eos_test_updater_commit_info_new (4,
+                                                                               2,
+                                                                               next_collection_ref));
+  eos_test_subserver_update (subserver,
+                             &error);
+  g_assert_no_error (error);
+
+  /* Update the client again. Even though we deployed
+   * the checkpoint, we should not have the new commit that
+   * came from the checkpoint branch. Instead we should
+   * have the newest commit on the non-checkpoint branch */
+  update_client (fixture, client);
+
+  eos_test_client_has_commit (client,
+                              default_remote_name,
+                              4,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_false (has_commit);
+
+  eos_test_client_has_commit (client,
+                              default_remote_name,
+                              3,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_true (has_commit);
+
+  /* Finally, we create another commit on the old branch
+   * which is a checkpoint and a new commit on the new branch
+   * which continues off from the old branch */
+  eos_test_updater_insert_commit_steal_info (subserver->commit_graph,
+                                             eos_test_updater_commit_info_new (5,
+                                                                               3,
+                                                                               default_collection_ref));
+  eos_test_updater_insert_commit_steal_info (subserver->commit_graph,
+                                             eos_test_updater_commit_info_new (6,
+                                                                               5,
+                                                                               next_collection_ref));
+  eos_test_subserver_update (subserver,
+                             &error);
+  g_assert_no_error (error);
+
+  /* Update the client. We should stop
+   * at the checkpoint commit again. */
+  update_client (fixture, client);
+
+  eos_test_client_has_commit (client,
+                              default_remote_name,
+                              6,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_false (has_commit);
+
+  eos_test_client_has_commit (client,
+                              default_remote_name,
+                              5,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_true (has_commit);
+
+  /* Update one more time. We should now have the
+   * commit on the post-checkpoint branch. */
+  update_client (fixture, client);
+
+  eos_test_client_has_commit (client,
+                              default_remote_name,
+                              6,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_true (has_commit);
+}
+
 int
 main (int argc,
       char **argv)
@@ -226,6 +571,12 @@ main (int argc,
   eos_test_add ("/updater/update-refspec-checkpoint",
                 NULL,
                 test_update_refspec_checkpoint);
+  eos_test_add ("/updater/update-refspec-checkpoint-continue-old-branch",
+                NULL,
+                test_update_refspec_checkpoint_continue_old_branch);
+  eos_test_add ("/updater/update-refspec-checkpoint-continue-old-branch-then-new-branch",
+                NULL,
+                test_update_refspec_checkpoint_continue_old_branch_then_new_branch);
 
   return g_test_run ();
 }

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -120,6 +120,8 @@ test_update_refspec_checkpoint (EosUpdaterFixture *fixture,
   g_autoptr(GFile) client_root = NULL;
   g_autoptr(EosTestClient) client = NULL;
   g_autoptr(GHashTable) additional_metadata_for_commit = NULL;
+  g_autoptr(GHashTable) leaf_commit_nodes =
+    eos_test_subserver_ref_to_commit_new ();
   gboolean has_commit;
 
   /* We could get OSTree working by setting OSTREE_BOOTID, but shortly
@@ -162,7 +164,7 @@ test_update_refspec_checkpoint (EosUpdaterFixture *fixture,
                                 &error);
   g_assert_no_error (error);
 
-  g_hash_table_insert (subserver->ref_to_commit,
+  g_hash_table_insert (leaf_commit_nodes,
                        ostree_collection_ref_dup (default_collection_ref),
                        GUINT_TO_POINTER (1));
   eos_test_subserver_update (subserver,
@@ -172,9 +174,11 @@ test_update_refspec_checkpoint (EosUpdaterFixture *fixture,
   /* Also insert a commit (2) for the refspec "REMOTE:REFv2". The first time we
    * update, we should only update to commit 1, but when we switch over
    * the ref we pull from, we should have commit 2. */
-  g_hash_table_insert (subserver->ref_to_commit,
+  g_hash_table_insert (leaf_commit_nodes,
                        ostree_collection_ref_dup (next_collection_ref),
                        GUINT_TO_POINTER (2));
+  eos_test_subserver_populate_commit_graph_from_leaf_nodes (subserver,
+                                                            leaf_commit_nodes);
   eos_test_subserver_update (subserver,
                              &error);
   g_assert_no_error (error);

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -167,9 +167,6 @@ test_update_refspec_checkpoint (EosUpdaterFixture *fixture,
   g_hash_table_insert (leaf_commit_nodes,
                        ostree_collection_ref_dup (default_collection_ref),
                        GUINT_TO_POINTER (1));
-  eos_test_subserver_update (subserver,
-                             &error);
-  g_assert_no_error (error);
 
   /* Also insert a commit (2) for the refspec "REMOTE:REFv2". The first time we
    * update, we should only update to commit 1, but when we switch over


### PR DESCRIPTION
Previously we would always unconditionally follow the upgrade refspec
if we were booted into a commit that had the update refspec as part
of its metadata. However, such an approach means that the client must
always be able to use the current updater on the checkpoint commit
to upgrade to the most recent commit. This leaves very little room
for error in case the updater on the current commit is not able
to process the new upgrade (for instance, incorrectly configured
flatpak remotes).

Considering that, we might want to "fix" the updater again before
we try upgrading on the branch that really requires it. That can
be done by adding new commits to the currently booted branch. However,
if we do that we need the updater to pay attention to the currently
booted branch and not the "upgrade" branch in the booted commit's
metadata.

This branch does exactly that. It wraps get_refspec_to_upgrade_on
with another function that first pulls on the currently booted branch
to see if there is a new commit and if so uses that, then, if there
is not a new commit, pulls the upgrade-refspec branch for new commits
and attempts to apply them.

Finally, this branch also includes updates to the tests to allow tests
to build up their own non-linear commit graph.

https://phabricator.endlessm.com/T22295