### PR TITLE
eos-updater: set IO class to idle

### DIFF
--- a/eos-updater/eos-updater.service.in
+++ b/eos-updater/eos-updater.service.in
@@ -7,6 +7,7 @@ After=network.target
 ExecStart=@bindir@/eos-updater
 Type=dbus
 BusName=com.endlessm.Updater
+IOSchedulingClass=idle
 
 # Sandboxing
 # FIXME: Enable more of these options once we have systemd > 229


### PR DESCRIPTION
Our benchmarks show this significantly reduces the interactivity impact of
ongoing ostree operations while the user is continuing other tasks on the
system. The effect is very pronounced with the default CFQ scheduler, and in
combination with BFQ, using the idle class improves the worst case to nearly
the same as an unloaded system.

https://phabricator.endlessm.com/T22479