### PR TITLE
eos-updater: Avoid scheduler for offline updates

### DIFF
--- a/eos-updater/data.h
+++ b/eos-updater/data.h
@@ -42,12 +42,19 @@ struct EosUpdaterData
    */
   gchar **overridden_urls;
 
-  /* The results from ostree_repo_find_remotes_async(), which contain all the
-   * possible sources of the given refs, including internet, LAN and USB sources
-   * (depending on what OstreeRepoFinders were enabled in the poll stage).
+  /* The results from ostree_repo_find_remotes_async(), which contain different
+   * possible sources of the given refs. If LAN/USB OstreeRepoFinders were
+   * configured at the poll stage, and any updates were found in them, this
+   * array contains only results from those sources. Otherwise it contains
+   * results from the Internet.
    * This needs to be passed from poll() to fetch().
    * May be NULL if using the fallback code in poll(). */
   OstreeRepoFinderResult **results;
+
+  /* This is TRUE if the results array above only contains offline (LAN/USB)
+   * sources for refs, which implies that the fetch can be done without
+   * consulting the update scheduler. */
+  gboolean offline_results_only;
 
   /* The object to pass to the tasks performed by the updater, in order to be
    * able to cancel them. Upon cancellation (which is done by the Cancel()

--- a/eos-updater/fetch.c
+++ b/eos-updater/fetch.c
@@ -981,6 +981,13 @@ check_scheduler (FetchData     *fetch_data,
       return TRUE;
     }
 
+  /* If we are using offline (LAN/USB) sources, don’t check the scheduler at all. */
+  if (fetch_data->data->offline_results_only)
+    {
+      g_message ("Fetch: not checking with download scheduler for offline updates");
+      return TRUE;
+    }
+
   /* Otherwise, connect to the download scheduler. If we can’t connect, fail
    * safe, and don’t download on a potentially metered connection. */
   if (!schedule_download (fetch_data, context, cancellable, error))

--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -219,6 +219,7 @@ eos_update_info_new (const gchar *checksum,
                      const gchar *old_refspec,
                      const gchar *version,
                      const gchar * const *urls,
+                     gboolean offline_results_only,
                      OstreeRepoFinderResult **results)
 {
   EosUpdateInfo *info;
@@ -235,6 +236,7 @@ eos_update_info_new (const gchar *checksum,
   info->old_refspec = g_strdup (old_refspec);
   info->version = g_strdup (version);
   info->urls = g_strdupv ((gchar **) urls);
+  info->offline_results_only = offline_results_only;
   info->results = g_steal_pointer (&results);
 
   return info;
@@ -1184,6 +1186,8 @@ metadata_fetch_finished (GObject *object,
 
       g_clear_pointer (&data->results, ostree_repo_finder_result_freev);
       data->results = g_steal_pointer (&info->results);
+
+      data->offline_results_only = info->offline_results_only;
 
       /* Everything is happy thusfar */
       /* if we have a checksum for the remote upgrade candidate

--- a/eos-updater/poll-common.h
+++ b/eos-updater/poll-common.h
@@ -74,6 +74,7 @@ struct _EosUpdateInfo
   gchar *old_refspec;
   gchar *version;
   gchar **urls;
+  gboolean offline_results_only;
 
   OstreeRepoFinderResult **results;  /* (owned) (array zero-terminated=1) */
 };
@@ -85,6 +86,7 @@ eos_update_info_new (const gchar *csum,
                      const gchar *old_refspec,
                      const gchar *version,
                      const gchar * const *urls,
+                     gboolean offline_results_only,
                      OstreeRepoFinderResult **results);
 
 GDateTime *


### PR DESCRIPTION
Currently eos-updater asks the download scheduler (mogwai) before
fetching an update, so that the user's configured update schedule can be
respected. However that system is designed to help users with limited
Internet connections; it doesn't make sense to use it when the update
comes from local sources, such as the local network or a USB drive. So
this commit makes changes to eos-updater so that offline OS updates can
happen regardless of whether or not automatic updates are turned on.

The way this is implemented is that in the Poll() stage, we first check
offline sources for updates, and then only check the Internet if none
were found offline. If we simply check all the sources at once as we
previously were, you'd have to make significant changes to the Fetch()
stage, because the scheduler can't make a decision when the offline and
online results are mixed together.

There are two notable implications of this implementation:

1. This means that even if the LAN or USB drive has an older update than
what's available on the Internet, we update from it first (then on the
next check for updates the Internet would be used). In my opinion, this
is desired behavior because after the offline update is complete, the
delta for the online update may be smaller.

2. Before this commit if the fetch from an offline source fails we try
to fetch from the Internet (if they both provide the latest commit).
After this commit, if the offline fetch fails the whole update fails.
This might be less than ideal but I don't think it will matter in
practice. The alternative would be to rearchitect eos-updater or the
libostree API used for the fetch in significant ways.

A mounted filesystem or a peer on the network could conceivably prevent
you from updating, but that's true both before and after this commit;
see ostreedev/ostree#1527

https://phabricator.endlessm.com/T23972