### PR TITLE
Move eos-updater executable to /usr/libexec

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -221,7 +221,7 @@ eos_updater_libeos_updater_dbus_la_SOURCES = \
 	$(NULL)
 nodist_eos_updater_libeos_updater_dbus_la_SOURCES = $(eos_updater_codegen_sources)
 
-bin_PROGRAMS += eos-updater/eos-updater
+libexec_PROGRAMS += eos-updater/eos-updater
 
 eos_updater_eos_updater_CPPFLAGS = \
 	$(AM_CPPFLAGS) \

--- a/debian/eos-updater.install
+++ b/debian/eos-updater.install
@@ -6,7 +6,7 @@ lib/systemd/system/eos-updater-flatpak-installer.service
 lib/systemd/system/eos-updater.service
 lib/systemd/system/eos-update-server.service
 lib/systemd/system/eos-update-server.socket
-usr/bin/eos-updater
+usr/libexec/eos-updater
 usr/libexec/eos-autoupdater
 usr/libexec/eos-updater-avahi
 usr/libexec/eos-updater-flatpak-installer

--- a/eos-updater/eos-updater.service.in
+++ b/eos-updater/eos-updater.service.in
@@ -4,7 +4,7 @@ Documentation=man:eos-updater(8)
 After=network.target
 
 [Service]
-ExecStart=@bindir@/eos-updater
+ExecStart=@libexecdir@/eos-updater
 Type=dbus
 BusName=com.endlessm.Updater
 IOSchedulingClass=idle


### PR DESCRIPTION
I constantly run `eos-updater update` rather than `eos-updater-ctl
update` thanks to tab completion. There's no reason for this executable
to be in $PATH.

https://phabricator.endlessm.com/T27471