### PR TITLE
eos-updater: Fix for upgrading to eos4 and newer's ref (sync with master)

### DIFF
--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -513,9 +513,11 @@ should_follow_checkpoint (OstreeSysroot     *sysroot,
 {
   g_autoptr(GHashTable) hw_descriptors = NULL;
   const gchar *sys_vendor, *product_name;
-  gboolean is_eos3a_to_eos4 =
-    ((g_str_equal (booted_ref, "eos3a") || g_str_has_suffix (booted_ref, "/eos3a")) &&
-     (g_str_equal (target_ref, "eos4") || g_str_has_suffix (target_ref, "/eos4")));
+  /* https://phabricator.endlessm.com/T32542, https://phabricator.endlessm.com/T32552 */
+  gboolean is_conditional_upgrade_path =
+    (g_str_equal (booted_ref, "eos3a") ||
+     g_str_has_suffix (booted_ref, "/eos3a") ||
+     g_str_has_suffix (booted_ref, "nexthw/eos3.9"));
 
   /* Simplifies the code below. */
   g_assert (out_reason != NULL);
@@ -529,7 +531,7 @@ should_follow_checkpoint (OstreeSysroot     *sysroot,
     }
 
   /* https://phabricator.endlessm.com/T30922 */
-  if (is_eos3a_to_eos4 &&
+  if (is_conditional_upgrade_path &&
       booted_system_is_split_disk (repo))
     {
       *out_reason = g_strdup (_("Split disk systems are not supported in EOS 4."));
@@ -537,7 +539,7 @@ should_follow_checkpoint (OstreeSysroot     *sysroot,
     }
 
   /* https://phabricator.endlessm.com/T31726 */
-  if (is_eos3a_to_eos4 &&
+  if (is_conditional_upgrade_path &&
       booted_system_is_arm64 ())
     {
       *out_reason = g_strdup (_("ARM64 system upgrades are not supported in EOS 4. Please reinstall."));
@@ -550,7 +552,7 @@ should_follow_checkpoint (OstreeSysroot     *sysroot,
   product_name = g_hash_table_lookup (hw_descriptors, PRODUCT_KEY);
 
   /* https://phabricator.endlessm.com/T31777 */
-  if (is_eos3a_to_eos4 &&
+  if (is_conditional_upgrade_path &&
       g_strcmp0 (sys_vendor, "Asus") == 0 &&
       booted_system_has_i8565u_cpu ())
     {
@@ -562,7 +564,7 @@ should_follow_checkpoint (OstreeSysroot     *sysroot,
     }
 
   /* https://phabricator.endlessm.com/T31772 */
-  if (is_eos3a_to_eos4 &&
+  if (is_conditional_upgrade_path &&
       sys_vendor != NULL && product_name != NULL &&
       booted_system_is_unsupported_by_eos4_kernel (sys_vendor, product_name))
     {
@@ -571,7 +573,7 @@ should_follow_checkpoint (OstreeSysroot     *sysroot,
     }
 
   /* https://phabricator.endlessm.com/T31776 */
-  if (is_eos3a_to_eos4 &&
+  if (is_conditional_upgrade_path &&
       boot_args_contain ("ro"))
     {
       *out_reason = g_strdup (_("Read-only systems are not supported in EOS 4."));

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -1463,12 +1463,18 @@ test_update_refspec_checkpoint_eos3a_eos4 (EosUpdaterFixture *fixture,
        * mismatches. */
       { "eos3", NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, TRUE },
       { "eos3a2", NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, TRUE },
-      { NULL, "eos3b", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, TRUE },
-      { NULL, "eos4a", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, TRUE },
+      { NULL, "eos3b", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
+      { NULL, "eos4a", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
       { "os/eos/arm64/eos3a", NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
       { NULL, "os/eos/arm64/eos4", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
       { "os/eos/arm64/eos3a", "os/eos/arm64/eos4", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
+      { "os/eos/arm64/eos3a", "os/eos/arm64/latest1", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
       { "os/eos/arm64/eos3a", "os/eos/arm64/eos4", NULL, NULL, FALSE, "aarch64", NULL, NULL, TRUE, TRUE },
+
+      /* Ref matching. When the ref matches the "nexthw/eos3.9", the checkpoint
+       * is followed. It should allow updating to "eos4" directly.
+       * https://phabricator.endlessm.com/T32542 */
+      { "nexthw/eos3.9", NULL, NULL, NULL, FALSE, NULL, NULL, NULL, FALSE, TRUE },
 
       /* Asus with i-8565U CPU */
       { NULL, NULL, NULL, NULL, FALSE, NULL, cpuinfo_i8565u, NULL, FALSE, TRUE },


### PR DESCRIPTION
Users may upgrading system from booted ref eos3a to both eos4, or even
newer target ref in the future. The newer target ref is defined as
"latest1" in T32550.

This PR allows eos3.9 nexthw upgrading to eos4 or newer ref as well.

https://phabricator.endlessm.com/T32552
https://phabricator.endlessm.com/T32542