### PR TITLE
e-u-f-i: Unset RemainAfterExit on -fallback.service

### DIFF
--- a/eos-updater-flatpak-installer/eos-updater-flatpak-installer-fallback.service.in
+++ b/eos-updater-flatpak-installer/eos-updater-flatpak-installer-fallback.service.in
@@ -15,7 +15,6 @@ Conflicts=shutdown.target
 
 [Service]
 Type=oneshot
-RemainAfterExit=true
 ExecStart=@libexecdir@/eos-updater-flatpak-installer --pull --mode=perform
 Restart=no
 


### PR DESCRIPTION
Quoth systemd.timer(5):

> […] services with RemainAfterExit= set […] are usually not suitable
> for activation via repetitive timers, as they will only be activated
> once, and then stay around forever.

And indeed before this patch,
eos-updater-flatpak-installer-fallback.timer would only fire once
(assuming the .service succeeds) because the .service is considered to
be still running after it exits.

https://phabricator.endlessm.com/T31564
