### PR TITLE
eos-updater.conf: Check USB drives for updates

### DIFF
--- a/eos-updater/eos-updater.conf
+++ b/eos-updater/eos-updater.conf
@@ -2,5 +2,5 @@
 # keys. To customise it, copy it to /etc/eos-updater/eos-updater.conf
 # and edit it.
 [Download]
-Order=main;
+Order=volume;main;
 OverrideUris=


### PR DESCRIPTION
This commit changes the default eos-updater.conf so that eos-updater
checks USB drives (technically mounted filesystems) for OS updates in
addition to checking the Internet. The USB OS update feature seems to be
in fairly good shape and it's slated for release in 3.4.8. Previously
we've been using a hook in the image builder to change eos-updater.conf
for testing LAN/USB updates, but now that we're ready to deploy them it
makes sense to make the change here.

This commit alone doesn't enable USB OS updates. The other requirement
is for the `eos` remote to have a collection ID configured on it, which
we will be doing in the image builder for non-OEM images (and eventually
for all images and in an update for existing users as well).

https://phabricator.endlessm.com/T23413