### PR TITLE
debian/control: Add eos-updater gir dep for e-u-p-v

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -86,6 +86,7 @@ Depends:
  gir1.2-flatpak-1.0,
  gir1.2-glib-2.0,
  gir1.2-ostree-1.0,
+ gir1.2-eos-updater-0,
  python3-gi,
  ${misc:Depends},
  ${python3:Depends},


### PR DESCRIPTION
The eos-updater-prepare-volume script now depends on the GObject
introspection bindings for eos-updater, so add a dependency on
gir1.2-eos-updater-0 to the eos-updater-tools package, so the bindings
will be installed into Endless.

https://phabricator.endlessm.com/T22895