### PR TITLE
poll: Use ostree_commit_get_object_sizes if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ PKG_CHECK_MODULES([OSTREE],
 
 ac_save_LIBS=$LIBS
 LIBS="$ac_save_LIBS $OSTREE_LIBS"
-AC_CHECK_FUNCS([ostree_repo_get_commit_sizes])
+AC_CHECK_FUNCS([ostree_repo_get_commit_sizes ostree_commit_get_object_sizes])
 LIBS=$ac_save_LIBS
 
 PKG_CHECK_MODULES([SOUP],

--- a/test-common/ostree-spawn.c
+++ b/test-common/ostree-spawn.c
@@ -207,6 +207,7 @@ ostree_commit (GFile *repo,
       { "gpg-sign", keyid },
       { "gpg-homedir", gpg_home_path },
       { "timestamp", formatted_timestamp },
+      { "generate-sizes", NULL },
       { NULL, raw_tree_path },
     };
   CmdArg empty = { NULL, NULL };

--- a/tests/test-update-direct.c
+++ b/tests/test-update-direct.c
@@ -500,7 +500,7 @@ test_update_sizes (EosUpdaterFixture *fixture,
   gint64 expected_unpacked;
   gint64 expected_full_download;
   gint64 expected_full_unpacked;
-#ifdef HAVE_OSTREE_REPO_GET_COMMIT_SIZES
+#if defined (HAVE_OSTREE_COMMIT_GET_OBJECT_SIZES) || defined (HAVE_OSTREE_REPO_GET_COMMIT_SIZES)
   expected_download = 11635;
   expected_unpacked = 10487043;
   expected_full_download = 12696;


### PR DESCRIPTION
OSTree upstream recently gained an API to return the parsed entries in
the `ostree.sizes` metadata[1]. Split out a helper function and use it
if it's available to sum the various commit size properies. There is one
slight behavior change here - the updater only continues on error if the
error is `G_IO_ERROR_NOT_FOUND`. This is what both APIs return when
`ostree.sizes` does not exist as well as what's now set when neither
APIs are available.

1. https://github.com/ostreedev/ostree/pull/1957

https://phabricator.endlessm.com/T18171