### PR TITLE
eos-autoupdater: Lower OnBootSec from 15m to 3m

### DIFF
--- a/eos-autoupdater/eos-autoupdater.timer.in
+++ b/eos-autoupdater/eos-autoupdater.timer.in
@@ -5,7 +5,9 @@ ConditionKernelCommandLine=!endless.live_boot
 ConditionKernelCommandLine=ostree
 
 [Timer]
-OnBootSec=15m
+# After 3 minutes the network connection has likely been set up, but we don't
+# have a hard requirement; offline updates need to work too
+OnActiveSec=3m
 OnUnitInactiveSec=1h
 RandomizedDelaySec=30min
 


### PR DESCRIPTION
This commit makes eos-autoupdater.timer potentially start 3 minutes
after boot, rather than 15 minutes after boot. Because we have
RandomizedDelaySec=30m, in practice it will start between 3 and 33
minutes after boot. The primary reason for the change is that we will
soon be shipping PAYG Endless computers, on which if the eos-paygd
daemon crashes or exits with an error code, the whole computer shuts
down after a 20 minute grace period. This poses a risk of making
computers stuck in a boot loop and never receiving an update which might
fix the problem, in case the hypothetical crash happens before
eos-updater runs. So make such a boot loop less likely by having the
updater run automatically earlier after boot.

The reason the updater currently runs 15 minutes after boot is to give
ntp a chance to update an incorrect clock to the correct time, because a
sufficiently incorrect clock would prevent GPG signature verification
from working.[1] One might think this problem could be solved by adding
After=time-sync.target to the unit, but in practice that target is
reached before the clock is synchronized.[2] And if we were to enable
systemd-time-wait-sync.service to make time-sync.target work as
advertised, it's not clear when updates would be triggered on offline
machines, and according to the man page, systemd-time-wait-sync.service
is unreliable when used in conjunction with ntp rather than
systemd-timesyncd.service (and Endless uses ntp).[3] I think we should
just accept that there's some chance updates will fail due to a wrong
clock or for other reasons, and the updater will just try again when
OnUnitInactiveSec=1h is reached or a reboot occurs.

By starting 3 minutes after boot, we're giving the machine some time to
get online and get the clock corrected, without blocking on the
completion of either of those tasks. It wouldn't make sense to wait for
an Internet connection because we want LAN/USB updates to happen
automatically.[4] Also note that After=network-online.target doesn't
guarantee a working Internet connection, because
NetworkManager-wait-online.service only waits until NetworkManager has
started up.

[1] https://github.com/endlessm/eos-shell/issues/1478
[2] https://github.com/systemd/systemd/issues/5097
[3] https://www.freedesktop.org/software/systemd/man/systemd-time-wait-sync.service.html
[4] https://phabricator.endlessm.com/T21250

https://phabricator.endlessm.com/T27051