### PR TITLE
debian: Use libexecdir as /usr/libexec as allowed by FHS 3.0

### DIFF
--- a/debian/eos-updater-tests.install
+++ b/debian/eos-updater-tests.install
@@ -1,2 +1,2 @@
-usr/lib/*/installed-tests/eos-updater-0
+usr/libexec/installed-tests/eos-updater-0
 usr/share/installed-tests/eos-updater-0

--- a/debian/eos-updater.install
+++ b/debian/eos-updater.install
@@ -7,10 +7,10 @@ lib/systemd/system/eos-updater.service
 lib/systemd/system/eos-update-server.service
 lib/systemd/system/eos-update-server.socket
 usr/bin/eos-updater
-usr/lib/*/eos-autoupdater
-usr/lib/*/eos-updater-avahi
-usr/lib/*/eos-updater-flatpak-installer
-usr/lib/*/eos-update-server
+usr/libexec/eos-autoupdater
+usr/libexec/eos-updater-avahi
+usr/libexec/eos-updater-flatpak-installer
+usr/libexec/eos-update-server
 usr/lib/*/libeos-updater-flatpak-installer-0.so.*
 usr/lib/*/libeos-updater-util-0.so.*
 usr/share/dbus-1/interfaces/com.endlessm.Updater.xml

--- a/debian/libeos-updater-flatpak-installer-0-tests.install
+++ b/debian/libeos-updater-flatpak-installer-0-tests.install
@@ -1,2 +1,2 @@
-usr/lib/*/installed-tests/libeos-updater-flatpak-installer-0
+usr/libexec/installed-tests/libeos-updater-flatpak-installer-0
 usr/share/installed-tests/libeos-updater-flatpak-installer-0

--- a/debian/libeos-updater-util-0-tests.install
+++ b/debian/libeos-updater-util-0-tests.install
@@ -1,2 +1,2 @@
-usr/lib/*/installed-tests/libeos-updater-util-0
+usr/libexec/installed-tests/libeos-updater-util-0
 usr/share/installed-tests/libeos-updater-util-0


### PR DESCRIPTION
Following such illustrious guidance as:
 * https://salsa.debian.org/debian/flatpak-builder/commit/d525fb2f3024db21e9169605e4ab30e3cc203523
 * https://manpages.debian.org/unstable/debhelper/debhelper.7.en.html
   (v12 compatibility)

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T26056