### PR TITLE
T31918 Teach eos-updater not to cross eos3a→eos4 checkpoint on certain systems

### DIFF
--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -26,12 +26,16 @@
 
 #include <eos-updater/object.h>
 #include <eos-updater/poll-common.h>
+#include <gio/gunixmounts.h>
+#include <glib.h>
+#include <glib/gi18n.h>
 #include <libeos-updater-util/metrics-private.h>
 #include <libeos-updater-util/ostree-util.h>
 #include <libeos-updater-util/util.h>
 #include <libsoup/soup.h>
 #include <ostree.h>
 #include <string.h>
+#include <sys/utsname.h>
 
 #ifdef HAS_EOSMETRICS_0
 #include <eosmetrics/eosmetrics.h>
@@ -383,6 +387,117 @@ get_booted_refspec (OstreeDeployment     *booted_deployment,
   return TRUE;
 }
 
+/* On split-disk systems, an additional (bigger, slower) disk is mounted at
+ * /var/endless-extra, and the system flatpak repo is configured to be at
+ * /var/endless-extra/flatpak rather than /var/lib/flatpak/repo. */
+static gboolean
+booted_system_is_split_disk (OstreeRepo *os_repo)
+{
+  g_autoptr(GUnixMountEntry) extra_mount = NULL;
+
+  extra_mount = g_unix_mount_at ("/var/endless-extra", NULL);
+
+  if (g_strcmp0 (g_getenv ("EOS_UPDATER_TEST_IS_SPLIT_DISK"), "1") == 0)
+    return TRUE;
+
+  return (extra_mount != NULL);
+}
+
+/* Allow overriding various things for the tests. */
+static const gchar *
+allow_env_override (const gchar *default_value,
+                    const gchar *env_key)
+{
+  const gchar *env_value = g_getenv (env_key);
+
+  if (env_value != NULL && g_strcmp0 (env_value, "") != 0)
+    return env_value;
+  else
+    return default_value;
+}
+
+/* ARM64 systems have their architecture listed as `aarch64` on Linux. On other
+ * OSs, such as Darwin, it’s listed as `arm64`. */
+static gboolean
+booted_system_is_arm64 (void)
+{
+  struct utsname buf;
+  const gchar *uname_machine;
+
+  if (uname (&buf) != 0)
+    return FALSE;
+
+  uname_machine = allow_env_override (buf.machine, "EOS_UPDATER_TEST_UNAME_MACHINE");
+
+  return (g_strcmp0 (uname_machine, "aarch64") == 0);
+}
+
+/* Check for an Intel i-8565U CPU using the info from /proc/cpuinfo. If the
+ * system has multiple CPUs, this will match any of them. */
+static gboolean
+booted_system_has_i8565u_cpu (void)
+{
+  const gchar *cpuinfo_path;
+  g_autofree gchar *cpuinfo = NULL;
+
+  cpuinfo_path = allow_env_override ("/proc/cpuinfo", "EOS_UPDATER_TEST_CPUINFO_PATH");
+
+  if (!g_file_get_contents (cpuinfo_path, &cpuinfo, NULL, NULL))
+    return FALSE;
+
+  return g_regex_match_simple ("^model name\\s*:\\s*Intel\\(R\\) Core\\(TM\\) i7-8565U CPU @ 1.80GHz$", cpuinfo,
+                               G_REGEX_MULTILINE, 0);
+}
+
+/* Check @sys_vendor/@product_name against a list of systems which are no longer
+ * supported. */
+static gboolean
+booted_system_is_unsupported_by_eos4_kernel (const gchar *sys_vendor,
+                                             const gchar *product_name)
+{
+  const struct
+    {
+      const gchar *sys_vendor;
+      const gchar *product_name;
+    }
+  no_upgrade_systems[] =
+    {
+      { "Acer", "Aspire ES1-533" },
+      { "Acer", "Aspire ES1-732" },
+      { "Acer", "Veriton Z4660G" },
+      { "Acer", "Veriton Z4860G" },
+      { "Acer", "Veriton Z6860G" },
+      { "ASUSTeK COMPUTER INC.", "Z550MA" },
+      { "Endless", "ELT-JWM" },
+    };
+
+  for (gsize i = 0; i < G_N_ELEMENTS (no_upgrade_systems); i++)
+    {
+      if (g_str_equal (sys_vendor, no_upgrade_systems[i].sys_vendor) &&
+          g_str_equal (product_name, no_upgrade_systems[i].product_name))
+        return TRUE;
+    }
+
+  return FALSE;
+}
+
+/* Check if /proc/cmdline contains the given @needle, surrounded by word boundaries. */
+static gboolean
+boot_args_contain (const gchar *needle)
+{
+  const gchar *cmdline_path;
+  g_autofree gchar *cmdline = NULL;
+  g_autofree gchar *regex = NULL;
+
+  cmdline_path = allow_env_override ("/proc/cmdline", "EOS_UPDATER_TEST_CMDLINE_PATH");
+
+  if (!g_file_get_contents (cmdline_path, &cmdline, NULL, NULL))
+    return FALSE;
+
+  regex = g_strconcat ("\\b", needle, "\\b", NULL);
+  return g_regex_match_simple (regex, cmdline, 0, 0);
+}
+
 /* Whether the upgrade should follow the given checkpoint and move to the given
  * @target_ref for the upgrade deployment. The default for this is %TRUE, but
  * there are various systems for which support has been withdrawn, which need
@@ -396,15 +511,70 @@ should_follow_checkpoint (OstreeSysroot     *sysroot,
                           const gchar       *target_ref,
                           gchar            **out_reason)
 {
+  g_autoptr(GHashTable) hw_descriptors = NULL;
+  const gchar *sys_vendor, *product_name;
+  gboolean is_eos3a_to_eos4 = (g_str_equal (booted_ref, "eos3a") &&
+                               g_str_equal (target_ref, "eos4"));
+
   /* Simplifies the code below. */
   g_assert (out_reason != NULL);
 
   /* Allow an override in case the logic below is incorrect or doesn’t age well. */
-  if (g_getenv ("EOS_UPDATER_FORCE_FOLLOW_CHECKPOINT") != NULL)
+  if (g_strcmp0 (g_getenv ("EOS_UPDATER_FORCE_FOLLOW_CHECKPOINT"), "1") == 0)
     {
       g_message ("Forcing checkpoint target ‘%s’ to be used as EOS_UPDATER_FORCE_FOLLOW_CHECKPOINT is set",
                   target_ref);
       return TRUE;
+    }
+
+  /* https://phabricator.endlessm.com/T30922 */
+  if (is_eos3a_to_eos4 &&
+      booted_system_is_split_disk (repo))
+    {
+      *out_reason = g_strdup (_("Split disk systems are not supported in EOS 4."));
+      return FALSE;
+    }
+
+  /* https://phabricator.endlessm.com/T31726 */
+  if (is_eos3a_to_eos4 &&
+      booted_system_is_arm64 ())
+    {
+      *out_reason = g_strdup (_("ARM64 system upgrades are not supported in EOS 4. Please reinstall."));
+      return FALSE;
+    }
+
+  /* These support being overridden by tests inside get_hw_descriptors(). */
+  hw_descriptors = get_hw_descriptors ();
+  sys_vendor = g_hash_table_lookup (hw_descriptors, VENDOR_KEY);
+  product_name = g_hash_table_lookup (hw_descriptors, PRODUCT_KEY);
+
+  /* https://phabricator.endlessm.com/T31777 */
+  if (is_eos3a_to_eos4 &&
+      g_strcmp0 (sys_vendor, "Asus") == 0 &&
+      booted_system_has_i8565u_cpu ())
+    {
+      /* Translators: The first placeholder is a system vendor name (such as
+       * Acer). The second placeholder is a computer model (such as
+       * Aspire ES1-533). */
+      *out_reason = g_strdup_printf (_("%s %s systems are not supported in EOS 4."), "Asus", "i-8565U");
+      return FALSE;
+    }
+
+  /* https://phabricator.endlessm.com/T31772 */
+  if (is_eos3a_to_eos4 &&
+      sys_vendor != NULL && product_name != NULL &&
+      booted_system_is_unsupported_by_eos4_kernel (sys_vendor, product_name))
+    {
+      *out_reason = g_strdup_printf (_("%s %s systems are not supported in EOS 4."), sys_vendor, product_name);
+      return FALSE;
+    }
+
+  /* https://phabricator.endlessm.com/T31776 */
+  if (is_eos3a_to_eos4 &&
+      boot_args_contain ("ro"))
+    {
+      *out_reason = g_strdup (_("Read-only systems are not supported in EOS 4."));
+      return FALSE;
     }
 
   /* Checkpoint can be followed. */

--- a/test-common/utils.h
+++ b/test-common/utils.h
@@ -222,6 +222,11 @@ struct _EosTestClient
   gchar *product;
   gchar *remote_name;
   gchar *ostree_path;
+  gchar *cpuinfo;
+  gchar *cmdline;
+  gchar *uname_machine;
+  gboolean is_split_disk;
+  gboolean force_follow_checkpoint;
 };
 
 typedef enum
@@ -238,6 +243,18 @@ EosTestClient *eos_test_client_new (GFile *client_root,
                                     const gchar *vendor,
                                     const gchar *product,
                                     GError **error);
+
+
+void eos_test_client_set_is_split_disk (EosTestClient *client,
+                                        gboolean       is_split_disk);
+void eos_test_client_set_uname_machine (EosTestClient *client,
+                                        const gchar   *uname_machine);
+void eos_test_client_set_cpuinfo (EosTestClient *client,
+                                  const gchar   *cpuinfo);
+void eos_test_client_set_cmdline (EosTestClient *client,
+                                  const gchar   *cmdline);
+void eos_test_client_set_force_follow_checkpoint (EosTestClient *client,
+                                                  gboolean       force_follow_checkpoint);
 
 gboolean eos_test_client_run_updater (EosTestClient *client,
                                       DownloadSource *order,

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -1389,6 +1389,214 @@ test_update_refspec_checkpoint_ignore_remote (EosUpdaterFixture *fixture,
   g_assert_true (has_commit);
 }
 
+/* Specifically test the checkpoint at the upgrade from the eos3a branch (EOS 3.9)
+ * to the eos4 branch (EOS 4). With the release of EOS 4, various features and
+ * systems are no longer supported, so we need to make sure they *don’t* get
+ * migrated to the eos4 branch.
+ *
+ * Conversely, test that machines which don’t match any of the
+ * no-longer-supported machines *do* get migrated to the eos4 branch.
+ *
+ * https://phabricator.endlessm.com/T31918 */
+static void
+test_update_refspec_checkpoint_eos3a_eos4 (EosUpdaterFixture *fixture,
+                                           gconstpointer      user_data)
+{
+  const gchar *cpuinfo_i8565u =
+      "processor	: 0\n"
+      "vendor_id	: GenuineIntel\n"
+      "cpu family	: 6\n"
+      "model		: 142\n"
+      "model name	: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz\n"
+      "stepping	: 12\n";
+      /* etc */
+  const gchar *cpuinfo_not_i8565u =
+      "processor	: 0\n"
+      "vendor_id	: NotIntel\n"
+      "cpu family	: 6\n"
+      "model		: 123\n"
+      "model name	: Some collection of ASICs\n"
+      "stepping	: 12\n";
+      /* etc */
+  const gchar *cmdline_ro_end = "BOOT_IMAGE=(hd0,gpt3)/boot/ostree/eos-c8cadea7ee2eb6b5fe6a15144bf2fc123327d5a0302e8e396cbb93c7e20f4be1/vmlinuz-5.11.0-12-generic root=UUID=11356111-ea76-4f63-9d7e-1d6b9d10a065 rw splash plymouth.ignore-serial-consoles quiet loglevel=0 ostree=/ostree/boot.0/eos/c8cadea7ee2eb6b5fe6a15144bf2fc123327d5a0302e8e396cbb93c7e20f4be1/0 ro";
+  const gchar *cmdline_ro_middle = "BOOT_IMAGE=(hd0,gpt3)/boot/ostree/eos-c8cadea7ee2eb6b5fe6a15144bf2fc123327d5a0302e8e396cbb93c7e20f4be1/vmlinuz-5.11.0-12-generic root=UUID=11356111-ea76-4f63-9d7e-1d6b9d10a065 rw splash plymouth.ignore-serial-consoles quiet ro loglevel=0 ostree=/ostree/boot.0/eos/c8cadea7ee2eb6b5fe6a15144bf2fc123327d5a0302e8e396cbb93c7e20f4be1/0";
+  const gchar *cmdline_not_ro = "BOOT_IMAGE=(hd0,gpt3)/boot/ostree/eos-c8cadea7ee2eb6b5fe6a15144bf2fc123327d5a0302e8e396cbb93c7e20f4be1/vmlinuz-5.11.0-12-generic root=UUID=11356111-ea76-4f63-9d7e-1d6b9d10a065 rw splash plymouth.ignore-serial-consoles quiet loglevel=0 ostree=/ostree/boot.0/eos/c8cadea7ee2eb6b5fe6a15144bf2fc123327d5a0302e8e396cbb93c7e20f4be1/0";
+  const struct
+    {
+      /* Setup */
+      const gchar *sys_vendor;  /* (nullable) for default */
+      const gchar *product_name;  /* (nullable) for default */
+      gboolean is_split_disk;
+      const gchar *uname_machine;  /* (nullable) for default */
+      const gchar *cpuinfo;  /* (nullable) for default */
+      const gchar *cmdline;  /* (nullable) for default */
+      gboolean force_follow_checkpoint;
+
+      /* Results */
+      gboolean expect_checkpoint_followed;
+    }
+  tests[] =
+    {
+      /* Normal system */
+      { NULL, NULL, FALSE, NULL, NULL, NULL, FALSE, TRUE },
+      { NULL, NULL, FALSE, NULL, NULL, NULL, TRUE, TRUE },
+
+      /* Split disk */
+      { NULL, NULL, TRUE, NULL, NULL, NULL, FALSE, FALSE },
+      { NULL, NULL, TRUE, NULL, NULL, NULL, TRUE, TRUE },
+
+      /* aarch64 */
+      { NULL, NULL, FALSE, "x86_64", NULL, NULL, FALSE, TRUE },
+      { NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
+      { NULL, NULL, FALSE, "aarch64", NULL, NULL, TRUE, TRUE },
+
+      /* Asus with i-8565U CPU */
+      { NULL, NULL, FALSE, NULL, cpuinfo_i8565u, NULL, FALSE, TRUE },
+      { "Asus", NULL, FALSE, NULL, cpuinfo_not_i8565u, NULL, FALSE, TRUE },
+      { "Asus", NULL, FALSE, NULL, cpuinfo_i8565u, NULL, FALSE, FALSE },
+      { "Asus", NULL, FALSE, NULL, cpuinfo_i8565u, NULL, TRUE, TRUE },
+
+      /* Various systems unsupported by the new kernel */
+      { "Acer", "Aspire ES1-533", FALSE, NULL, NULL, NULL, FALSE, FALSE },
+      { "Acer", "Aspire ES1-732", FALSE, NULL, NULL, NULL, FALSE, FALSE },
+      { "Acer", "Veriton Z4660G", FALSE, NULL, NULL, NULL, FALSE, FALSE },
+      { "Acer", "Veriton Z4860G", FALSE, NULL, NULL, NULL, FALSE, FALSE },
+      { "Acer", "Veriton Z6860G", FALSE, NULL, NULL, NULL, FALSE, FALSE },
+      { "ASUSTeK COMPUTER INC.", "Z550MA", FALSE, NULL, NULL, NULL, FALSE, FALSE },
+      { "Endless", "ELT-JWM", FALSE, NULL, NULL, NULL, FALSE, FALSE },
+      { "Endless", "ELT-JWM", FALSE, NULL, NULL, NULL, TRUE, TRUE },
+
+      /* Read-only in kernel command line args */
+      { NULL, NULL, FALSE, NULL, NULL, cmdline_not_ro, FALSE, TRUE },
+      { NULL, NULL, FALSE, NULL, NULL, cmdline_ro_end, FALSE, FALSE },
+      { NULL, NULL, FALSE, NULL, NULL, cmdline_ro_middle, FALSE, FALSE },
+      { NULL, NULL, FALSE, NULL, NULL, cmdline_ro_end, TRUE, TRUE },
+    };
+
+  if (eos_test_skip_chroot ())
+    return;
+
+  for (gsize i = 0; i < G_N_ELEMENTS (tests); i++)
+    {
+      const OstreeCollectionRef _eos3a_collection_ref = { (gchar *) "com.endlessm.CollectionId", (gchar *) "eos3a" };
+      const OstreeCollectionRef *eos3a_collection_ref = &_eos3a_collection_ref;
+      const OstreeCollectionRef _eos4_collection_ref = { (gchar *) "com.endlessm.CollectionId", (gchar *) "eos4" };
+      const OstreeCollectionRef *eos4_collection_ref = &_eos4_collection_ref;
+      g_autoptr(GFile) server_root = NULL;
+      g_autoptr(EosTestServer) server = NULL;
+      g_autofree gchar *keyid = get_keyid (fixture->gpg_home);
+      g_autoptr(GError) error = NULL;
+      g_autoptr(EosTestSubserver) subserver = NULL;
+      g_autoptr(GFile) client_root = NULL;
+      g_autoptr(EosTestClient) client = NULL;
+      g_autoptr(GHashTable) additional_metadata_for_commit = NULL;
+      g_autoptr(GHashTable) leaf_commit_nodes =
+        eos_test_subserver_ref_to_commit_new ();
+      gboolean has_commit;
+
+      g_test_message ("Test %" G_GSIZE_FORMAT, i);
+
+      /* Create the checkpoint */
+      insert_update_refspec_metadata_for_commit (1,
+                                                 "eos4",
+                                                 &additional_metadata_for_commit);
+
+      server_root = g_file_get_child (fixture->tmpdir, "main");
+      server = eos_test_server_new_quick (server_root,
+                                          default_vendor,
+                                          default_product,
+                                          eos3a_collection_ref,
+                                          0,
+                                          fixture->gpg_home,
+                                          keyid,
+                                          default_ostree_path,
+                                          NULL,
+                                          NULL,
+                                          additional_metadata_for_commit,
+                                          &error);
+      g_assert_no_error (error);
+      g_assert_cmpuint (server->subservers->len, ==, 1u);
+
+      subserver = g_object_ref (EOS_TEST_SUBSERVER (g_ptr_array_index (server->subservers, 0)));
+      client_root = g_file_get_child (fixture->tmpdir, "client");
+      client = eos_test_client_new (client_root,
+                                    default_remote_name,
+                                    subserver,
+                                    eos3a_collection_ref,
+                                    tests[i].sys_vendor ? tests[i].sys_vendor : default_vendor,
+                                    tests[i].product_name ? tests[i].product_name : default_product,
+                                    &error);
+      g_assert_no_error (error);
+
+      /* Set the client to imitate a machine which may or may not follow the
+       * checkpoint. */
+      eos_test_client_set_is_split_disk (client, tests[i].is_split_disk);
+      eos_test_client_set_uname_machine (client, tests[i].uname_machine);
+      eos_test_client_set_cpuinfo (client, tests[i].cpuinfo);
+      eos_test_client_set_cmdline (client, tests[i].cmdline);
+      eos_test_client_set_force_follow_checkpoint (client, tests[i].force_follow_checkpoint);
+
+      g_hash_table_insert (leaf_commit_nodes,
+                           ostree_collection_ref_dup (eos3a_collection_ref),
+                           GUINT_TO_POINTER (1));
+
+      /* Also insert a commit (2) for the refspec "REMOTE:eos4". The first time we
+       * update, we should only update to commit 1 */
+      g_hash_table_insert (leaf_commit_nodes,
+                           ostree_collection_ref_dup (eos4_collection_ref),
+                           GUINT_TO_POINTER (2));
+      eos_test_subserver_populate_commit_graph_from_leaf_nodes (subserver,
+                                                                leaf_commit_nodes);
+      eos_test_subserver_update (subserver,
+                                 &error);
+      g_assert_no_error (error);
+
+      /* Now update the client. We stopped making commits on this
+       * ref, so it is effectively a "checkpoint" and we should only have
+       * the first commit. */
+      update_client (fixture, client, NULL);
+
+      eos_test_client_has_commit (client,
+                                  default_remote_name,
+                                  1,
+                                  &has_commit,
+                                  &error);
+      g_assert_no_error (error);
+      g_assert_true (has_commit);
+
+      eos_test_client_has_commit (client,
+                                  default_remote_name,
+                                  2,
+                                  &has_commit,
+                                  &error);
+      g_assert_no_error (error);
+      g_assert_false (has_commit);
+
+      /* Update the client again. Because we had deployed the
+       * checkpoint, *if the machine is going to cross the checkpoint*, we
+       * should now have the new ref to update on and should
+       * have pulled the new commit (we can't assert on anything here, but
+       * we can do the next step to figure out what branch we're on). */
+      update_client (fixture, client, NULL);
+
+      eos_test_client_has_commit (client,
+                                  default_remote_name,
+                                  2,
+                                  &has_commit,
+                                  &error);
+      g_assert_no_error (error);
+
+      if (tests[i].expect_checkpoint_followed)
+        g_assert_true (has_commit);
+      else
+        g_assert_false (has_commit);
+
+      /* Prepare for the next iteration */
+      eos_updater_fixture_teardown (fixture, user_data);
+      eos_updater_fixture_setup (fixture, user_data);
+    }
+}
+
 int
 main (int argc,
       char **argv)
@@ -1427,6 +1635,9 @@ main (int argc,
   eos_test_add ("/updater/update-refspec-checkpoint-ignore-remote",
                 NULL,
                 test_update_refspec_checkpoint_ignore_remote);
+  eos_test_add ("/updater/update-refspec-checkpoint-eos3a-eos4",
+                NULL,
+                test_update_refspec_checkpoint_eos3a_eos4);
 
   return g_test_run ();
 }


### PR DESCRIPTION
See the commit messages.

This adds a load of checks for systems which should not be migrated to `eos4`. The checks are based on searching around tasks and code for ways to distinguish these systems, rather than actual testing on these systems. The basis for the checks still needs to be checked against the actual systems.

https://phabricator.endlessm.com/T31918