### PR TITLE
T22805: eos-updater: Allow upgrades even if the current commit is missing (eos3.3 backport)

### DIFF
--- a/libeos-updater-flatpak-installer/tests/installer.c
+++ b/libeos-updater-flatpak-installer/tests/installer.c
@@ -100,7 +100,7 @@ flatpak_deployments_fixture_teardown (FlatpakDeploymentsFixture  *fixture,
 {
   g_autoptr(GError) error = NULL;
 
-  eos_updater_remove_recursive (fixture->flatpak_deployments_directory, &error);
+  eos_updater_remove_recursive (fixture->flatpak_deployments_directory, NULL, &error);
   g_assert_no_error (error);
 
   g_object_unref (fixture->flatpak_deployments_directory);

--- a/libeos-updater-util/flatpak.c
+++ b/libeos-updater-util/flatpak.c
@@ -2731,7 +2731,7 @@ inspect_directory_in_ostree_repo (OstreeRepo    *repo,
                                 cancellable,
                                 error))
     {
-      eos_updater_remove_recursive (checkout_directory, NULL);
+      eos_updater_remove_recursive (checkout_directory, NULL, NULL);
       return NULL;
     }
 
@@ -2791,7 +2791,7 @@ euu_flatpak_ref_actions_from_ostree_commit (OstreeRepo    *repo,
    * OstreeRepo. Note that these operations may fail, but we don’t
    * really care. */
   if (checkout_directory != NULL)
-    eos_updater_remove_recursive (checkout_directory, NULL);
+    eos_updater_remove_recursive (checkout_directory, NULL, NULL);
   ostree_repo_checkout_gc (repo, cancellable, NULL);
 
   return g_steal_pointer (&flatpak_ref_actions_table);

--- a/libeos-updater-util/util.c
+++ b/libeos-updater-util/util.c
@@ -466,6 +466,7 @@ eos_updater_setup_quit_file (const gchar *path,
 
 static gboolean
 rm_file_ignore_noent (GFile         *file,
+                      gboolean       ignore_enotempty,
                       GCancellable  *cancellable,
                       GError       **error)
 {
@@ -476,17 +477,21 @@ rm_file_ignore_noent (GFile         *file,
 
   if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
     return TRUE;
+  if (ignore_enotempty &&
+      g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_EMPTY))
+    return TRUE;
 
   g_propagate_error (error, g_steal_pointer (&local_error));
   return FALSE;
 }
 
 static gboolean
-rm_rf_internal (GFile   *topdir,
-                GError **error)
+rm_rf_internal (GFile                     *topdir,
+                EosUpdaterFileFilterFunc   filter_func,
+                GError                   **error)
 {
   GQueue queue = G_QUEUE_INIT;
-  GList *dir_stack = NULL;
+  GList *dirs_to_delete = NULL;
   g_autoptr(GError) local_error = NULL;
   g_autoptr(GFileInfo) top_info = NULL;
 
@@ -502,11 +507,17 @@ rm_rf_internal (GFile   *topdir,
       g_propagate_error (error, g_steal_pointer (&local_error));
       return FALSE;
     }
+
+  if (filter_func != NULL &&
+      filter_func (topdir, top_info) == EOS_UPDATER_FILE_FILTER_IGNORE)
+    return TRUE;
   if (g_file_info_get_file_type (top_info) != G_FILE_TYPE_DIRECTORY)
-    return rm_file_ignore_noent (topdir, NULL, error);
+    return rm_file_ignore_noent (topdir, FALSE, NULL, error);
+
+  gboolean any_ignored = FALSE;
 
   g_queue_push_head (&queue, g_object_ref (topdir));
-  dir_stack = g_list_prepend (dir_stack, g_object_ref (topdir));
+
   while (!g_queue_is_empty (&queue))
     {
       g_autoptr(GFile) dir = G_FILE (g_queue_pop_tail (&queue));
@@ -518,6 +529,8 @@ rm_rf_internal (GFile   *topdir,
 
       if (enumerator == NULL)
         return FALSE;
+
+      guint n_ignored = 0;
 
       for (;;)
         {
@@ -534,24 +547,36 @@ rm_rf_internal (GFile   *topdir,
           if (info == NULL || child == NULL)
             break;
 
-          if (g_file_info_get_file_type (info) == G_FILE_TYPE_DIRECTORY)
+          if (filter_func != NULL &&
+              filter_func (child, info) == EOS_UPDATER_FILE_FILTER_IGNORE)
             {
-              g_queue_push_head (&queue, g_object_ref (child));
-              dir_stack = g_list_prepend (dir_stack, g_object_ref (child));
+              n_ignored++;
+              continue;
             }
-          else if (!rm_file_ignore_noent (child, NULL, error))
+
+          if (g_file_info_get_file_type (info) == G_FILE_TYPE_DIRECTORY)
+            g_queue_push_head (&queue, g_object_ref (child));
+          else if (!rm_file_ignore_noent (child, FALSE, NULL, error))
             return FALSE;
         }
+
+      if (n_ignored == 0)
+        dirs_to_delete = g_list_prepend (dirs_to_delete, g_object_ref (dir));
+      else
+        any_ignored = TRUE;
     }
 
-  while (dir_stack != NULL)
+  if (!any_ignored)
+    dirs_to_delete = g_list_append (dirs_to_delete, g_object_ref (topdir));
+
+  while (dirs_to_delete != NULL)
     {
-      GList *first = dir_stack;
+      GList *first = dirs_to_delete;
       g_autoptr(GFile) dir = G_FILE (first->data);
 
-      dir_stack = g_list_remove_link (dir_stack, first);
+      dirs_to_delete = g_list_remove_link (dirs_to_delete, first);
       g_list_free_1 (first);
-      if (!rm_file_ignore_noent (dir, NULL, error))
+      if (!rm_file_ignore_noent (dir, TRUE, NULL, error))
         return FALSE;
     }
 
@@ -559,9 +584,11 @@ rm_rf_internal (GFile   *topdir,
 }
 
 gboolean
-eos_updater_remove_recursive (GFile *topdir, GError **error)
+eos_updater_remove_recursive (GFile                     *topdir,
+                              EosUpdaterFileFilterFunc   filter_func,
+                              GError                   **error)
 {
-  if (!rm_rf_internal (topdir, error))
+  if (!rm_rf_internal (topdir, filter_func, error))
     {
       g_autofree gchar *raw_path = g_file_get_path (topdir);
       g_prefix_error (error,

--- a/libeos-updater-util/util.h
+++ b/libeos-updater-util/util.h
@@ -95,7 +95,17 @@ EosQuitFile *eos_updater_setup_quit_file (const gchar *path,
                                           guint timeout_seconds,
                                           GError **error);
 
-gboolean eos_updater_remove_recursive (GFile   *topdir,
-                                       GError **error);
+typedef enum
+{
+  EOS_UPDATER_FILE_FILTER_IGNORE = 0,
+  EOS_UPDATER_FILE_FILTER_HANDLE = 1,
+} EosUpdaterFileFilterReturn;
+
+typedef EosUpdaterFileFilterReturn (*EosUpdaterFileFilterFunc) (GFile     *file,
+                                                                GFileInfo *file_info);
+
+gboolean eos_updater_remove_recursive (GFile                     *topdir,
+                                       EosUpdaterFileFilterFunc   filter_func,
+                                       GError                   **error);
 
 G_END_DECLS

--- a/src/eos-updater-poll-common.c
+++ b/src/eos-updater-poll-common.c
@@ -76,39 +76,6 @@ G_STATIC_ASSERT (G_N_ELEMENTS (order_key_str) == EOS_UPDATER_DOWNLOAD_LAST + 1);
 static const gchar *const EOS_UPDATER_BRANCH_SELECTED = "99f48aac-b5a0-426d-95f4-18af7d081c4e";
 #endif
 
-static gboolean
-status_of_current_and_remote_commit (OstreeRepo   *repo,
-                                     const gchar  *booted_checksum,
-                                     const gchar  *checksum,
-                                     GVariant    **out_current_commit,
-                                     GVariant    **out_remote_commit,
-                                     GError      **error)
-{
-  g_autoptr(GVariant) current_commit = NULL;
-  g_autoptr(GVariant) update_commit = NULL;
-
-  g_return_val_if_fail (OSTREE_IS_REPO (repo), FALSE);
-  g_return_val_if_fail (booted_checksum != NULL, FALSE);
-  g_return_val_if_fail (checksum != NULL, FALSE);
-  g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
-
-  g_debug ("%s: current: %s, update: %s", G_STRFUNC, booted_checksum, checksum);
-
-  if (!ostree_repo_load_commit (repo, booted_checksum, &current_commit, NULL, error))
-    return FALSE;
-
-  if (!ostree_repo_load_commit (repo, checksum, &update_commit, NULL, error))
-    return FALSE;
-
-  if (out_current_commit)
-    *out_current_commit = g_steal_pointer (&current_commit);
-
-  if (out_remote_commit)
-    *out_remote_commit = g_steal_pointer (&update_commit);
-
-  return TRUE;
-}
-
 gboolean
 is_checksum_an_update (OstreeRepo *repo,
                        const gchar *checksum,
@@ -132,12 +99,12 @@ is_checksum_an_update (OstreeRepo *repo,
   if (booted_checksum == NULL)
     return FALSE;
 
-  if (!status_of_current_and_remote_commit (repo,
-                                            booted_checksum,
-                                            checksum,
-                                            &current_commit,
-                                            &update_commit,
-                                            error))
+  g_debug ("%s: current: %s, update: %s", G_STRFUNC, booted_checksum, checksum);
+
+  if (!ostree_repo_load_commit (repo, booted_checksum, &current_commit, NULL, error))
+    return FALSE;
+
+  if (!ostree_repo_load_commit (repo, checksum, &update_commit, NULL, error))
     return FALSE;
 
   /* Determine if the new commit is newer than the old commit to prevent

--- a/src/eos-updater-poll-common.c
+++ b/src/eos-updater-poll-common.c
@@ -99,6 +99,16 @@ is_checksum_an_update (OstreeRepo *repo,
   if (booted_checksum == NULL)
     return FALSE;
 
+  /* We need to check if the offered checksum on the server
+   * was the same as the booted checksum. It is possible for the timestamp
+   * on the server to be newer if the commit was re-generated from an
+   * existing tree. */
+  if (g_str_equal (booted_checksum, checksum))
+    {
+      *commit = NULL;
+      return TRUE;
+    }
+
   g_debug ("%s: current: %s, update: %s", G_STRFUNC, booted_checksum, checksum);
 
   if (!ostree_repo_load_commit (repo, booted_checksum, &current_commit, NULL, error))
@@ -137,15 +147,7 @@ is_checksum_an_update (OstreeRepo *repo,
    */
   is_newer = (g_strcmp0 (booted_ref, upgrade_ref) != 0 ||
               update_timestamp > current_timestamp);
-
-  /* We also need to check if the offered checksum on the server
-   * was the same as the booted checksum. It is possible for the timestamp
-   * on the server to be newer if the commit was re-generated from an
-   * existing tree. */
-  if (is_newer && g_strcmp0 (booted_checksum, checksum) != 0)
-    *commit = g_steal_pointer (&update_commit);
-  else
-    *commit = NULL;
+  *commit = is_newer ? g_steal_pointer (&update_commit) : NULL;
 
   return TRUE;
 }

--- a/test-common/convenience.c
+++ b/test-common/convenience.c
@@ -208,7 +208,8 @@ etc_update_server (EtcData *data,
 /* Pulls the updates from the server using eos-updater and autoupdater.
  */
 void
-etc_update_client (EtcData *data)
+etc_update_client_with_warnings (EtcData     *data,
+                                 const gchar *expected_updater_warnings)
 {
   DownloadSource main_source = DOWNLOAD_MAIN;
   g_auto(CmdAsyncResult) updater_cmd = CMD_ASYNC_RESULT_CLEARED;
@@ -223,7 +224,9 @@ etc_update_client (EtcData *data)
   g_assert_nonnull (data->client);
   g_assert_nonnull (data->fixture);
 
-  // update the client
+  /* Update the client. FIXME: We can’t do a glob match against
+   * @expected_updater_warnings yet. @expected_updater_warnings is ignored
+   * for the eos3.3 backport. */
   eos_test_client_run_updater (data->client,
                                &main_source,
                                1,
@@ -258,6 +261,12 @@ etc_update_client (EtcData *data)
                               &error);
   g_assert_no_error (error);
   g_assert_true (has_commit);
+}
+
+void
+etc_update_client (EtcData *data)
+{
+  etc_update_client_with_warnings (data, NULL);
 }
 
 /* Deletes an object from a repositories' objects directory. The repo

--- a/test-common/convenience.c
+++ b/test-common/convenience.c
@@ -26,6 +26,7 @@
  * `utils.h`.
  */
 
+#include <libeos-updater-util/util.h>
 #include <string.h>
 #include <test-common/convenience.h>
 #include <test-common/gpg.h>
@@ -299,4 +300,42 @@ etc_delete_object (GFile *repo,
   object_file = g_file_get_child (prefix_dir, rest);
   g_file_delete (object_file, NULL, &error);
   g_assert_no_error (error);
+}
+
+static EosUpdaterFileFilterReturn
+filter_commit_cb (GFile     *file,
+                  GFileInfo *file_info)
+{
+  /* Always recurse. Ignore anything which isn’t a file. */
+  if (g_file_info_get_file_type (file_info) == G_FILE_TYPE_DIRECTORY)
+    return EOS_UPDATER_FILE_FILTER_HANDLE;
+  else if (g_file_info_get_file_type (file_info) != G_FILE_TYPE_REGULAR)
+    return EOS_UPDATER_FILE_FILTER_IGNORE;
+
+  /* Delete .commit and .commitmeta objects. Ignore everything else. */
+  if (g_str_has_suffix (g_file_info_get_name (file_info), ".commit") ||
+      g_str_has_suffix (g_file_info_get_name (file_info), ".commitmeta"))
+    return EOS_UPDATER_FILE_FILTER_HANDLE;
+  else
+    return EOS_UPDATER_FILE_FILTER_IGNORE;
+}
+
+/* Delete all .commit and .commitmeta objects from the client repository. We
+ * could settle for just deleting them for the currently deployed commit, but
+ * it’s easier to just delete them all, and shouldn’t affect the test. */
+void
+etc_delete_all_client_commits (EtcData *data)
+{
+  g_autoptr(GFile) client_repo = NULL;
+  g_autoptr(GError) local_error = NULL;
+  g_autoptr(GFile) objects_dir = NULL;
+
+  g_assert_nonnull (data);
+  g_assert_nonnull (data->client);
+
+  client_repo = eos_test_client_get_repo (data->client);
+  objects_dir = g_file_get_child (client_repo, "objects");
+
+  eos_updater_remove_recursive (objects_dir, filter_commit_cb, &local_error);
+  g_assert_no_error (local_error);
 }

--- a/test-common/convenience.h
+++ b/test-common/convenience.h
@@ -62,4 +62,6 @@ void etc_update_client_with_warnings (EtcData     *data,
 void etc_delete_object (GFile *repo,
                         const gchar *object);
 
+void etc_delete_all_client_commits (EtcData *data);
+
 G_END_DECLS

--- a/test-common/convenience.h
+++ b/test-common/convenience.h
@@ -56,6 +56,8 @@ void etc_update_server (EtcData *data,
                         guint commit);
 
 void etc_update_client (EtcData *data);
+void etc_update_client_with_warnings (EtcData     *data,
+                                      const gchar *expected_updater_warnings);
 
 void etc_delete_object (GFile *repo,
                         const gchar *object);

--- a/test-common/misc-utils.c
+++ b/test-common/misc-utils.c
@@ -29,13 +29,6 @@
 #include <unistd.h>
 
 gboolean
-rm_rf (GFile   *file,
-       GError **error)
-{
-  return eos_updater_remove_recursive (file, error);
-}
-
-gboolean
 load_to_bytes (GFile *file,
                GBytes **bytes,
                GError **error)

--- a/test-common/misc-utils.h
+++ b/test-common/misc-utils.h
@@ -26,9 +26,6 @@
 
 G_BEGIN_DECLS
 
-gboolean rm_rf (GFile   *topdir,
-                GError **error);
-
 static inline GPtrArray *
 string_array_new (void)
 {

--- a/test-common/utils.c
+++ b/test-common/utils.c
@@ -75,11 +75,11 @@ eos_updater_fixture_teardown (EosUpdaterFixture *fixture,
   g_autoptr (GError) error = NULL;
 
   kill_gpg_agent (fixture->gpg_home);
-  rm_rf (fixture->gpg_home, &error);
+  eos_updater_remove_recursive (fixture->gpg_home, NULL, &error);
   g_assert_no_error (error);
   g_object_unref (fixture->gpg_home);
 
-  rm_rf (fixture->tmpdir, &error);
+  eos_updater_remove_recursive (fixture->tmpdir, NULL, &error);
   g_assert_no_error (error);
   g_object_unref (fixture->tmpdir);
 
@@ -1845,7 +1845,7 @@ simulated_reap_updater (EosTestClient *client,
   g_autoptr(GFile) updater_dir = get_updater_dir_for_client (client->root);
   g_autoptr(GFile) quit_file = updater_quit_file (updater_dir);
 
-  if (!rm_rf (quit_file, error))
+  if (!eos_updater_remove_recursive (quit_file, NULL, error))
     return FALSE;
   g_free (reaped->cmdline);
   reaped->cmdline = g_strdup (cmd->cmdline);
@@ -1882,7 +1882,7 @@ real_reap_updater (EosTestClient *client,
                             &wu,
                             NULL);
 
-  if (!rm_rf (quit_file, error))
+  if (!eos_updater_remove_recursive (quit_file, NULL, error))
     return FALSE;
 
   g_main_loop_run (loop);
@@ -2781,7 +2781,7 @@ eos_test_client_remove_update_server_quit_file (EosTestClient *client,
   g_autoptr(GFile) update_server_dir = get_update_server_dir (client->root);
   g_autoptr(GFile) quit_file = get_update_server_quit_file (update_server_dir);
 
-  return rm_rf (quit_file, error);
+  return eos_updater_remove_recursive (quit_file, NULL, error);
 }
 
 gboolean

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -37,6 +37,7 @@ uninstalled_test_programs = \
 	test-update-cleanup-workaround \
 	test-update-broken-delta \
 	test-update-install-flatpaks \
+	test-update-missing-deployed-commit \
 	test-update-refspec-checkpoint \
 	$(NULL)
 
@@ -108,6 +109,12 @@ test_update_broken_delta_CFLAGS = $(test_cflags)
 test_update_broken_delta_LDFLAGS = $(test_ldflags)
 test_update_broken_delta_LDADD = $(test_ldadd)
 test_update_broken_delta_SOURCES = test-update-broken-delta.c
+
+test_update_missing_deployed_commit_CPPFLAGS = $(test_cppflags)
+test_update_missing_deployed_commit_CFLAGS = $(test_cflags)
+test_update_missing_deployed_commit_LDFLAGS = $(test_ldflags)
+test_update_missing_deployed_commit_LDADD = $(test_ldadd)
+test_update_missing_deployed_commit_SOURCES = test-update-missing-deployed-commit.c
 
 test_update_refspec_checkpoint_CPPFLAGS = $(test_cppflags)
 test_update_refspec_checkpoint_CFLAGS = $(test_cflags)

--- a/tests/test-update-install-flatpaks.c
+++ b/tests/test-update-install-flatpaks.c
@@ -20,6 +20,7 @@
  *  - Sam Spilsbury <sam@endlessm.com>
  */
 
+#include <libeos-updater-util/util.h>
 #include <test-common/flatpak-spawn.h>
 #include <test-common/gpg.h>
 #include <test-common/misc-utils.h>
@@ -3449,7 +3450,7 @@ test_update_flatpak_pull_fail_system_not_deployed (EosUpdaterFixture *fixture,
   /* Before updating the client, nuke the flatpak remote directory. This
    * will make the pull operation fail, which should make the entire
    * deployment fail */
-  rm_rf (flatpak_remote_dir, &error);
+  eos_updater_remove_recursive (flatpak_remote_dir, NULL, &error);
   g_assert_no_error (error);
 
   /* Attempt to update client - run updater daemon */
@@ -4035,7 +4036,7 @@ test_update_deploy_dependency_runtime_flatpaks_on_reboot_no_network (EosUpdaterF
 
   /* Kill the network connection by deleting the remote repositories */
   flatpak_remote_repositories = g_file_get_child (updater_directory, "flatpak");
-  rm_rf (flatpak_remote_repositories, &error);
+  eos_updater_remove_recursive (flatpak_remote_repositories, NULL, &error);
   g_assert_no_error (error);
 
   /* Now simulate a reboot by running eos-updater-flatpak-installer */
@@ -4327,7 +4328,7 @@ test_update_deploy_dependency_autodownload_extension_flatpaks_on_reboot_no_netwo
 
   /* Kill the network connection by deleting the remote repositories */
   flatpak_remote_repositories = g_file_get_child (updater_directory, "flatpak");
-  rm_rf (flatpak_remote_repositories, &error);
+  eos_updater_remove_recursive (flatpak_remote_repositories, NULL, &error);
   g_assert_no_error (error);
 
   /* Now simulate a reboot by running eos-updater-flatpak-installer */
@@ -4846,7 +4847,7 @@ test_update_deploy_flatpaks_on_reboot_resume_on_failure_resolved (EosUpdaterFixt
   /* Remove the offending partial installation and try again */
   failed_flatpak_installation_directory = g_file_get_child (flatpak_user_installation_dir,
                                                             test_broken_flatpak_relative_path);
-  rm_rf (failed_flatpak_installation_directory, &error);
+  eos_updater_remove_recursive (failed_flatpak_installation_directory, NULL, &error);
   g_assert_no_error (error);
 
   /* Should now work again */

--- a/tests/test-update-install-flatpaks.c
+++ b/tests/test-update-install-flatpaks.c
@@ -779,6 +779,90 @@ test_update_install_flatpaks_custom_branch_name (EosUpdaterFixture *fixture,
   g_assert_true (g_strv_contains ((const gchar * const *) flatpaks_in_repo, flatpaks_to_install[0].app_id));
 }
 
+/* As with test_update_install_flatpaks_in_repo(), except check that it works
+ * when the .commit object for the currently deployed commit is deleted before
+ * running eos-updater. */
+static void
+test_update_install_flatpaks_missing_deployed_commit (EosUpdaterFixture *fixture,
+                                                      gconstpointer      user_data)
+{
+  g_auto(EtcData) real_data = { NULL, };
+  EtcData *data = &real_data;
+  FlatpakToInstall flatpaks_to_install[] = {
+    { "install", "com.endlessm.TestInstallFlatpaksCollection", "test-repo", "org.test.Test", "stable", "app", FLATPAK_TO_INSTALL_FLAGS_NONE }
+  };
+  g_autofree gchar *flatpak_user_installation = NULL;
+  g_autoptr(GFile) flatpak_user_installation_dir = NULL;
+  g_auto(GStrv) wanted_flatpaks = flatpaks_to_install_app_ids_strv (flatpaks_to_install,
+                                                                    G_N_ELEMENTS (flatpaks_to_install));
+  g_auto(GStrv) flatpaks_in_repo = NULL;
+  g_autoptr(GFile) updater_directory = NULL;
+  g_autofree gchar *updater_directory_str = NULL;
+  g_autofree gchar *keyid = get_keyid (fixture->gpg_home);
+  g_autoptr(GFile) gpg_key_file = get_gpg_key_file_for_keyid (fixture->gpg_home, keyid);
+  g_autoptr(GError) error = NULL;
+
+  g_test_bug ("T22805");
+
+  etc_data_init (data, fixture);
+
+  /* Commit number 1 will install some flatpaks
+   */
+  autoinstall_flatpaks_files (1,
+                              flatpaks_to_install,
+                              G_N_ELEMENTS (flatpaks_to_install),
+                              &data->additional_directories_for_commit,
+                              &data->additional_files_for_commit);
+
+  /* Create and set up the server with the commit 0.
+   */
+  etc_set_up_server (data);
+  /* Create and set up the client, that pulls the update from the
+   * server, so it should have also a commit 0 and a deployment based
+   * on this commit.
+   */
+  etc_set_up_client_synced_to_server (data);
+
+  updater_directory = g_file_get_child (data->client->root, "updater");
+  updater_directory_str = g_file_get_path (updater_directory);
+  flatpak_user_installation = g_build_filename (updater_directory_str,
+                                                "flatpak-user",
+                                                NULL);
+  flatpak_user_installation_dir = g_file_new_for_path (flatpak_user_installation);
+  eos_test_setup_flatpak_repo_simple (updater_directory,
+                                      "stable",
+                                      "test-repo",
+                                      "com.endlessm.TestInstallFlatpaksCollection",
+                                      "com.endlessm.TestInstallFlatpaksCollection",
+                                      (const gchar **) wanted_flatpaks,
+                                      gpg_key_file,
+                                      keyid,
+                                      &error);
+  g_assert_no_error (error);
+
+  /* Update the server, so it has a new commit (1).
+   */
+  etc_update_server (data, 1);
+  /* Delete the currently deployed commit object (and all other commit objects)
+   * from the client.
+   */
+  etc_delete_all_client_commits (data);
+  /* Try to update the client. It should succeed, but should warn about the
+   * currently deployed commit being missing. It should pull the flatpak.
+   */
+  etc_update_client_with_warnings (data,
+                                   "Error loading current commit ‘*’ to check "
+                                   "if ‘*’ is an update (assuming it is): No "
+                                   "such metadata object *.commit");
+
+  /* Assert that our flatpaks were pulled into the local repo */
+  flatpaks_in_repo = flatpaks_in_installation_repo (flatpak_user_installation_dir,
+                                                    &error);
+  g_assert_no_error (error);
+
+  g_assert_true (g_strv_contains ((const gchar * const *) flatpaks_in_repo, flatpaks_to_install[0].app_id));
+}
+
 /* Insert a list of flatpaks to automatically install on the commit, this
  * time with a collection-id specified, but no collection-id is
  * configured in the ostree config. The pulling of refs should continue
@@ -6377,6 +6461,7 @@ main (int argc,
   eos_test_add ("/updater/install-no-flatpaks", NULL, test_update_install_no_flatpaks);
   eos_test_add ("/updater/install-flatpaks-pull-to-repo", NULL, test_update_install_flatpaks_in_repo);
   eos_test_add ("/updater/install-flatpaks-custom-branch-name", NULL, test_update_install_flatpaks_custom_branch_name);
+  eos_test_add ("/updater/install-flatpaks-missing-deployed-commit", NULL, test_update_install_flatpaks_missing_deployed_commit);
   eos_test_add ("/updater/install-flatpaks-pull-to-repo-if-collection-id-not-supported", NULL, test_update_install_flatpaks_in_repo_fallback_if_collection_not_in_repo_config);
   eos_test_add ("/updater/install-flatpaks-pull-to-repo-fallback-if-collection-id-not-configured-in-remote-or-repo", NULL, test_update_install_flatpaks_in_repo_fallback_if_collection_not_in_remote_or_repo);
   eos_test_add ("/updater/install-flatpaks-pull-to-repo-error-if-collection-id-invalid", NULL, test_update_install_flatpaks_in_repo_error_if_collection_invalid);

--- a/tests/test-update-missing-deployed-commit.c
+++ b/tests/test-update-missing-deployed-commit.c
@@ -1,0 +1,89 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2018 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Authors:
+ *  - Philip Withnall <withnall@endlessm.com>
+ */
+
+#include <gio/gio.h>
+#include <libeos-updater-util/util.h>
+#include <locale.h>
+#include <test-common/convenience.h>
+
+
+/* Delete the commit object representing the currently deployed commit, and try
+ * to do an update. The update should succeed (but should warn about the missing
+ * commit object). */
+static void
+test_update_missing_deployed_commit (EosUpdaterFixture *fixture,
+                                     gconstpointer      user_data)
+{
+  g_auto(EtcData) real_data = { NULL, };
+  EtcData *data = &real_data;
+
+  g_test_bug ("T22805");
+
+  /* We could get OSTree working by setting OSTREE_BOOTID, but shortly
+   * afterwards we hit unsupported syscalls in qemu-user when running in an
+   * ARM chroot (for example), so just bail. */
+  if (!eos_test_has_ostree_boot_id ())
+    {
+      g_test_skip ("OSTree will not work without a boot ID");
+      return;
+    }
+
+  etc_data_init (data, fixture);
+  /* Create and set up the server with the commit 0.
+   */
+  etc_set_up_server (data);
+  /* Create and set up the client, that pulls the update from the
+   * server, so it should have also a commit 0 and a deployment based
+   * on this commit.
+   */
+  etc_set_up_client_synced_to_server (data);
+  /* Update the server, so it has a new commit (1), and the delta
+   * files between commits 0 and 1.
+   */
+  etc_update_server (data, 1);
+  /* Delete the currently deployed commit object (and all other commit objects)
+   * from the client.
+   */
+  etc_delete_all_client_commits (data);
+  /* Try to update the client. It should succeed, but should warn about the
+   * currently deployed commit being missing.
+   */
+  etc_update_client_with_warnings (data,
+                                   "Error loading current commit ‘*’ to check "
+                                   "if ‘*’ is an update (assuming it is): No "
+                                   "such metadata object *.commit");
+}
+
+int
+main (int argc,
+      char **argv)
+{
+  setlocale (LC_ALL, "");
+
+  g_test_init (&argc, &argv, NULL);
+  g_test_bug_base ("https://phabricator.endlessm.com/");
+
+  eos_test_add ("/updater/update-missing-deployed-commit", NULL,
+                test_update_missing_deployed_commit);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
This is a backport of https://github.com/endlessm/eos-updater/pull/214 to the eos3.3 branch. It does **not** depend on #211 (unlike #214), and has a few minor changes to make it build properly on eos3.3. These are noted in the commit messages.