### PR TITLE
Add prune-ref flatpak-installer action

### DIFF
--- a/eos-updater-flatpak-installer/docs/eos-updater-flatpak-autoinstall.d.5
+++ b/eos-updater-flatpak-installer/docs/eos-updater-flatpak-autoinstall.d.5
@@ -52,11 +52,11 @@ increasing counter within the domain of that filename.
 .IX Item "Flatpak Ref Action"
 A JSON object containing, at minimum, properties \fBaction\fP,
 \fBserial\fP, \fBbranch\fP and optionally \fBfilters\fP. Valid values for
-\fBaction\fP are \fBinstall\fP, \fBupdate\fP and \fBuninstall\fP,
-each having their own required properties as explained below. The only valid
-type for \fBserial\fP, is an integer, which must be monotonically
-increasing as new entries are appended to the file. \fBbranch\fP must refer
-to a valid branch for the given flatpak.
+\fBaction\fP are \fBinstall\fP, \fBupdate\fP, \fBuninstall\fP and
+\fBprune\-ref\fP, each having their own required properties as explained
+below. The only valid type for \fBserial\fP, is an integer, which must be
+monotonically increasing as new entries are appended to the file.
+\fBbranch\fP must refer to a valid branch for the given flatpak.
 .\"
 .IP "\fIThe \fBfilters\fP entry\fP"
 .IX Item "The filters entry"
@@ -117,6 +117,19 @@ introduced. The entry must have the additional properties \fBname\fP,
 \fBref\-kind\fP. It is not an error if the flatpak is already uninstalled
 when the action is applied.
 \."
+.IP "\fI\fBprune\-ref\fP actions\fP"
+.IX Item "prune\-ref actions"
+Where the \fBaction\fP property of a \fIFlatpak Ref Action\fP entry is
+\fBprune\-ref\fP, the action will describe a flatpak whose ref should be
+removed if it is no longer installed. This will happen upon the next boot of
+the deployment in which the action was introduced. The entry must have the
+additional properties \fBname\fP, \fBref\-kind\fP and both
+\fBcollection\-id\fP and \fBremote\fP, which describe the flatpak app ID,
+whether the flatpak is a runtime or an app and either the \fBostree\fP(1)
+collection ID or remote to install the app from. It is not an error if the
+flatpak is installed or the ref is already removed when the action is
+applied.
+\."
 .SH "EXAMPLES"
 .IX Header "EXAMPLES"
 .\"
@@ -167,6 +180,15 @@ when the action is applied.
             "locale": ["id_ID"],
             "~architecture": ["armhf"]
         }
+    },
+    {
+        "action": "prune-ref",
+        "branch": "stable",
+        "serial": 2017100300,
+        "ref\-kind": "app",
+        "name": "org.example.UninstalledApp",
+        "collection\-id": "org.example.Apps",
+        "remote": "example\-apps"
     }
 ]
 \."

--- a/eos-updater-flatpak-installer/eos-updater-autoinstall.schema.json
+++ b/eos-updater-flatpak-installer/eos-updater-autoinstall.schema.json
@@ -88,6 +88,38 @@
                 }
             },
             "required": ["ref-kind", "name", "branch"]
+        },
+        {
+            "properties": {
+                "action": {
+                    "const": "prune-ref",
+                    "description": "The machine-readable type of event",
+                    "type": "string"
+                },
+                "serial": {
+                    "$ref": "#/definitions/serial"
+                },
+                "filters": {
+                    "$ref": "#/definitions/filters"
+                },
+                "ref-kind": {
+                    "$ref": "#/definitions/ref-kind"
+                },
+                "name": {
+                    "description": "The app-id to be pruned",
+                    "$ref": "#/definitions/name"
+                },
+                "branch": {
+                    "$ref": "#/definitions/branch"
+                },
+                "collection-id": {
+                    "$ref": "#/definitions/collection-id"
+                },
+                "remote": {
+                    "$ref": "#/definitions/remote"
+                }
+            },
+            "required": ["ref-kind", "name", "branch", "collection-id", "remote"]
         }
     ],
     "required": ["action", "serial"],

--- a/eos-updater/fetch.c
+++ b/eos-updater/fetch.c
@@ -598,6 +598,7 @@ perform_action_preparation (FlatpakInstallation        *installation,
                                            cancellable,
                                            error);
       case EUU_FLATPAK_REMOTE_REF_ACTION_UNINSTALL:
+      case EUU_FLATPAK_REMOTE_REF_ACTION_PRUNE_REF:
         return TRUE;
       default:
         g_assert_not_reached ();

--- a/libeos-updater-flatpak-installer/perform-flatpak-actions.c
+++ b/libeos-updater-flatpak-installer/perform-flatpak-actions.c
@@ -32,6 +32,42 @@
 #include <string.h>
 
 static gboolean
+validate_collection_id_remote (FlatpakInstallation  *installation,
+                               const gchar          *collection_id,
+                               const gchar          *expected_remote_name,
+                               GError              **error)
+{
+  g_autofree gchar *candidate_remote_name = NULL;
+  g_assert (collection_id != NULL);
+  g_assert (expected_remote_name != NULL);
+
+  g_message ("Finding remote name for %s", collection_id);
+
+  /* Ignore errors here. We always have the @expected_remote_name to use. */
+  candidate_remote_name = euu_lookup_flatpak_remote_for_collection_id (installation,
+                                                                       collection_id,
+                                                                       NULL);
+
+  if (candidate_remote_name != NULL &&
+      g_strcmp0 (expected_remote_name, candidate_remote_name) != 0)
+    {
+      g_set_error (error,
+                   EOS_UPDATER_ERROR,
+                   EOS_UPDATER_ERROR_FLATPAK_REMOTE_CONFLICT,
+                   "Specified flatpak remote ‘%s’ conflicts with the remote "
+                   "detected for collection ID ‘%s’ (‘%s’), cannot continue.",
+                   expected_remote_name,
+                   collection_id,
+                   candidate_remote_name);
+      return FALSE;
+    }
+
+  g_message ("Remote name for %s is %s", collection_id, expected_remote_name);
+
+  return TRUE;
+}
+
+static gboolean
 try_update_application (FlatpakInstallation       *installation,
                         FlatpakRef                *ref,
                         EosUpdaterInstallerFlags   flags,
@@ -69,44 +105,23 @@ try_update_application (FlatpakInstallation       *installation,
 static gboolean
 try_install_application (FlatpakInstallation       *installation,
                          const gchar               *collection_id,
-                         const gchar               *in_remote_name,
+                         const gchar               *remote_name,
                          FlatpakRef                *ref,
                          EosUpdaterInstallerFlags   flags,
                          GError                   **error)
 {
   g_autofree gchar *formatted_ref = flatpak_ref_format_ref (ref);
-  g_autofree gchar *candidate_remote_name = NULL;
-  const gchar *remote_name = in_remote_name;
   gboolean no_pull = !(flags & EU_INSTALLER_FLAGS_ALSO_PULL);
   g_autoptr(GError) local_error = NULL;
 
-  g_assert (in_remote_name != NULL);
+  g_assert (remote_name != NULL);
 
-  if (collection_id != NULL)
-    {
-      g_message ("Finding remote name for %s", collection_id);
-
-      /* Ignore errors here. We always have the @in_remote_name to use. */
-      candidate_remote_name = euu_lookup_flatpak_remote_for_collection_id (installation,
-                                                                           collection_id,
-                                                                           NULL);
-
-      if (candidate_remote_name != NULL &&
-          g_strcmp0 (in_remote_name, candidate_remote_name) != 0)
-        {
-          g_set_error (error,
-                       EOS_UPDATER_ERROR,
-                       EOS_UPDATER_ERROR_FLATPAK_REMOTE_CONFLICT,
-                       "Specified flatpak remote ‘%s’ conflicts with the remote "
-                       "detected for collection ID ‘%s’ (‘%s’), cannot continue.",
-                       in_remote_name,
-                       collection_id,
-                       candidate_remote_name);
-          return FALSE;
-        }
-
-      g_message ("Remote name for %s is %s", collection_id, remote_name);
-    }
+  if (collection_id != NULL &&
+      !validate_collection_id_remote (installation,
+                                      collection_id,
+                                      remote_name,
+                                      error))
+    return FALSE;
 
   g_message ("Attempting to install %s:%s", remote_name, formatted_ref);
 
@@ -176,6 +191,39 @@ try_uninstall_application (FlatpakInstallation  *installation,
 }
 
 static gboolean
+try_prune_ref (FlatpakInstallation  *installation,
+               const gchar          *collection_id,
+               const gchar          *remote_name,
+               FlatpakRef           *ref,
+               GError              **error)
+{
+  g_autofree gchar *formatted_ref = flatpak_ref_format_ref (ref);
+
+  if (collection_id != NULL &&
+      !validate_collection_id_remote (installation,
+                                      collection_id,
+                                      remote_name,
+                                      error))
+    return FALSE;
+
+  g_message ("Attempting to prune ref %s:%s", remote_name, formatted_ref);
+
+  if (!euu_flatpak_transaction_prune_ref (installation,
+                                          remote_name,
+                                          formatted_ref,
+                                          TRUE, /* no_prune */
+                                          NULL, /* cancellable */
+                                          error))
+    {
+      g_message ("Could not prune ref %s:%s", remote_name, formatted_ref);
+      return FALSE;
+    }
+
+  g_message ("Successfully pruned ref %s:%s", remote_name, formatted_ref);
+  return TRUE;
+}
+
+static gboolean
 perform_action (FlatpakInstallation        *installation,
                 EuuFlatpakRemoteRefAction  *action,
                 EosUpdaterInstallerFlags    flags,
@@ -202,6 +250,12 @@ perform_action (FlatpakInstallation        *installation,
         return try_uninstall_application (installation,
                                           action->ref->ref,
                                           error);
+      case EUU_FLATPAK_REMOTE_REF_ACTION_PRUNE_REF:
+        return try_prune_ref (installation,
+                              collection_id,
+                              remote_name,
+                              action->ref->ref,
+                              error);
       default:
         g_assert_not_reached ();
     }
@@ -368,6 +422,7 @@ eufi_apply_flatpak_ref_actions (FlatpakInstallation       *installation,
 static gboolean
 check_if_flatpak_is_installed (FlatpakInstallation        *installation,
                                EuuFlatpakRemoteRefAction  *action,
+                               gboolean                    match_remote,
                                gboolean                   *out_is_installed,
                                GError                    **error)
 {
@@ -397,10 +452,60 @@ check_if_flatpak_is_installed (FlatpakInstallation        *installation,
     }
   g_clear_error (&local_error);
 
-  *out_is_installed = (installed_ref != NULL);
-  g_message ("Flatpak described by ref %s is %s",
-             formatted_ref,
-             *out_is_installed ? "installed": "not installed");
+  if (match_remote)
+    {
+      if (installed_ref != NULL)
+        {
+          const gchar *installed_remote = flatpak_installed_ref_get_origin (installed_ref);
+          *out_is_installed = g_strcmp0 (installed_remote, action->ref->remote);
+        }
+      else
+        *out_is_installed = FALSE;
+      g_message ("Flatpak described by ref %s:%s is %s",
+                 action->ref->remote, formatted_ref,
+                 *out_is_installed ? "installed" : "not installed");
+    }
+  else
+    {
+      *out_is_installed = (installed_ref != NULL);
+      g_message ("Flatpak described by ref %s is %s",
+                 formatted_ref,
+                 *out_is_installed ? "installed" : "not installed");
+    }
+
+  return TRUE;
+}
+
+static gboolean
+check_if_ostree_ref_exists (FlatpakInstallation        *installation,
+                            EuuFlatpakRemoteRefAction  *action,
+                            gboolean                   *out_exists,
+                            GError                    **error)
+{
+  g_autoptr(GFile) installation_directory = flatpak_installation_get_path (installation);
+  g_autoptr(GFile) repo_directory = g_file_get_child (installation_directory, "repo");
+  g_autoptr(OstreeRepo) repo = ostree_repo_new (repo_directory);
+  g_autofree gchar *formatted_ref = NULL;
+  g_autofree gchar *refspec = NULL;
+  g_autofree gchar *rev = NULL;
+
+  if (!ostree_repo_open (repo, NULL, error))
+    return FALSE;
+
+  formatted_ref = flatpak_ref_format_ref (action->ref->ref);
+  refspec = g_strdup_printf ("%s:%s", action->ref->remote, formatted_ref);
+  if (!ostree_repo_resolve_rev_ext (repo,
+                                    refspec,
+                                    TRUE, /* allow_noent */
+                                    OSTREE_REPO_RESOLVE_REV_EXT_LOCAL_ONLY,
+                                    &rev,
+                                    error))
+    return FALSE;
+
+  *out_exists = (rev != NULL);
+  g_message ("OSTree ref %s %s",
+             refspec,
+             *out_exists ? "exists" : "does not exist");
 
   return TRUE;
 }
@@ -440,6 +545,7 @@ eufi_check_ref_actions_applied (FlatpakInstallation  *installation,
           case EUU_FLATPAK_REMOTE_REF_ACTION_INSTALL:
             if (!check_if_flatpak_is_installed (installation,
                                                 pending_action,
+                                                FALSE, /* match_remote */
                                                 &is_installed,
                                                 error))
               return FALSE;
@@ -457,6 +563,7 @@ eufi_check_ref_actions_applied (FlatpakInstallation  *installation,
           case EUU_FLATPAK_REMOTE_REF_ACTION_UNINSTALL:
             if (!check_if_flatpak_is_installed (installation,
                                                 pending_action,
+                                                FALSE, /* match_remote */
                                                 &is_installed,
                                                 error))
               return FALSE;
@@ -475,6 +582,37 @@ eufi_check_ref_actions_applied (FlatpakInstallation  *installation,
             /* Nothing meaningful we can do here - the flatpak is meant
              * to be installed if it would have been installed before
              * otherwise it stays uninstalled */
+            break;
+          case EUU_FLATPAK_REMOTE_REF_ACTION_PRUNE_REF:
+            if (!check_if_flatpak_is_installed (installation,
+                                                pending_action,
+                                                TRUE, /* match_remote */
+                                                &is_installed,
+                                                error))
+              return FALSE;
+
+            if (!is_installed)
+              {
+                gboolean ref_exists = FALSE;
+
+                if (!check_if_ostree_ref_exists (installation,
+                                                 pending_action,
+                                                 &ref_exists,
+                                                 error))
+                  return FALSE;
+
+                if (ref_exists)
+                  {
+                    g_autofree gchar *formatted_ref = flatpak_ref_format_ref (pending_action->ref->ref);
+                    g_autofree gchar *msg = g_strdup_printf ("OSTree ref %s:%s should have been "
+                                                             "removed by %s but exists\n",
+                                                             pending_action->ref->remote,
+                                                             formatted_ref,
+                                                             name);
+                    g_string_append (deltas, msg);
+                  }
+              }
+
             break;
           default:
             g_assert_not_reached ();

--- a/libeos-updater-util/flatpak-util.h
+++ b/libeos-updater-util/flatpak-util.h
@@ -35,7 +35,8 @@ G_BEGIN_DECLS
 typedef enum {
   EUU_FLATPAK_REMOTE_REF_ACTION_INSTALL = 0,
   EUU_FLATPAK_REMOTE_REF_ACTION_UNINSTALL = 1,
-  EUU_FLATPAK_REMOTE_REF_ACTION_UPDATE = 2
+  EUU_FLATPAK_REMOTE_REF_ACTION_UPDATE = 2,
+  EUU_FLATPAK_REMOTE_REF_ACTION_PRUNE_REF = 3,
 } EuuFlatpakRemoteRefActionType;
 
 typedef struct {
@@ -196,6 +197,13 @@ gboolean euu_flatpak_transaction_uninstall (FlatpakInstallation *installation,
                                             const gchar         *formatted_ref,
                                             gboolean             no_prune,
                                             GCancellable        *cancellable,
+                                            GError              **error);
+
+gboolean euu_flatpak_transaction_prune_ref (FlatpakInstallation  *installation,
+                                            const gchar          *remote,
+                                            const gchar          *formatted_ref,
+                                            gboolean              no_prune,
+                                            GCancellable         *cancellable,
                                             GError              **error);
 
 G_END_DECLS

--- a/libeos-updater-util/tests/flatpak-util.c
+++ b/libeos-updater-util/tests/flatpak-util.c
@@ -328,7 +328,7 @@ test_no_compress_install_install_different_branches (void)
 {
   FlatpakToInstallEntry entries[] = {
     { EUU_FLATPAK_REMOTE_REF_ACTION_INSTALL, FLATPAK_REF_KIND_APP, "org.test.Test", "stable", 1, 0 },
-    { EUU_FLATPAK_REMOTE_REF_ACTION_INSTALL, FLATPAK_REF_KIND_APP, "org.test.Runtime", "stable", 1, 0 }
+    { EUU_FLATPAK_REMOTE_REF_ACTION_INSTALL, FLATPAK_REF_KIND_APP, "org.test.Test", "other", 1, 0 }
   };
   FlatpakToInstallFile files[] = {
     { "autoinstall", entries, G_N_ELEMENTS (entries) }

--- a/test-common/ostree-spawn.c
+++ b/test-common/ostree-spawn.c
@@ -654,17 +654,20 @@ ostree_list_refs_in_repo (GFile      *repo,
 gboolean
 ostree_httpd (GFile *served_dir,
               GFile *port_file,
+              GFile *log_file,
               CmdResult *cmd,
               GError **error)
 {
   g_autofree gchar *raw_port_file = g_file_get_path (port_file);
   g_autofree gchar *raw_served_dir = g_file_get_path (served_dir);
+  g_autofree gchar *raw_log_file = g_file_get_path (log_file);
   CmdArg args[] =
     {
       { NULL, OSTREE_TRIVIAL_HTTPD_BINARY },
       { "autoexit", NULL },
       { "daemonize", NULL },
       { "port-file", raw_port_file },
+      { "log-file", raw_log_file },
       { NULL, raw_served_dir },
       { NULL, NULL }
     };

--- a/test-common/ostree-spawn.c
+++ b/test-common/ostree-spawn.c
@@ -241,6 +241,10 @@ ostree_summary (GFile *repo,
                 GError **error)
 {
   g_autofree gchar *gpg_home_path = g_file_get_path (gpg_home);
+  g_autoptr(GFile) summary_sig_file = NULL;
+  g_autoptr(GFileInfo) summary_sig_info = NULL;
+  g_autoptr(GDateTime) summary_sig_mtime = NULL;
+  g_autoptr(GDateTime) now = NULL;
   CmdArg args[] =
     {
       { NULL, "summary" },
@@ -250,10 +254,39 @@ ostree_summary (GFile *repo,
       { NULL, NULL }
     };
 
-  return spawn_ostree_in_repo_args (repo,
-                                    args,
-                                    cmd,
-                                    error);
+  if (!spawn_ostree_in_repo_args (repo,
+                                  args,
+                                  cmd,
+                                  error))
+    return FALSE;
+
+  /* To try to avoid downloading the summary file when it already has the
+   * current version, the ostree client requests the summary and signature with
+   * an If-Modified-Since HTTP header (when it can't use the preferable
+   * If-None-Match header). The HTTP header only has second precision, so it
+   * may not receive an updated summary if the request is sent within the same
+   * second the summary is updated.
+   *
+   * To ensure the client will always receive the updated summary, sleep until
+   * the next second if necessary. Note that only the signature file is checked
+   * since it's always created after the summary.
+   */
+  summary_sig_file = g_file_get_child (repo, "summary.sig");
+  summary_sig_info = g_file_query_info (summary_sig_file,
+                                        G_FILE_ATTRIBUTE_TIME_MODIFIED ","
+                                        G_FILE_ATTRIBUTE_TIME_MODIFIED_USEC,
+                                        G_FILE_QUERY_INFO_NONE,
+                                        NULL,
+                                        error);
+  if (summary_sig_info == NULL)
+    return FALSE;
+  summary_sig_mtime = g_file_info_get_modification_date_time (summary_sig_info);
+  now = g_date_time_new_now_utc ();
+  if ((g_date_time_difference (now, summary_sig_mtime) < G_USEC_PER_SEC) &&
+      (g_date_time_get_second (now) == g_date_time_get_second (summary_sig_mtime)))
+    g_usleep (G_USEC_PER_SEC - (gulong) g_date_time_get_microsecond (now));
+
+  return TRUE;
 }
 
 gboolean

--- a/test-common/ostree-spawn.h
+++ b/test-common/ostree-spawn.h
@@ -163,6 +163,7 @@ gboolean ostree_list_refs_in_repo (GFile      *repo,
  * g_spawn_sync becomes stuck on reading pipes. */
 gboolean ostree_httpd (GFile *served_dir,
                        GFile *port_file,
+                       GFile *log_file,
                        CmdResult *cmd,
                        GError **error);
 

--- a/test-common/utils.c
+++ b/test-common/utils.c
@@ -1074,10 +1074,12 @@ run_httpd (GFile *served_root,
 {
   g_auto(CmdResult) cmd = CMD_RESULT_CLEARED;
   g_autoptr(GFile) port_file = g_file_get_child (httpd_dir, "port-file");
+  g_autoptr(GFile) log_file = g_file_get_child (httpd_dir, "httpd-log");
   guint16 port;
 
   if (!ostree_httpd (served_root,
                      port_file,
+                     log_file,
                      &cmd,
                      error))
     return FALSE;


### PR DESCRIPTION
The purpose of this PR is to add an action for the flatpak installer to cleanup dangling OSTree refs for uninstalled Flatpaks. This is primarily for cleaning up from bugs here or in other software (the image builder).

The PR could be split up some if preferred. The first 4 commits are entirely independent things I came across when making tests. The last commit could be broken up by component. It also might need a couple more tests.

https://phabricator.endlessm.com/T32791