### PR TITLE
poll: Don't treat move to older commit on new branch as a downgrade

### DIFF
--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -71,15 +71,50 @@ G_STATIC_ASSERT (G_N_ELEMENTS (order_key_str) == EOS_UPDATER_DOWNLOAD_LAST + 1);
 static const gchar *const EOS_UPDATER_BRANCH_SELECTED = "99f48aac-b5a0-426d-95f4-18af7d081c4e";
 #endif
 
+static gboolean
+status_of_current_and_remote_commit (OstreeRepo   *repo,
+                                     const gchar  *booted_checksum,
+                                     const gchar  *checksum,
+                                     GVariant    **out_current_commit,
+                                     GVariant    **out_remote_commit,
+                                     GError      **error)
+{
+  g_autoptr(GVariant) current_commit = NULL;
+  g_autoptr(GVariant) update_commit = NULL;
+
+  g_return_val_if_fail (OSTREE_IS_REPO (repo), FALSE);
+  g_return_val_if_fail (booted_checksum != NULL, FALSE);
+  g_return_val_if_fail (checksum != NULL, FALSE);
+  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+  g_debug ("%s: current: %s, update: %s", G_STRFUNC, booted_checksum, checksum);
+
+  if (!ostree_repo_load_commit (repo, booted_checksum, &current_commit, NULL, error))
+    return FALSE;
+
+  if (!ostree_repo_load_commit (repo, checksum, &update_commit, NULL, error))
+    return FALSE;
+
+  if (out_current_commit)
+    *out_current_commit = g_steal_pointer (&current_commit);
+
+  if (out_remote_commit)
+    *out_remote_commit = g_steal_pointer (&update_commit);
+
+  return TRUE;
+}
+
 gboolean
 is_checksum_an_update (OstreeRepo *repo,
                        const gchar *checksum,
+                       const gchar *booted_ref,
+                       const gchar *upgrade_ref,
                        GVariant **commit,
                        GError **error)
 {
-  g_autofree gchar *cur = NULL;
   g_autoptr(GVariant) current_commit = NULL;
   g_autoptr(GVariant) update_commit = NULL;
+  g_autofree gchar *booted_checksum = NULL;
   gboolean is_newer;
   guint64 update_timestamp, current_timestamp;
 
@@ -88,16 +123,16 @@ is_checksum_an_update (OstreeRepo *repo,
   g_return_val_if_fail (commit != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
-  cur = eos_updater_get_booted_checksum (error);
-  if (cur == NULL)
+  booted_checksum = eos_updater_get_booted_checksum (error);
+  if (booted_checksum == NULL)
     return FALSE;
 
-  g_debug ("%s: current: %s, update: %s", G_STRFUNC, cur, checksum);
-
-  if (!ostree_repo_load_commit (repo, cur, &current_commit, NULL, error))
-    return FALSE;
-
-  if (!ostree_repo_load_commit (repo, checksum, &update_commit, NULL, error))
+  if (!status_of_current_and_remote_commit (repo,
+                                            booted_checksum,
+                                            checksum,
+                                            &current_commit,
+                                            &update_commit,
+                                            error))
     return FALSE;
 
   /* Determine if the new commit is newer than the old commit to prevent
@@ -110,11 +145,32 @@ is_checksum_an_update (OstreeRepo *repo,
            "update_timestamp: %" G_GUINT64_FORMAT,
            G_STRFUNC, update_timestamp, current_timestamp);
 
-  is_newer = update_timestamp > current_timestamp;
-  /* if we have a checksum for the remote upgrade candidate
-   * and it's ≠ what we're currently booted into, advertise it as such.
+  /* "Newer" if we are switching branches or the update timestamp
+   * is greater than the timestamp of the current commit.
+   *
+   * Generally speaking the updater is only allowed to go forward
+   * but we can go "back in time" if we switched branches. This might
+   * happen with checkpoint commits, where we have the following
+   * history (numbers indicate commit timestamps):
+   *
+   * eos3a    -----(1)
+   *               /\
+   *              /  \
+   * eos3  (0)--(2)--(3)
+   *
+   * It is possible to make a commit on a new refspec
+   * with an older timestamp than the redirect commit on the old
+   * refspec that redirects to it. So we shouldn't fail to switch branches
+   * if the commit on the new branch was older in time.
    */
-  if (is_newer && g_strcmp0 (cur, checksum) != 0)
+  is_newer = (g_strcmp0 (booted_ref, upgrade_ref) != 0 ||
+              update_timestamp > current_timestamp);
+
+  /* We also need to check if the offered checksum on the server
+   * was the same as the booted checksum. It is possible for the timestamp
+   * on the server to be newer if the commit was re-generated from an
+   * existing tree. */
+  if (is_newer && g_strcmp0 (booted_checksum, checksum) != 0)
     *commit = g_steal_pointer (&update_commit);
   else
     *commit = NULL;

--- a/eos-updater/poll-common.h
+++ b/eos-updater/poll-common.h
@@ -33,6 +33,8 @@ G_BEGIN_DECLS
 gboolean
 is_checksum_an_update (OstreeRepo *repo,
                        const gchar *checksum,
+                       const gchar *booted_ref,
+                       const gchar *upgrade_ref,
                        GVariant **commit,
                        GError **error);
 

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -248,6 +248,124 @@ test_update_refspec_checkpoint (EosUpdaterFixture *fixture,
   g_assert_cmpstr (branches_option, ==, expected_branches);
 }
 
+/* Start with a commit, then make a new commit (2) on a new branch. Finally,
+ * make a "checkpoint" commit on the old branch (3) which points to the new
+ * branch. Even though (2) is older than (3), the checkpoint should still be
+ * followed and we should "upgrade" to the older commit on the newer branch. */
+static void
+test_update_refspec_checkpoint_even_if_downgrade (EosUpdaterFixture *fixture,
+                                                  gconstpointer user_data)
+{
+  g_autoptr(GFile) server_root = NULL;
+  g_autoptr(EosTestServer) server = NULL;
+  g_autofree gchar *keyid = get_keyid (fixture->gpg_home);
+  g_autoptr(GError) error = NULL;
+  g_autoptr(EosTestSubserver) subserver = NULL;
+  g_autoptr(GFile) client_root = NULL;
+  g_autoptr(EosTestClient) client = NULL;
+  g_autoptr(GHashTable) additional_metadata_for_commit = NULL;
+  g_autoptr(GHashTable) leaf_commit_nodes =
+    eos_test_subserver_ref_to_commit_new ();
+  gboolean has_commit;
+
+  /* We could get OSTree working by setting OSTREE_BOOTID, but shortly
+   * afterwards we hit unsupported syscalls in qemu-user when running in an
+   * ARM chroot (for example), so just bail. */
+  if (!eos_test_has_ostree_boot_id ())
+    {
+      g_test_skip ("OSTree will not work without a boot ID");
+      return;
+    }
+
+  insert_update_refspec_metadata_for_commit (2,
+                                             next_ref,
+                                             &additional_metadata_for_commit);
+
+  server_root = g_file_get_child (fixture->tmpdir, "main");
+  server = eos_test_server_new_quick (server_root,
+                                      default_vendor,
+                                      default_product,
+                                      default_collection_ref,
+                                      0,
+                                      fixture->gpg_home,
+                                      keyid,
+                                      default_ostree_path,
+                                      NULL,
+                                      NULL,
+                                      additional_metadata_for_commit,
+                                      &error);
+  g_assert_no_error (error);
+  g_assert_cmpuint (server->subservers->len, ==, 1u);
+
+  subserver = g_object_ref (EOS_TEST_SUBSERVER (g_ptr_array_index (server->subservers, 0)));
+  client_root = g_file_get_child (fixture->tmpdir, "client");
+  client = eos_test_client_new (client_root,
+                                default_remote_name,
+                                subserver,
+                                default_collection_ref,
+                                default_vendor,
+                                default_product,
+                                &error);
+  g_assert_no_error (error);
+
+  /* Insert a commit on "REMOTE:REFv2". The first time we
+   * update, we should update to commit 2, but when we switch over
+   * the ref we pull from, we should have commit 1. */
+  g_hash_table_insert (leaf_commit_nodes,
+                       ostree_collection_ref_dup (next_collection_ref),
+                       GUINT_TO_POINTER (1));
+  g_hash_table_insert (leaf_commit_nodes,
+                       ostree_collection_ref_dup (default_collection_ref),
+                       GUINT_TO_POINTER (2));
+  eos_test_subserver_populate_commit_graph_from_leaf_nodes (subserver,
+                                                            leaf_commit_nodes);
+  eos_test_subserver_update (subserver,
+                             &error);
+  g_assert_no_error (error);
+
+  /* Now update the client. We stopped making commits on this
+   * ref, so it is effectively a "checkpoint" and we should have
+   * the second commit (we will also have the first, but only
+   * because the tests don't have a mechanism to remove old
+   * commit files). */
+  update_client (fixture, client);
+
+  eos_test_client_has_commit (client,
+                              default_remote_name,
+                              2,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_true (has_commit);
+
+  /* Update the client again. Because we had deployed the
+   * checkpoint, we should now have the new ref to update on and should
+   * have pulled the new commit (we can't assert on anything here, but
+   * we can do the next step to figure out what branch we're on). */
+  update_client (fixture, client);
+
+  /* Now that we should be on the new branch, make a commit there
+   * and update again. */
+  g_hash_table_insert (leaf_commit_nodes,
+                       ostree_collection_ref_dup (next_collection_ref),
+                       GUINT_TO_POINTER (3));
+  eos_test_subserver_populate_commit_graph_from_leaf_nodes (subserver,
+                                                            leaf_commit_nodes);
+  eos_test_subserver_update (subserver,
+                             &error);
+  g_assert_no_error (error);
+
+  update_client (fixture, client);
+
+  eos_test_client_has_commit (client,
+                              default_remote_name,
+                              3,
+                              &has_commit,
+                              &error);
+  g_assert_no_error (error);
+  g_assert_true (has_commit);
+}
+
 /* Start with a commit, and then make a final commit on the first refspec
  * which adds a new marker, such that when that commit is deployed, the updater
  * will know to use a new refspec to upgrade with. However, say we screwed
@@ -715,6 +833,9 @@ main (int argc,
   eos_test_add ("/updater/update-refspec-checkpoint",
                 NULL,
                 test_update_refspec_checkpoint);
+  eos_test_add ("/updater/update-refspec-checkpoint-even-if-downgrade",
+                NULL,
+                test_update_refspec_checkpoint_even_if_downgrade);
   eos_test_add ("/updater/update-refspec-checkpoint-continue-old-branch",
                 NULL,
                 test_update_refspec_checkpoint_continue_old_branch);


### PR DESCRIPTION
Previously we checked if the commit timestamp was always greater than
the booted commit timestamp before pulling it. This won't work in
the case that a commit is made on a new branch (1), then we make
another commit on the old branch (2) with a checkpoint pointing
to then new branch.

https://phabricator.endlessm.com/T22498