### PR TITLE
eupv: Don't error out on missing flatpaks

### DIFF
--- a/eos-updater-prepare-volume/eos-updater-prepare-volume
+++ b/eos-updater-prepare-volume/eos-updater-prepare-volume
@@ -56,11 +56,17 @@ class VolumePreparer:
 
         self.sysroot = OSTree.Sysroot.new_default()
 
-    def __run(self, cmd):
+    def __run(self, cmd, fatal_error=True):
         """Run cmd locally."""
         print('# {}'.format(cmd))
 
-        subprocess.check_call(cmd)
+        try:
+            subprocess.check_call(cmd)
+        except subprocess.CalledProcessError:
+            if fatal_error:
+                raise
+            else:
+                sys.stderr.write('Warning: command failed: {}\n'.format(cmd))
 
     def __fail(self, exit_status, message):
         """Print an error to stderr and exit with the given error status."""
@@ -192,13 +198,6 @@ class VolumePreparer:
                                'OSTree deployment ref could not be found; '
                                'are you on an OSTree system?')
 
-        all_flatpak_refs = \
-            list(self.flatpak_refs) + \
-            list(autoinstall_flatpaks)
-
-        # Eliminate duplicates.
-        all_flatpak_refs = list(set(all_flatpak_refs))
-
         # Pass the heavy lifting off to `ostree create-usb` and
         # `flatpak create-usb`
         _, repo = self.sysroot.get_repo()
@@ -208,9 +207,18 @@ class VolumePreparer:
                         '--commit={}'.format(os_collection_ref[2]),
                         self.volume_path, os_collection_ref[0],
                         os_collection_ref[1]])
-        if len(all_flatpak_refs) > 0:
+        # For specified flatpaks, an error is fatal
+        for flatpak_ref in self.flatpak_refs:
             self.__run(['flatpak', '--system', 'create-usb',
-                        self.volume_path] + all_flatpak_refs)
+                        self.volume_path, flatpak_ref],
+                       fatal_error=True)
+        # For autoinstall flatpaks, an error is a warning. Some may have been
+        # manually or automatically uninstalled, and the drive can still be
+        # used to update some OS versions.
+        for flatpak_ref in autoinstall_flatpaks:
+            self.__run(['flatpak', '--system', 'create-usb',
+                        self.volume_path, flatpak_ref],
+                       fatal_error=False)
         # Ensure that this USB drive can later be read by any user and the
         # .ostree directory can be written to by any user
         if not self.preserve_permissions:

--- a/eos-updater-prepare-volume/eos-updater-prepare-volume
+++ b/eos-updater-prepare-volume/eos-updater-prepare-volume
@@ -156,6 +156,8 @@ class VolumePreparer:
             if action.type != \
                EosUpdaterUtil.FlatpakRemoteRefActionType.UNINSTALL:
                 autoinstalls.add(action.ref.ref.format_ref())
+            else:
+                autoinstalls.discard(action.ref.ref.format_ref())
 
         return autoinstalls
 
@@ -213,8 +215,8 @@ class VolumePreparer:
                         self.volume_path, flatpak_ref],
                        fatal_error=True)
         # For autoinstall flatpaks, an error is a warning. Some may have been
-        # manually or automatically uninstalled, and the drive can still be
-        # used to update some OS versions.
+        # manually uninstalled, and the drive can still be used to update some
+        # OS versions.
         for flatpak_ref in autoinstall_flatpaks:
             self.__run(['flatpak', '--system', 'create-usb',
                         self.volume_path, flatpak_ref],


### PR DESCRIPTION
In a perfect world, USB drives created with eos-updater-prepare-volume
could be used to update Endless computers on any previous OS versions,
but alas, this is not a perfect world. One of the reasons we can't keep
that promise is checkpoints ("eos.checkpoint-target"), but we also can't
guarantee we'll have all the flatpaks needed by
eos-updater-flatpak-installer on the target machine receiving the
update. This is because flatpaks may be uninstalled by the user after
being auto-installed, or they may be installed and later uninstalled by
eos-updater-flatpak-installer, as will be the case for
com.hack_computer.ProjectLibrary in 3.9.1.

So make failures of the `flatpak create-usb` command non-fatal for
flatpaks not explicitly specified by the user. We may also want to
install any missing flatpaks before doing the copy when we have an
Internet connection, but that improvement is left as an exercise for the
reader.

https://phabricator.endlessm.com/T30368