### PR TITLE
debian: Bump to debhelper-compat level 13

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Philip Withnall <withnall@endlessm.com>
 Standards-Version: 3.9.6
 Build-Depends:
- debhelper-compat (= 12),
+ debhelper-compat (= 13),
  dh-python,
  eos-metrics-0-dev,
  flatpak (>= 1.3.3+dev37.20fb7d1-0),

--- a/debian/rules
+++ b/debian/rules
@@ -34,8 +34,5 @@ override_dh_installsystemd:
 		eos-updater-avahi.path \
 		$(NULL)
 
-override_dh_missing:
-	dh_missing --fail-missing
-
 %:
 	dh $@ --with gir,python3


### PR DESCRIPTION
`dh_missing` now defaults to `--fail-missing`, so we can drop our
override there.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T25765