### PR TITLE
eupv: Work when the user ID differs on the destination computer

### DIFF
--- a/eos-updater-prepare-volume/eos-updater-prepare-volume
+++ b/eos-updater-prepare-volume/eos-updater-prepare-volume
@@ -204,7 +204,9 @@ class VolumePreparer:
         if len(all_flatpak_refs) > 0:
             self.__run(['flatpak', '--system', 'create-usb',
                         self.volume_path] + all_flatpak_refs)
-        # Ensure that this USB drive can later be written to by non-root users
+        # Ensure that this USB drive can later be read by any user and the
+        # .ostree directory can be written to by any user
+        self.__run(['chmod', '755', GLib.build_filenamev([self.volume_path])])
         self.__run(['chmod', '-R', '777', GLib.build_filenamev([self.volume_path, '.ostree'])])
 
 


### PR DESCRIPTION
Currently if the USB drive used for USB updates uses a filesystem that
preserves Linux permissions (such as ext4) and its toplevel directory
doesn't give read and execute permission to other users, and the user ID
who owns the flash drive is different than the logged in user's ID on
the receiving computer where the drive is used, gnome-software will
crash and fail to display the apps on the USB drive. For example if I
use the shared user with user ID 1001 to format a drive ext4, copy apps
to it, and then put it in a computer logged in as the primary user with
user ID 1000, that user will be unable to open the drive or receive
updates from it.

We already do a recursive chmod on the ".ostree" directory on the drive
after the copy, so this commit just adds another chmod command before
that which sets the permissions to 755 on the drive's toplevel directory
(in other words the owner has full permissions and group/other users
have read and execute permissions).

This issue shouldn't appear for most users since most flash drives are
formatted with a filesystem that doesn't care about linux permissions
like FAT.

https://phabricator.endlessm.com/T25940