### PR TITLE
eos-updater-flatpak-installer: skip parental controls checks

### DIFF
--- a/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
+++ b/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
@@ -19,6 +19,11 @@ RemainAfterExit=true
 ExecStart=@libexecdir@/eos-updater-flatpak-installer
 Restart=no
 
+# Flatpak checks parental controls at deploy time. In order to do this, it
+# needs to talk to accountsservice on the system bus, neither of which are
+# running when this job runs.
+Environment=FLATPAK_SKIP_PARENTAL_CONTROLS_NO_SYSTEM_BUS=1
+
 # Sandboxing
 # flatpak triggers use bwrap which requires net/sys admin and chroot
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_SYS_ADMIN CAP_SYS_CHROOT


### PR DESCRIPTION
Without this, deploying Flatpaks after a reboot fails with the following
in the journal (line-wrapped for legibility):

    Attempting to install eos-apps:app/com.hack_computer.Clubhouse/x86_64/eos3
    Failed to install eos-apps:app/com.hack_computer.Clubhouse/x86_64/eos3:
      Could not connect: No such file or directory
    eos-updater-flatpak-installer: Couldn’t apply some flatpak update actions for this boot:
      Could not connect: No such file or directory

This problem does not occur if I trigger this service once the system is
fully booted.

I believe this is because deploying a Flatpak now involves a parental
controls check, which involves talking to accountsservice on the system
bus, neither of which are running at the point where this service runs.
Work around this by using the same workaround we used in the image
builder to skip the parental controls check.

https://phabricator.endlessm.com/T28530