### PR TITLE
test-common: Set LD_LIBRARY_PATH when running e-u-p-v

### DIFF
--- a/test-common/utils.c
+++ b/test-common/utils.c
@@ -2967,6 +2967,13 @@ eos_test_client_prepare_volume (EosTestClient *client,
                                                                       "..",
                                                                       "libeos-updater-util",
                                                                       NULL);
+  gchar *ld_library_path = g_getenv ("LD_LIBRARY_PATH");
+  g_autofree gchar *new_ld_library_path = NULL;
+  if (ld_library_path == NULL || *ld_library_path == '\0')
+    new_ld_library_path = g_strdup (libeos_updater_util_path);
+  else
+    new_ld_library_path = g_strdup_printf ("%s:%s", libeos_updater_util_path, ld_library_path);
+
   g_autoptr(GFile) sysroot = get_sysroot_for_client (client->root);
   CmdEnvVar envv[] =
     {
@@ -2974,6 +2981,7 @@ eos_test_client_prepare_volume (EosTestClient *client,
       { "OSTREE_SYSROOT", NULL, sysroot },
       { "OSTREE_SYSROOT_DEBUG", "mutable-deployments", NULL },
       { "GI_TYPELIB_PATH", libeos_updater_util_path, NULL },
+      { "LD_LIBRARY_PATH", new_ld_library_path, NULL },
       /* FIXME: Add back G_DEBUG=fatal-warnings after we can rely on
        * https://gitlab.gnome.org/GNOME/pygobject/commit/806c5059f989ed1b8bc62e6aa1ef55123ac110de */
       { "G_DEBUG", "gc-friendly", NULL },


### PR DESCRIPTION
Currently the ARM OBS build is failing with the message:

  (process:24961): WARNING **: Failed to load shared library
'libeos-updater-util-0.so.0' referenced by the typelib:
libeos-updater-util-0.so.0: cannot open shared object file: No such file
or directory

This commit adds the libeos-updater-util to LD_LIBRARY_PATH so that the
built .so file can be found when running the tests.

https://phabricator.endlessm.com/T21756