### PR TITLE
eupv: don't manually generate the summary

### DIFF
--- a/eos-updater-prepare-volume/eos-updater-prepare-volume
+++ b/eos-updater-prepare-volume/eos-updater-prepare-volume
@@ -190,11 +190,9 @@ class VolumePreparer:
         all_flatpak_refs = list(set(all_flatpak_refs))
 
         # Pass the heavy lifting off to `ostree create-usb` and `flatpak create-usb`
-        # which require an updated summary file
         # TODO: Verify that it adds GPG keys where appropriate.
         _, repo = self.sysroot.get_repo()
         repo_path = os.path.realpath(repo.get_path().get_path())
-        self.__run(['ostree', 'summary', '--update', '--repo', repo_path])
         self.__run(['ostree', 'create-usb', '--repo', repo_path,
                     '--commit={}'.format(os_collection_ref[2]),
                     self.volume_path, os_collection_ref[0], os_collection_ref[1]])

--- a/eos-updater-prepare-volume/eos-updater-prepare-volume
+++ b/eos-updater-prepare-volume/eos-updater-prepare-volume
@@ -190,7 +190,6 @@ class VolumePreparer:
         all_flatpak_refs = list(set(all_flatpak_refs))
 
         # Pass the heavy lifting off to `ostree create-usb` and `flatpak create-usb`
-        # TODO: Verify that it adds GPG keys where appropriate.
         _, repo = self.sysroot.get_repo()
         repo_path = os.path.realpath(repo.get_path().get_path())
         self.__run(['ostree', 'create-usb', '--repo', repo_path,


### PR DESCRIPTION
Generating the summary requires acquiring an exclusive lock on the
OSTree repository which risks this process failing if another process,
like `ostree commit` or `ostree prune`, holds an exclusive lock for
longer than OSTree's core.lock-timeout-secs config option (which
defaults to only 30 seconds which is not always sufficient).

In testing directly and with Gnome Software calling this script to copy
the OS and dependencies to USB, this step seems to be unnecessary, so
we're best off skipping it.

https://phabricator.endlessm.com/T23422