### PR TITLE
libeuu: Fix a gtk-doc annotation

### DIFF
--- a/libeos-updater-util/flatpak.c
+++ b/libeos-updater-util/flatpak.c
@@ -2851,7 +2851,7 @@ euu_flatpak_ref_actions_from_paths (GStrv    directories_to_search,
  * euu_flatpak_ref_actions_from_paths() followed by
  * euu_flatten_flatpak_ref_actions_table().
  *
- * Returns: (transfer full) (element-type GPtrArray<EuuFlatpakRemoteRefAction>):
+ * Returns: (transfer container) (element-type EuuFlatpakRemoteRefAction):
  *    The set of actions, with at most one per ref
  */
 GPtrArray *


### PR DESCRIPTION
This commit fixes the gtk-doc annotation on the new function
euu_flattened_flatpak_ref_actions_from_paths() so it gets the
element-type correct and specifies (transfer container) instead of
(transfer full). With transfer full, the elements are freed too many
times, because Python tries to free them after freeing the pointer array
(which itself frees them).

This prevents a seg fault when running eos-updater-prepare-volume.

https://phabricator.endlessm.com/T21756