### PR TITLE
all: Fix various typos and incorrect terminology

### DIFF
--- a/eos-updater-flatpak-installer/docs/eos-updater-flatpak-autoinstall.d.5
+++ b/eos-updater-flatpak-installer/docs/eos-updater-flatpak-autoinstall.d.5
@@ -123,7 +123,7 @@ when the action is applied.
 [
     {
         "action": "install",
-        "branch": "master",
+        "branch": "stable",
         "serial": 2017100100,
         "ref\-kind": "app",
         "name": "org.example.MyApp",

--- a/eos-updater-flatpak-installer/docs/eos-updater-flatpak-installer.8
+++ b/eos-updater-flatpak-installer/docs/eos-updater-flatpak-installer.8
@@ -37,7 +37,7 @@ in the directories specified by \fBeos\-updater\-flatpak\-autoinstall.d\fP(5)
 and the counter state in
 \fI/var/lib/eos\-application\-tools/flatpak\-autoinstall.progress\fP, then for
 each basename, perform only newly updated actions and save the most up to date
-serial number for each file in ther counter state file.
+serial number for each file in the counter state file.
 \".
 When set to \fBstamp\fP, \fBeos\-updater\-flatpak\-installer\fP will only save
 the updated actions to

--- a/eos-updater/com.endlessm.Updater.xml
+++ b/eos-updater/com.endlessm.Updater.xml
@@ -230,7 +230,7 @@
       ErrorCode:
 
       Error code of the current error, or `0` if no error has been reported.
-      This is in an unspecified error doman, and hence is useless.
+      This is in an unspecified error domain, and hence is useless.
 
       Deprecated: Use `ErrorName` instead.
     -->

--- a/libeos-update-server/repo.c
+++ b/libeos-update-server/repo.c
@@ -866,8 +866,8 @@ handle_refs_heads (EusRepo     *self,
   /* If not, this is probably a request for a head which is only available on
    * the server — and hence available in our repository as a remote ref.
    * Transparently redirect to /refs/remotes/$remote_name. For example, map
-   * /refs/heads/os/eos/amd64/master to
-   * /refs/remotes/eos/os/eos/amd64/master. */
+   * /refs/heads/os/eos/amd64/stable to
+   * /refs/remotes/eos/os/eos/amd64/stable. */
   head = requested_path + prefix_len; /* e.g eos2/i386 */
   g_clear_pointer (&raw_path, g_free);
   raw_path = g_build_filename (self->cached_repo_root,
@@ -1093,7 +1093,7 @@ eus_repo_new (OstreeRepo    *repo,
  *
  * To stop handling requests, call eus_repo_disconnect(). It is an error to
  * call eus_repo_connect() twice in a row without calling eus_repo_disconnect()
- * inbetween.
+ * between.
  *
  * Since: UNRELEASED
  */

--- a/libeos-updater-util/avahi-service-file.h
+++ b/libeos-updater-util/avahi-service-file.h
@@ -123,7 +123,7 @@ const gchar *eos_avahi_service_file_get_directory (void);
  * implicitly for the size of the record (you can think about the
  * record as a pascal string). 2 bytes go for the name of the TXT
  * record (it is "rb" from "refs bloom"). 1 byte go for the equal
- * sign. 1 byte goes for the bloom k paramater and 1 byte goes for the
+ * sign. 1 byte goes for the bloom k parameter and 1 byte goes for the
  * bloom hashing function ID. That gives us 250 bytes max.
  *
  * Default value of this option (if not overridden) is 250.

--- a/test-common/utils.c
+++ b/test-common/utils.c
@@ -2298,7 +2298,7 @@ eos_test_get_installed_flatpaks (GFile   *updater_dir,
 
   /* To match output like:
    * Ref
-   * org.gnome.Recipes/x86_64/master
+   * org.gnome.Recipes/x86_64/stable
    * org.gnome.Platform/x86_64/3.24
    *
    * We use a regex here, rather than libflatpak, because the test library

--- a/tests/test-update-install-flatpaks.c
+++ b/tests/test-update-install-flatpaks.c
@@ -4984,7 +4984,7 @@ test_update_deploy_flatpaks_on_reboot_partially_on_failure (EosUpdaterFixture *f
   g_assert_error (error, G_SPAWN_EXIT_ERROR, EUFI_EXIT_CODE_APPLY_FAILED);
   g_clear_error (&error);
 
-  /* Assert that our frist flatpak was installed, but the second
+  /* Assert that our first flatpak was installed, but the second
    * one was not */
   deployed_flatpaks = eos_test_get_installed_flatpaks (updater_directory, &error);
   g_assert_no_error (error);
@@ -5000,7 +5000,7 @@ test_update_deploy_flatpaks_on_reboot_partially_on_failure (EosUpdaterFixture *f
  *
  * In this scenario, we attempt to install two flatpaks, but the second one
  * will fail to install due to a file being in the way. We then fix
- * the probelm by removing the file that's in the way and run
+ * the problem by removing the file that's in the way and run
  * the installer again. Verify that although an error was set the first
  * time, the second time around the installer successfully completes
  * and both flatpaks are installed. */
@@ -5123,7 +5123,7 @@ test_update_deploy_flatpaks_on_reboot_resume_on_failure_resolved (EosUpdaterFixt
                                   &error);
   g_assert_no_error (error);
 
-  /* Assert that our frist flatpak was installed, but the second
+  /* Assert that our first flatpak was installed, but the second
    * one was not */
   deployed_flatpaks = eos_test_get_installed_flatpaks (updater_directory, &error);
   g_assert_no_error (error);


### PR DESCRIPTION
Done using:
```
codespell \
    --builtin clear,rare,usage \
    --skip './po/*' --skip './help/*/*.po' --skip './.git/*' --skip './NEWS*' \
    --write-changes .
```
and then some manual checking and editing.

Signed-off-by: Philip Withnall <withnall@endlessm.com>