### PR TITLE
poll: Drop support for downstream ostree_repo_get_commit_sizes API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ PKG_CHECK_MODULES([OSTREE],
 
 ac_save_LIBS=$LIBS
 LIBS="$ac_save_LIBS $OSTREE_LIBS"
-AC_CHECK_FUNCS([ostree_repo_get_commit_sizes ostree_commit_get_object_sizes])
+AC_CHECK_FUNCS([ostree_commit_get_object_sizes])
 LIBS=$ac_save_LIBS
 
 PKG_CHECK_MODULES([SOUP],

--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -1249,17 +1249,8 @@ get_commit_sizes (OstreeRepo    *repo,
     }
 
   return TRUE;
-#elif defined (HAVE_OSTREE_REPO_GET_COMMIT_SIZES)
-  return ostree_repo_get_commit_sizes (repo, checksum,
-                                       (gint64 *) new_archived,
-                                       (gint64 *) new_unpacked,
-                                       NULL,
-                                       (gint64 *) archived,
-                                       (gint64 *) unpacked,
-                                       NULL,
-                                       cancellable, error);
 #else
-  /* Neither API available, just pretend as if sizes could not be found */
+  /* API not available, just pretend as if sizes could not be found */
   g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
                        "OSTree does not support parsing ostree.sizes metadata");
   return FALSE;

--- a/tests/test-update-direct.c
+++ b/tests/test-update-direct.c
@@ -500,7 +500,7 @@ test_update_sizes (EosUpdaterFixture *fixture,
   gint64 expected_unpacked;
   gint64 expected_full_download;
   gint64 expected_full_unpacked;
-#if defined (HAVE_OSTREE_COMMIT_GET_OBJECT_SIZES) || defined (HAVE_OSTREE_REPO_GET_COMMIT_SIZES)
+#if defined (HAVE_OSTREE_COMMIT_GET_OBJECT_SIZES)
   expected_download = 11635;
   expected_unpacked = 10487043;
   expected_full_download = 12696;


### PR DESCRIPTION
We've backported upstream's `ostree_commit_get_object_sizes`'s to our
ostree and dropped `ostree_repo_get_commit_sizes`[1]. Drop support for
the latter since the Endless downstream ostree is the only place it
existed.

1. https://github.com/endlessm/ostree/pull/164

https://phabricator.endlessm.com/T18171