### PR TITLE
ctl: Handle size properties being negative

### DIFF
--- a/eos-updater-ctl/eos-updater-ctl
+++ b/eos-updater-ctl/eos-updater-ctl
@@ -91,9 +91,12 @@ def dump_daemon_properties(proxy):
             "FullUnpackedSize",
             "UnpackedSize",
         ):
-            value = GLib.format_size_full(
-                value.get_int64(), GLib.FormatSizeFlags.LONG_FORMAT
-            )
+            if value.get_int64() >= 0:
+                value = GLib.format_size_full(
+                    value.get_int64(), GLib.FormatSizeFlags.LONG_FORMAT
+                )
+            else:
+                value = "Unknown"
 
         print("{:>{}}: {}".format(x, width, value))
 


### PR DESCRIPTION
Spotted on GNOME OS:

    ======= Properties =======
               State: Fetching
           CurrentID: 'fc691d2fdcd5f7d44062a301888d1a86f00f48d803d1c3278915b4460e70a617'
    Traceback (most recent call last):
      File "/usr/bin/eos-updater-ctl", line 124, in name_appeared_cb
        dump_daemon_properties(proxy)
      File "/usr/bin/eos-updater-ctl", line 94, in dump_daemon_properties
        value = GLib.format_size_full(
    OverflowError: -1 not in range 0 to 18446744073709551615

This is because on GNOME OS the necessary OSTree metadata is not
available to tell eos-updater the download size and unpacked size, only
the number of bytes that have been downloaded so far:

    [gnome@linux ~]$ gdbus introspect --system --dest com.endlessm.Updater --object-path /com/endlessm/Updater --only-properties
    node /com/endlessm/Updater {
      interface com.endlessm.Updater {
        properties:
          readonly u State = 5;
          readonly s UpdateID = '2341da03b41ba5f1b11376b7d5bbb1f5ed2d2b6c093f275e0bf1a173e39a3610';
          readonly s UpdateRefspec = 'gnome-os:gnome-os/master/x86_64-user';
          readonly s OriginalRefspec = 'gnome-os:gnome-os/master/x86_64-user';
          readonly s CurrentID = 'fc691d2fdcd5f7d44062a301888d1a86f00f48d803d1c3278915b4460e70a617';
          readonly s UpdateLabel = '';
          readonly s UpdateMessage = '';
          readonly s Version = '';
          readonly x DownloadSize = -1;
          readonly x DownloadedBytes = 214456258;
          readonly x UnpackedSize = -1;
          readonly x FullDownloadSize = -1;
          readonly x FullUnpackedSize = -1;
          @org.freedesktop.DBus.Deprecated("true")
          readonly u ErrorCode = 0;
          readonly s ErrorName = '';
          readonly s ErrorMessage = '';
      };
    };
