### PR TITLE
poll: Retry P2P code path on each Poll()

### DIFF
--- a/eos-updater/poll.c
+++ b/eos-updater/poll.c
@@ -651,7 +651,7 @@ metadata_fetch_internal (OstreeRepo     *repo,
   g_auto(SourcesConfig) config = SOURCES_CONFIG_CLEARED;
   g_autoptr(OstreeDeployment) deployment = NULL;
   g_autoptr(EosUpdateInfo) info = NULL;
-  static gboolean use_new_code = TRUE;
+  gboolean use_new_code = TRUE;
   /* TODO: link this --^ to failure of the fetch or apply stages?
    * Add environment variables or something else to force it one way or the other?
    * Make it clear in the logging which code path is being used. */


### PR DESCRIPTION
Currently eos-updater has two code paths for fetching metadata (and
update payloads), a P2P one that checks LAN/USB sources if configured to
do so in addition to checking the Internet, and a fallback one that only
checks the Internet in the same way eos-updater did in pre-P2P times, in
case the P2P code fails. There's a static boolean variable
"use_new_code" which is set to FALSE if the P2P fetch failed. However if
you're offline and don't have LAN/USB sources available, it will fail
every time, and since the variable is static its value persists to
subsequent Poll() operations for the lifetime of the eos-updater
process. So even if you have a USB drive plugged in for one of those
polls, eos-updater will only check the Internet and the update won't be
found unless eos-updater is restarted. The end result of this is that
users don't see USB OS updates show up in the App Center in the case
where they are (a) offline and (b) eos-updater did at least one Poll()
before the USB was plugged in.

So this commit simply takes away the static designation of the
"use_new_code" variable, so that the P2P code is tried every time. In
combination with the code in gnome-software that calls eos-updater's
Poll() method on USB insertion, this should make USB OS updates appear
for users.

https://phabricator.endlessm.com/T23950