### PR TITLE
flatpak-installer: Drop dependency on eos-extra-settled.target

### DIFF
--- a/eos-updater-flatpak-installer/eos-updater-flatpak-installer-fallback.service.in
+++ b/eos-updater-flatpak-installer/eos-updater-flatpak-installer-fallback.service.in
@@ -4,8 +4,8 @@ Documentation=man:eos-updater-flatpak-installer(8)
 # /home is a symlink to /var/home; /var/home is a symlink to /sysroot/home. The
 # second symlink is created by systemd-tmpfiles. Since we use ProtectHome=yes,
 # we must explicitly order this unit after tmpfiles are created.
-Requires=local-fs.target eos-extra-settled.target systemd-tmpfiles-setup.service
-After=local-fs.target eos-extra-settled.target systemd-tmpfiles-setup.service
+Requires=local-fs.target systemd-tmpfiles-setup.service
+After=local-fs.target systemd-tmpfiles-setup.service
 ConditionKernelCommandLine=!eos-updater-disable
 DefaultDependencies=no
 Conflicts=shutdown.target

--- a/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
+++ b/eos-updater-flatpak-installer/eos-updater-flatpak-installer.service.in
@@ -4,8 +4,8 @@ Documentation=man:eos-updater-flatpak-installer(8)
 # /home is a symlink to /var/home; /var/home is a symlink to /sysroot/home. The
 # second symlink is created by systemd-tmpfiles. Since we use ProtectHome=yes,
 # we must explicitly order this unit after tmpfiles are created.
-Requires=local-fs.target eos-extra-settled.target systemd-tmpfiles-setup.service
-After=local-fs.target eos-extra-settled.target systemd-tmpfiles-setup.service
+Requires=local-fs.target systemd-tmpfiles-setup.service
+After=local-fs.target systemd-tmpfiles-setup.service
 ConditionKernelCommandLine=!eos-updater-disable
 DefaultDependencies=no
 Conflicts=shutdown.target


### PR DESCRIPTION
Split disk support has been dropped for EOS 4 and the
eos-extra-settled.target unit is no longer installed. Don't require or
wait for it when installing flatpaks.

https://phabricator.endlessm.com/T32298