### PR TITLE
poll: Fix order of remote and ref arguments

### DIFF
--- a/src/eos-updater-poll.c
+++ b/src/eos-updater-poll.c
@@ -388,7 +388,7 @@ check_for_update_following_checkpoint_commits (OstreeRepo     *repo,
   g_return_val_if_fail (out_update_ref_info != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
-  if (!get_refspec_to_upgrade_on (&upgrade_refspec, &ref, &remote, &collection_ref, error))
+  if (!get_refspec_to_upgrade_on (&upgrade_refspec, &remote, &ref, &collection_ref, error))
     return FALSE;
 
   if (!fetch_latest_commit (repo,


### PR DESCRIPTION
Fix the order of the remote and ref arguments to
get_refspec_to_upgrade_on() in
check_for_update_following_checkpoint_commits() to match the function
definition. It appears those fields in UpdateRefInfo aren't used yet, so
that's why this hasn't caused a bug yet.