### PR TITLE
T29247 Add failure metric reporting

### DIFF
--- a/eos-updater-flatpak-installer/meson.build
+++ b/eos-updater-flatpak-installer/meson.build
@@ -2,6 +2,7 @@ eos_update_flatpak_installer_sources = [
   'main.c',
 ]
 
+eosmetrics_dep = dependency('eosmetrics-0', required: get_option('metrics'))
 eos_update_flatpak_installer_deps = [
   dependency('flatpak', version: '>= 1.1.2'),
   dependency('gio-2.0', version: '>= 2.62'),
@@ -11,11 +12,16 @@ eos_update_flatpak_installer_deps = [
   dependency('ostree-1', version: '>= 2018.6'),
   libeos_updater_flatpak_installer_dep,
   libeos_updater_util_dep,
+  eosmetrics_dep,
 ]
 
 eos_update_flatpak_installer_cppflags = [
   '-DG_LOG_DOMAIN="eos-updater-flatpak-installer"',
 ]
+
+if eosmetrics_dep.found()
+  eos_update_flatpak_installer_cppflags += ['-DHAS_EOSMETRICS_0']
+endif
 
 executable('eos-updater-flatpak-installer',
   eos_update_flatpak_installer_sources,

--- a/libeos-updater-util/meson.build
+++ b/libeos-updater-util/meson.build
@@ -21,6 +21,7 @@ libeos_updater_util_headers = [
 ]
 
 libeos_updater_util_private_headers = [
+  'metrics-private.h',
   'ostree-bloom-private.h',
 ]
 

--- a/libeos-updater-util/metrics-private.h
+++ b/libeos-updater-util/metrics-private.h
@@ -1,0 +1,58 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2020 Endless OS Foundation LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Authors:
+ *  - Philip Withnall <withnall@endlessm.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+/*
+ * Records which branch will be used by the updater. The payload is a 4-tuple
+ * of 3 strings and boolean: vendor name, product ID, selected OStree ref, and
+ * whether the machine is on hold
+ */
+static const gchar *const EOS_UPDATER_METRIC_BRANCH_SELECTED = "99f48aac-b5a0-426d-95f4-18af7d081c4e";
+
+/**
+ * euu_get_metrics_enabled:
+ *
+ * Check whether metrics are enabled at runtime. They can be disabled using an
+ * environment variable for the unit tests.
+ *
+ * Returns: %TRUE if metrics are enabled, %FALSE otherwise
+ */
+static inline gboolean
+euu_get_metrics_enabled (void)
+{
+#ifdef HAS_EOSMETRICS_0
+  const gchar *disable_metrics = g_getenv ("EOS_DISABLE_METRICS");
+  return (disable_metrics == NULL || !g_str_equal (disable_metrics, "1"));
+#else
+  return FALSE;
+#endif
+}
+
+G_END_DECLS

--- a/libeos-updater-util/metrics-private.h
+++ b/libeos-updater-util/metrics-private.h
@@ -30,6 +30,12 @@
 G_BEGIN_DECLS
 
 /*
+ * Records a failure in the updater. The payload is an `(ss)` of the updater
+ * component, and the error message.
+ */
+static const gchar *const EOS_UPDATER_METRIC_FAILURE = "927d0f61-4890-4912-a513-b2cb0205908f";
+
+/*
  * Records which branch will be used by the updater. The payload is a 4-tuple
  * of 3 strings and boolean: vendor name, product ID, selected OStree ref, and
  * whether the machine is on hold

--- a/test-common/utils.c
+++ b/test-common/utils.c
@@ -2264,6 +2264,7 @@ eos_test_run_flatpak_installer (GFile        *client_root,
   };
   CmdEnvVar envv[] =
     {
+      { "EOS_DISABLE_METRICS", "1", NULL },
       { "EOS_UPDATER_TEST_FLATPAK_INSTALLATION_DIR", NULL, flatpak_installation_dir },
       { "EOS_UPDATER_TEST_UPDATER_FLATPAK_UPGRADE_STATE_DIR", NULL, flatpak_upgrade_state_dir },
       { "EOS_UPDATER_TEST_UPDATER_FLATPAK_AUTOINSTALL_OVERRIDE_DIRS", NULL, flatpak_autoinstall_override_dir },


### PR DESCRIPTION
Report a metric when `eos-updater` or `eos-updater-flatpak-installer` fails.

Azafea changes in https://github.com/endlessm/azafea/pull/123.

https://phabricator.endlessm.com/T29247