### PR TITLE
test-common: Use the flatpak --asumeyes option

### DIFF
--- a/test-common/flatpak-spawn.c
+++ b/test-common/flatpak-spawn.c
@@ -91,6 +91,7 @@ flatpak_install (GFile        *updater_dir,
       { NULL, FLATPAK_BINARY },
       { NULL, "install" },
       { "user", NULL },
+      { "assumeyes", NULL },
       { NULL, remote },
       { NULL, app_id },
       { NULL, NULL }
@@ -117,6 +118,7 @@ flatpak_uninstall (GFile        *updater_dir,
       { NULL, FLATPAK_BINARY },
       { NULL, "uninstall" },
       { "user", NULL },
+      { "assumeyes", NULL },
       { NULL, app_id },
       { NULL, NULL }
     };


### PR DESCRIPTION
Recent verisons of flatpak prompt the user for confirmation during
install/update/uninstall operations. So when the eos-updater unit tests
try to install the test runtime, there's an "Is this ok? [y/n]:"
prompt, and no is assumed since there's no user input, which eventually
leads to a unit test failure.

So this commit adds the --asumeyes option when the tests call out to
`flatpak install` or `flatpak uninstall`, which is meant for the purpose
of scripting and answers yes to questions (or the default option if it's
multiple choice).

https://phabricator.endlessm.com/T23138