### PR TITLE
eos-autoupdater: Add a timer for PAYG systems

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -166,6 +166,7 @@ nodist_eos_autoupdater_eos_autoupdater_SOURCES = \
 eos_autoupdater_in = \
 	eos-autoupdater/eos-autoupdater.service.in \
 	eos-autoupdater/eos-autoupdater.timer.in \
+	eos-autoupdater/eos-autoupdater-payg.timer.in \
 	$(NULL)
 
 systemdsystemunit_DATA += $(eos_autoupdater_in:%.in=%)

--- a/debian/eos-updater.install
+++ b/debian/eos-updater.install
@@ -1,5 +1,6 @@
 lib/systemd/system/eos-autoupdater.service
 lib/systemd/system/eos-autoupdater.timer
+lib/systemd/system/eos-autoupdater-payg.timer
 lib/systemd/system/eos-updater-avahi.path
 lib/systemd/system/eos-updater-avahi.service
 lib/systemd/system/eos-updater-flatpak-installer.service

--- a/debian/rules
+++ b/debian/rules
@@ -37,6 +37,7 @@ override_dh_installsystemd:
 		$(NULL)
 	dh_installsystemd -peos-updater \
 		eos-autoupdater.timer \
+		eos-autoupdater-payg.timer \
 		eos-update-server.socket \
 		eos-updater-avahi.path \
 		$(NULL)

--- a/eos-autoupdater/eos-autoupdater-payg.timer.in
+++ b/eos-autoupdater/eos-autoupdater-payg.timer.in
@@ -1,14 +1,15 @@
 [Unit]
-Description=Endless OS Automatic Update Timer
+Description=Endless OS Automatic Update Timer (PAYG)
 Documentation=man:eos-autoupdater(8)
 ConditionKernelCommandLine=!endless.live_boot
 ConditionKernelCommandLine=ostree
-ConditionKernelCommandLine=!eospayg
+ConditionKernelCommandLine=eospayg
 
 [Timer]
-OnBootSec=15m
+OnBootSec=0m
 OnUnitInactiveSec=1h
 RandomizedDelaySec=30min
+Unit=eos-autoupdater.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
On PAYG Endless images, if eos-paygd hits a fatal error condition (such
as a seg fault), the whole system is brought down. This creates a
reliability issue, because if we ever have such a bug, and it happens on
every boot, and it happens early enough in the boot, it may prevent the
machine from ever updating and receiving the bug fix. The automatic
updater is currently configured to run 15 minutes after boot up, to give
NTP a chance to correct the clock. But this shouldn't be a concern for
PAYG computers, which should have their clocks set correctly during
provisioning. So introduce a new timer, eos-autoupdater-payg.timer,
which activates eos-autoupdater.service immediately after boot (really
after the network comes up since the service has After=network.target).
Use a kernel command line parameter to ensure the new timer only runs on
PAYG images, and the existing timer only runs on non-PAYG images.

Both timers also have RandomizedDelaySec=30m, to reduce the chances that
many computers on the same network will update at once and overload the
network. This means the update won't often happen immediately after the
network comes up, but seems like a worthwhile trade-off.

https://phabricator.endlessm.com/T27051