### PR TITLE
libeos-updater-util: Check for new flatpak error code

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends:
  dh-autoreconf,
  dh-python,
  eos-metrics-0-dev,
- flatpak (>= 1.1.2),
+ flatpak (>= 1.3.3+dev37.20fb7d1-0),
  gir1.2-flatpak-1.0,
  gir1.2-glib-2.0,
  gir1.2-ostree-1.0,


### PR DESCRIPTION
libflatpak now returns FLATPAK_ERROR_REF_NOT_FOUND instead
of G_IO_ERROR_NOT_FOUND (and sometimes other errors) when a
ref can't be found either locally or in a remote. So update
some code which checks for G_IO_ERROR_NOT_FOUND.

See these commits:
https://github.com/flatpak/flatpak/commit/c0d5f1bfc8f09d5c7038422ecd948f26eaad747c
https://github.com/flatpak/flatpak/commit/c028e0dc1b7861a507c39f76c5bb582ee2150da1

https://phabricator.endlessm.com/T26678