### PR TITLE
test-common: Use standalone ostree-trivial-httpd

### DIFF
--- a/test-common/meson.build
+++ b/test-common/meson.build
@@ -19,11 +19,27 @@ libeos_updater_test_common_headers = [
   'utils.h',
 ]
 
+# ostree-trivial-httpd is in libexecdir/libostree or
+# libexecdir/installed-tests/libostree if
+# https://github.com/ostreedev/ostree/pull/1633 is merged.
+# Unfortunately, but we don't know where ostree's libexecdir is. Try to
+# build a path for typical places.
+ostree_trivial_httpd = find_program(
+    'ostree-trivial-httpd',
+    join_paths(libexecdir, 'libostree/ostree-trivial-httpd'),
+    join_paths(libexecdir, 'installed-tests/libostree/ostree-trivial-httpd'),
+    '/usr/libexec/libostree/ostree-trivial-httpd',
+    '/usr/libexec/installed-tests/libostree/ostree-trivial-httpd',
+    '/usr/lib/libostree/ostree-trivial-httpd',
+    '/usr/lib/installed-tests/libostree/ostree-trivial-httpd',
+)
+
 libeos_updater_test_common_cppflags = [
   '-DFLATPAK_BINARY="@0@"'.format(find_program('flatpak').path()),
   '-DG_LOG_DOMAIN="eos-updater-test-common"',
   '-DGPG_BINARY="@0@"'.format(find_program('gpg').path()),
   '-DOSTREE_BINARY="@0@"'.format(find_program('ostree').path()),
+  '-DOSTREE_TRIVIAL_HTTPD_BINARY="@0@"'.format(ostree_trivial_httpd.path()),
   '-DOSTREE_WITH_AUTOCLEANUPS',
 ]
 

--- a/test-common/ostree-spawn.c
+++ b/test-common/ostree-spawn.c
@@ -28,6 +28,10 @@
 #error OSTREE_BINARY is not defined
 #endif
 
+#ifndef OSTREE_TRIVIAL_HTTPD_BINARY
+#error OSTREE_TRIVIAL_HTTPD_BINARY is not defined
+#endif
+
 static void
 copy_strv_to_ptr_array (const gchar * const *strv,
                         GPtrArray *array)
@@ -624,8 +628,7 @@ ostree_httpd (GFile *served_dir,
   g_autofree gchar *raw_served_dir = g_file_get_path (served_dir);
   CmdArg args[] =
     {
-      { NULL, OSTREE_BINARY },
-      { NULL, "trivial-httpd" },
+      { NULL, OSTREE_TRIVIAL_HTTPD_BINARY },
       { "autoexit", NULL },
       { "daemonize", NULL },
       { "port-file", raw_port_file },


### PR DESCRIPTION
The `trivial-httpd` builtin for the `ostree` command has been deprecated
for a couple years and is not included on default builds of ostree. On
the other hand, the standalone `ostree-trivial-httpd` has been available
since ostree 2017.1 in `<libexecdir>/libostree/ostree-trivial-httpd`.
Try to use that instead of the builtin.

https://phabricator.endlessm.com/T31384