### PR TITLE
eupv: Exclude apps that are installed then uninstalled

### DIFF
--- a/eos-updater-prepare-volume/eos-updater-prepare-volume
+++ b/eos-updater-prepare-volume/eos-updater-prepare-volume
@@ -125,16 +125,19 @@ class VolumePreparer:
         might have a different counter value.
         """
         autoinstalls = set()
+        autouninstalls = set()
 
         applied_actions = EosUpdaterUtil.flatpak_ref_actions_from_paths(None)
 
         for filename, actions in applied_actions.items():
             for action in actions:
-                if action.type != \
+                if action.type == \
                    EosUpdaterUtil.FlatpakRemoteRefActionType.UNINSTALL:
+                    autouninstalls.add(action.ref.ref.format_ref())
+                else:
                     autoinstalls.add(action.ref.ref.format_ref())
 
-        return autoinstalls
+        return autoinstalls - autouninstalls
 
     def prepare_volume(self):
         # We need to be root in order to read all the files in the OSTree repo


### PR DESCRIPTION
Currently eos-updater-prepare-volume looks at the flatpak autoinstall
lists and simply includes all the ones that are set to be installed or
updated and none of the ones set to be uninstalled. But some apps such
as com.endlessm.CompanionAppService//eos3 have an install action and a
later uninstall action. So currently eos-updater-prepare-volume tries to
include that app on a USB, which fails since it's not installed. So this
commit fixes e-u-p-v so that for each uninstall action, it removes any
previous install/update actions in the set with the same ID.

https://phabricator.endlessm.com/T21756