### PR TITLE
T31190 eos-updater-flatpak-installer: Add a fallback service and timer

### DIFF
--- a/debian/eos-updater.install
+++ b/debian/eos-updater.install
@@ -3,6 +3,8 @@ lib/systemd/system/eos-autoupdater.timer
 lib/systemd/system/eos-updater-avahi.path
 lib/systemd/system/eos-updater-avahi.service
 lib/systemd/system/eos-updater-flatpak-installer.service
+lib/systemd/system/eos-updater-flatpak-installer-fallback.service
+lib/systemd/system/eos-updater-flatpak-installer-fallback.timer
 lib/systemd/system/eos-updater.service
 lib/systemd/system/eos-update-server.service
 lib/systemd/system/eos-update-server.socket

--- a/debian/rules
+++ b/debian/rules
@@ -27,11 +27,13 @@ override_dh_installsystemd:
 		eos-autoupdater.service \
 		eos-update-server.service \
 		eos-updater-flatpak-installer.service \
+		eos-updater-flatpak-installer-fallback.service \
 		$(NULL)
 	dh_installsystemd -peos-updater \
 		eos-autoupdater.timer \
 		eos-update-server.socket \
 		eos-updater-avahi.path \
+		eos-updater-flatpak-installer-fallback.timer \
 		$(NULL)
 
 %:

--- a/eos-updater-flatpak-installer/docs/eos-updater-flatpak-installer.8
+++ b/eos-updater-flatpak-installer/docs/eos-updater-flatpak-installer.8
@@ -1,6 +1,6 @@
 .\" Manpage for eos-updater-flatpak-installer.
 .\" Documentation is under the same licence as the eos-updater package.
-.TH man 8 "10 Nov 2017" "1.0" "eos\-updater\-flatpak\-installer man page"
+.TH man 8 "18 Dec 2020" "1.1" "eos\-updater\-flatpak\-installer man page"
 .\"
 .SH NAME
 .IX Header "NAME"
@@ -21,6 +21,11 @@ updates upon booting into the new OS deployment. It is the part of the system th
 ensures that when new flatpaks are installed on OS updates, they are
 only made available when rebooting into the new OS deployment and not while
 the old OS deployment is still running.
+.PP
+It is normally run by \fBeos\-updater\-flatpak\-installer.service\fP on the
+first boot after an OS upgrade. It is also run periodically during normal
+computer use by \fBeos\-updater\-flatpak\-installer\-fallback\fP as a fallback
+in case flatpak download or installation during OS upgrade fails.
 .PP
 .SH OPTIONS
 .IX Header "OPTIONS"

--- a/eos-updater-flatpak-installer/eos-updater-flatpak-installer-fallback.service.in
+++ b/eos-updater-flatpak-installer/eos-updater-flatpak-installer-fallback.service.in
@@ -1,0 +1,59 @@
+[Unit]
+Description=Endless OS Fallback Flatpak Installer
+Documentation=man:eos-updater-flatpak-installer(8)
+# /home is a symlink to /var/home; /var/home is a symlink to /sysroot/home. The
+# second symlink is created by systemd-tmpfiles. Since we use ProtectHome=yes,
+# we must explicitly order this unit after tmpfiles are created.
+Requires=local-fs.target eos-extra-settled.target systemd-tmpfiles-setup.service
+After=local-fs.target eos-extra-settled.target systemd-tmpfiles-setup.service
+ConditionKernelCommandLine=!eos-updater-disable
+DefaultDependencies=no
+Conflicts=shutdown.target
+
+# Unlike eos-updater-flatpak-installer.service, this service can run outside
+# of the normal update process.
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=@libexecdir@/eos-updater-flatpak-installer --pull --mode=perform
+Restart=no
+
+# Flatpak checks parental controls at deploy time. In order to do this, it
+# needs to talk to accountsservice on the system bus, neither of which are
+# running when this job runs.
+Environment=FLATPAK_SKIP_PARENTAL_CONTROLS_NO_SYSTEM_BUS=1
+
+# Sandboxing
+# flatpak triggers use bwrap which requires net/sys admin and chroot
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_SYS_ADMIN CAP_SYS_CHROOT
+Environment=GIO_USE_VFS=local
+Environment=GVFS_DISABLE_FUSE=1
+Environment=GVFS_REMOTE_VOLUME_MONITOR_IGNORE=1
+Environment=GSETTINGS_BACKEND=memory
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateDevices=yes
+# This differs from eos-updater-flatpak-installer.service, as the fallback needs to be able to --pull
+PrivateNetwork=no
+PrivateTmp=yes
+PrivateUsers=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+# bwrap also mounts /proc
+ProtectKernelTunables=no
+ProtectSystem=no
+# This differs from eos-updater-flatpak-installer.service, as the fallback needs to be able to --pull
+RestrictAddressFamilies=
+RestrictRealtime=yes
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+# @network-io is required for logging to the journal to work
+# @privileged and @chown are required for certain ostree operations
+# @mount is required for bwrap
+SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @obsolete @raw-io @resources
+
+[Install]
+Also=eos-updater-flatpak-installer-fallback.timer
+WantedBy=multi-user.target

--- a/eos-updater-flatpak-installer/eos-updater-flatpak-installer-fallback.timer.in
+++ b/eos-updater-flatpak-installer/eos-updater-flatpak-installer-fallback.timer.in
@@ -1,0 +1,15 @@
+[Unit]
+Description=Endless OS Fallback Flatpak Installer Timer
+Documentation=man:eos-updater-flatpak-installer(8)
+ConditionKernelCommandLine=!endless.live_boot
+ConditionKernelCommandLine=!eos-updater-disable
+
+[Timer]
+# After 5 minutes the network connection has likely been set up, but we don't
+# have a hard requirement
+OnActiveSec=5m
+OnUnitInactiveSec=1day
+RandomizedDelaySec=30min
+
+[Install]
+WantedBy=multi-user.target

--- a/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
+++ b/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Endless OS Post-Boot Flatpak Installer
+Documentation=man:eos-updater-flatpak-installer(8)
 # /home is a symlink to /var/home; /var/home is a symlink to /sysroot/home. The
 # second symlink is created by systemd-tmpfiles. Since we use ProtectHome=yes,
 # we must explicitly order this unit after tmpfiles are created.

--- a/eos-updater-flatpak-installer/main.c
+++ b/eos-updater-flatpak-installer/main.c
@@ -255,10 +255,11 @@ main (int    argc,
 
           if (also_pull)
             {
-              /* We can only add the dependencies when also pulling (which only
-               * happens when e-u-f-i is run manually). When not pulling, the
-               * dependencies should have been pulled and deployed before
-               * reboot already. */
+              /* We can only add the dependencies when also pulling (which
+               * happens when e-u-f-i is run manually or via
+               * `eos-updater-flatpak-installer-fallback.timer`). When not
+               * pulling, the dependencies should have been pulled and deployed
+               * before reboot already. */
               squashed_ref_actions_to_apply_with_dependencies =
                   euu_add_dependency_ref_actions_for_installation (installation,
                                                                    squashed_ref_actions_to_apply,

--- a/eos-updater-flatpak-installer/meson.build
+++ b/eos-updater-flatpak-installer/meson.build
@@ -39,6 +39,20 @@ configure_file(
   configuration: config,
 )
 
+configure_file(
+  input: 'eos-updater-flatpak-installer-fallback.service.in',
+  output: 'eos-updater-flatpak-installer-fallback.service',
+  install_dir: dependency('systemd').get_pkgconfig_variable('systemdsystemunitdir'),
+  configuration: config,
+)
+
+configure_file(
+  input: 'eos-updater-flatpak-installer-fallback.timer.in',
+  output: 'eos-updater-flatpak-installer-fallback.timer',
+  install_dir: dependency('systemd').get_pkgconfig_variable('systemdsystemunitdir'),
+  configuration: config,
+)
+
 # JSON Schema file
 install_data(
   files('eos-updater-autoinstall.schema.json'),


### PR DESCRIPTION
This service will be run once a day during normal system use (not just
during the first boot after an upgrade, as e-u-f-i is normally run),
just in case there were errors in downloading or installing the updates
during the most recent system upgrade.

The fallback runs e-u-f-i with `--pull`, so it will download flatpaks,
runtimes, etc. if necessary. For this reason it needs to be slightly
less constrained in its systemd sandbox than
`eos-updater-flatpak-installer.service`. Other than that the service
files are almost identical.

This could be considered a hack, but could also be considered as a
safety fallback in case of mistakes in previous OS versions. Otherwise,
the e-u-f-i process is only run with the eos-updater/OSTree/flatpak code
from release X just after upgrading to release X, or just before
upgrading to release X+Y. If there are problems in any of that code, the
user has to do a successful OS upgrade to get a fixed version of the
code, and it’s a month (or more) between OS releases.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T31190