### PR TITLE
Allow compilation against upstream OSTree

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,11 @@ PKG_CHECK_MODULES([JSON_GLIB],
 PKG_CHECK_MODULES([OSTREE],
                   [ostree-1 >= $OSTREE_REQUIRED_VERSION])
 
+ac_save_LIBS=$LIBS
+LIBS="$ac_save_LIBS $OSTREE_LIBS"
+AC_CHECK_FUNCS([ostree_repo_get_commit_sizes])
+LIBS=$ac_save_LIBS
+
 PKG_CHECK_MODULES([SOUP],
                   [libsoup-2.4])
 

--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -1237,6 +1237,7 @@ metadata_fetch_finished (GObject *object,
       eos_updater_set_update_label (updater, label ? label : "");
       eos_updater_set_update_message (updater, message ? message : "");
 
+#ifdef HAVE_OSTREE_REPO_GET_COMMIT_SIZES
       if (ostree_repo_get_commit_sizes (repo, info->checksum,
                                         &new_archived, &new_unpacked,
                                         NULL,
@@ -1252,6 +1253,7 @@ metadata_fetch_finished (GObject *object,
           eos_updater_set_downloaded_bytes (updater, 0);
         }
       else /* no size data available (may or may not be an error) */
+#endif
         {
           eos_updater_set_full_download_size (updater, -1);
           eos_updater_set_full_unpacked_size (updater, -1);


### PR DESCRIPTION
`ostree_repo_get_commit_sizes` is not available on upstream OSTree. As
a result, it failed to compile against it.  When the function is not
available, only the fallback to the call to
`ostree_repo_get_commit_sizes` is executed.