### PR TITLE
eufi: Fix a mistake in the docs

### DIFF
--- a/eos-updater-flatpak-installer/docs/eos-updater-flatpak-installer.8
+++ b/eos-updater-flatpak-installer/docs/eos-updater-flatpak-installer.8
@@ -112,7 +112,7 @@ with \fB\-\-mode=perform\fP.
 .IX Item "/usr/share/eos\-application\-tools/flatpak\-autoinstall.d/*"
 Each of the files in this directory contain a list of actions to be applied
 by the installer. Files are also loaded from matching subdirectories in
-\fI/var/lib\fP and \fI/usr/share\fP. See
+\fI/etc\fP and \fI/usr/share\fP. See
 \fBeos\-updater\-flatpak\-autoinstall.d\fP(5).
 .\"
 .IP \fI/var/lib/eos\-application\-tools/flatpak\-autoinstall.progress\fP 4


### PR DESCRIPTION
The /var/lib/... directory is mentioned twice and /etc/ is left out.