### PR TITLE
ctl: Pretty-print sizes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+# The default is 79 characters. Black, a popular auto-formatter, defaults to 88
+# based on empirical research.
+# https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length
+max-line-length = 88

--- a/eos-updater-ctl/eos-updater-ctl
+++ b/eos-updater-ctl/eos-updater-ctl
@@ -80,9 +80,22 @@ def dump_daemon_properties(proxy):
     print("{:>{}}: {}".format("State", width, UPDATER_STATES[s]))
 
     for x in proxy.get_cached_property_names():
-        if x != "State":
-            value = proxy.get_cached_property(x)
-            print("{:>{}}: {}".format(x, width, value))
+        if x == "State":  # Handled above
+            continue
+
+        value = proxy.get_cached_property(x)
+        if x in (
+            "DownloadSize",
+            "DownloadedBytes",
+            "FullDownloadSize",
+            "FullUnpackedSize",
+            "UnpackedSize",
+        ):
+            value = GLib.format_size_full(
+                value.get_int64(), GLib.FormatSizeFlags.LONG_FORMAT
+            )
+
+        print("{:>{}}: {}".format(x, width, value))
 
     print("")
 


### PR DESCRIPTION
Here's a diff:

```diff
            State: UpdateApplied
        CurrentID: '4f09a3945a3fffcaf5d9a3361b7dbc37b621d1201404a0753db874d78f0eedfb'
-    DownloadSize: int64 223547830
- DownloadedBytes: int64 223549376
+    DownloadSize: 223.5 MB (223547830 bytes)
+ DownloadedBytes: 223.5 MB (223549376 bytes)
        ErrorCode: uint32 0
     ErrorMessage: ''
        ErrorName: ''
-FullDownloadSize: int64 1755678232
-FullUnpackedSize: int64 4088847909
+FullDownloadSize: 1.8 GB (1755678232 bytes)
+FullUnpackedSize: 4.1 GB (4088847909 bytes)
  OriginalRefspec: 'eos:os/eos/amd64/master'
-    UnpackedSize: int64 452314713
+    UnpackedSize: 452.3 MB (452314713 bytes)
         UpdateID: '16b7353e8e87bf05421481940152098aefa0f25a3026b8cbbcb9c01a57f0378d'
      UpdateLabel: '200819-063538'
    UpdateMessage: 'Built with eos-ostree-builder Release_3.8.5'
```