### PR TITLE
T25765 Fix transaction operation error handling in eufi

### DIFF
--- a/eos-updater-avahi/eos-updater-avahi.c
+++ b/eos-updater-avahi/eos-updater-avahi.c
@@ -38,8 +38,7 @@ get_refs (OstreeRepo            *repo,
 {
   g_autoptr(GHashTable) refs = NULL;
   GHashTableIter iter;
-  OstreeCollectionRef *key;
-  gchar *value;
+  gpointer key, value;
   g_autoptr(GPtrArray) refs_array = NULL;
 
   if (!ostree_repo_list_collection_refs (repo,
@@ -58,11 +57,13 @@ get_refs (OstreeRepo            *repo,
     }
   refs_array = g_ptr_array_new_full (g_hash_table_size (refs) + 1, (GDestroyNotify)ostree_collection_ref_free);
   g_hash_table_iter_init (&iter, refs);
-  while (g_hash_table_iter_next (&iter, (gpointer *)&key, (gpointer *)&value))
+  while (g_hash_table_iter_next (&iter, &key, &value))
     {
+      g_autoptr(OstreeCollectionRef) ref = key;
+      g_autofree gchar *checksum = value;
+
       g_hash_table_iter_steal (&iter);
-      g_free (g_steal_pointer (&value));
-      g_ptr_array_add (refs_array, g_steal_pointer (&key));
+      g_ptr_array_add (refs_array, g_steal_pointer (&ref));
     }
   g_ptr_array_add (refs_array, NULL);
 

--- a/eos-updater/fetch.c
+++ b/eos-updater/fetch.c
@@ -399,6 +399,7 @@ transition_pending_ref_action_collection_ids_to_remote_names (FlatpakInstallatio
     {
       EuuFlatpakRemoteRefAction *action = g_ptr_array_index (pending_flatpak_ref_actions, i);
       EuuFlatpakLocationRef *to_install = action->ref;
+      gpointer candidate_remote_name_ptr = NULL;
       const gchar *candidate_remote_name = NULL;
       g_autoptr(GError) local_error = NULL;
 
@@ -418,7 +419,7 @@ transition_pending_ref_action_collection_ids_to_remote_names (FlatpakInstallatio
       if (to_install->collection_id != NULL &&
           !g_hash_table_lookup_extended (collection_ids_to_remote_names,
                                          to_install->collection_id,
-                                         NULL, (gpointer *) &candidate_remote_name))
+                                         NULL, &candidate_remote_name_ptr))
         {
           g_autofree gchar *found_remote_name = NULL;
 
@@ -454,6 +455,8 @@ transition_pending_ref_action_collection_ids_to_remote_names (FlatpakInstallatio
                                g_strdup (to_install->collection_id),
                                g_steal_pointer (&found_remote_name));
         }
+      else
+        candidate_remote_name = candidate_remote_name_ptr;
 
       /* Cross check the remote name from before with the one we have now */
       if (candidate_remote_name != NULL &&

--- a/eos-updater/main.c
+++ b/eos-updater/main.c
@@ -296,12 +296,12 @@ static void
 purge_old_config_file (const gchar *etc_path,
                        const gchar *checksum_to_delete)
 {
-  g_autofree guint8 *etc_contents = NULL;
+  g_autofree gchar *etc_contents = NULL;
   gsize etc_length;
   g_autoptr(GChecksum) checksum = NULL;
   g_autoptr(GError) error = NULL;
 
-  g_file_get_contents (etc_path, (gchar **) &etc_contents, &etc_length, &error);
+  g_file_get_contents (etc_path, &etc_contents, &etc_length, &error);
   if (g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
     {
       return;
@@ -316,7 +316,7 @@ purge_old_config_file (const gchar *etc_path,
   /* Work out its checksum. The @etc_length cast might truncate the file,
    * but that would only result in it being kept slightly-unnecessarily. */
   checksum = g_checksum_new (G_CHECKSUM_MD5);
-  g_checksum_update (checksum, etc_contents, (gssize) etc_length);
+  g_checksum_update (checksum, (const guchar *) etc_contents, (gssize) etc_length);
 
   /* If the files are the same, delete the @etc_path. */
   if (g_strcmp0 (g_checksum_get_string (checksum), checksum_to_delete) == 0)

--- a/libeos-update-server/repo.c
+++ b/libeos-update-server/repo.c
@@ -716,14 +716,14 @@ serve_file_if_exists (SoupMessage *msg,
     file_bytes = g_mapped_file_get_bytes (mapping);
   else
     {
-      g_autofree guint8 *contents = NULL;
+      g_autofree gchar *contents = NULL;
       gsize contents_len = 0;
 
       /* mmap() can legitimately fail if the underlying file system doesn’t
        * support it, which can happen if we’re using an overlayfs. Fall back to
        * reading in the file. */
       g_clear_error (&error);
-      if (!g_file_get_contents (raw_path, (gchar **) &contents, &contents_len, &error))
+      if (!g_file_get_contents (raw_path, &contents, &contents_len, &error))
         {
           g_warning ("Failed to load ‘%s’: %s", raw_path, error->message);
           soup_message_set_status (msg, SOUP_STATUS_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
Turns out that the `operation-error` signal needs to be handled in order for transactions to behave as you’d expect them to (for example, not failing on skipped operations, returning the error code from a failed operation).

See the individual commit messages for details.

This branch should improve our error reporting from EUFI. It may fix the upgrade-time installation of Totem, but I haven’t explicitly tested that (yet).

https://phabricator.endlessm.com/T25765