### PR TITLE
build: remove 'version' parameter from static libraries

### DIFF
--- a/eos-updater/meson.build
+++ b/eos-updater/meson.build
@@ -40,7 +40,6 @@ libeos_updater_dbus = static_library('eos-updater-dbus',
   dependencies: libeos_updater_dbus_deps,
   include_directories: root_inc,
   install: false,
-  version: meson.project_version(),
 )
 libeos_updater_dbus_dep = declare_dependency(
   link_with: libeos_updater_dbus,

--- a/libeos-update-server/meson.build
+++ b/libeos-update-server/meson.build
@@ -40,7 +40,6 @@ libeos_update_server = static_library('eos-update-server-' + eus_api_version,
   dependencies: libeos_update_server_deps,
   include_directories: root_inc,
   install: false,
-  version: meson.project_version(),
 )
 libeos_update_server_dep = declare_dependency(
   link_with: libeos_update_server,

--- a/test-common/meson.build
+++ b/test-common/meson.build
@@ -58,7 +58,6 @@ libeos_updater_test_common = static_library('eos-updater-test-common',
   dependencies: libeos_updater_test_common_deps,
   include_directories: root_inc,
   install: false,
-  version: meson.project_version(),
 )
 libeos_updater_test_common_dep = declare_dependency(
   link_with: libeos_updater_test_common,


### PR DESCRIPTION
it is invalid and fails to build with meson 0.60