### PR TITLE
Restore staged deployments for eos4.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Build-Depends:
  libgsystem-dev,
  libjson-glib-dev (>= 1.2.6-1endless2),
  libmogwai-schedule-client-0-dev,
+ libmount-dev (>= 2.24),
  libnm-dev (>= 1.2.0),
  libostree-dev (>= 2017.12),
  libsoup2.4-dev,

--- a/eos-updater/apply.c
+++ b/eos-updater/apply.c
@@ -270,11 +270,13 @@ apply_internal (ApplyData     *apply_data,
 
   origin = ostree_sysroot_origin_new_from_refspec (sysroot, update_refspec);
 
-  /* When booted into an OSTree system, stage the deployment so that the
-   * /etc merge happens during shutdown. Otherwise (primarily the test
-   * suite), deploy the finalized tree immediately.
+  /* When booted into an OSTree system without an automount /boot, stage the
+   * deployment so that the /etc merge happens during shutdown. Otherwise
+   * (primarily sd-boot and the test suite), deploy the finalized tree
+   * immediately.
    */
-  staged_deploy = ostree_sysroot_is_booted (sysroot);
+  staged_deploy = ostree_sysroot_is_booted (sysroot) &&
+    !eos_updater_sysroot_boot_is_automount (sysroot, NULL);
   if (staged_deploy)
     {
       g_message ("Creating staged deployment for revision %s", update_id);

--- a/eos-updater/apply.c
+++ b/eos-updater/apply.c
@@ -241,6 +241,7 @@ apply_internal (ApplyData     *apply_data,
   g_autoptr(GKeyFile) origin = NULL;
   g_autoptr(OstreeSysroot) sysroot = NULL;
   const gchar *osname = get_test_osname ();
+  gboolean staged_deploy;
   g_autoptr(GError) local_error = NULL;
 
   sysroot = ostree_sysroot_new_default ();
@@ -269,21 +270,62 @@ apply_internal (ApplyData     *apply_data,
 
   origin = ostree_sysroot_origin_new_from_refspec (sysroot, update_refspec);
 
-  if (!ostree_sysroot_deploy_tree (sysroot,
-                                   osname,
-                                   update_id,
-                                   origin,
-                                   booted_deployment,
-                                   NULL,
-                                   &new_deployment,
-                                   cancellable,
-                                   error))
-    return FALSE;
+  /* When booted into an OSTree system, stage the deployment so that the
+   * /etc merge happens during shutdown. Otherwise (primarily the test
+   * suite), deploy the finalized tree immediately.
+   */
+  staged_deploy = ostree_sysroot_is_booted (sysroot);
+  if (staged_deploy)
+    {
+      g_message ("Creating staged deployment for revision %s", update_id);
+      if (!ostree_sysroot_stage_tree (sysroot,
+                                      osname,
+                                      update_id,
+                                      origin,
+                                      booted_deployment,
+                                      NULL,
+                                      &new_deployment,
+                                      cancellable,
+                                      error))
+        return FALSE;
+    }
+  else
+    {
+      g_message ("Creating finalized deployment for revision %s", update_id);
+      if (!ostree_sysroot_deploy_tree (sysroot,
+                                       osname,
+                                       update_id,
+                                       origin,
+                                       booted_deployment,
+                                       NULL,
+                                       &new_deployment,
+                                       cancellable,
+                                       error))
+        return FALSE;
+
+      if (!ostree_sysroot_simple_write_deployment (sysroot,
+                                                   osname,
+                                                   new_deployment,
+                                                   booted_deployment,
+                                                   OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_NO_CLEAN,
+                                                   cancellable,
+                                                   error))
+        return FALSE;
+    }
+
+  g_message ("New deployment: index: %d, OS name: %s, deploy serial: %d, "
+             "checksum: %s, boot checksum: %s, boot serial: %d",
+             ostree_deployment_get_index (new_deployment),
+             ostree_deployment_get_osname (new_deployment),
+             ostree_deployment_get_deployserial (new_deployment),
+             ostree_deployment_get_csum (new_deployment),
+             ostree_deployment_get_bootcsum (new_deployment),
+             ostree_deployment_get_bootserial (new_deployment));
 
   /* If the original refspec is not the update refspec, then we may have
    * a ref to a no longer needed tree. Delete that remote ref so the
-   * cleanup done in simple_write_deployment() really removes that tree
-   * if no deployments point to it anymore.
+   * sysroot cleanup below really removes that tree if no deployments
+   * point to it anymore.
    */
   if (g_strcmp0 (update_refspec, orig_refspec) != 0)
     {
@@ -303,24 +345,6 @@ apply_internal (ApplyData     *apply_data,
             return FALSE;
         }
     }
-
-  if (!ostree_sysroot_simple_write_deployment (sysroot,
-                                               osname,
-                                               new_deployment,
-                                               booted_deployment,
-                                               OSTREE_SYSROOT_SIMPLE_WRITE_DEPLOYMENT_FLAGS_NO_CLEAN,
-                                               cancellable,
-                                               error))
-    return FALSE;
-
-  g_message ("New deployment: index: %d, OS name: %s, deploy serial: %d, "
-             "checksum: %s, boot checksum: %s, boot serial: %d",
-             ostree_deployment_get_index (new_deployment),
-             ostree_deployment_get_osname (new_deployment),
-             ostree_deployment_get_deployserial (new_deployment),
-             ostree_deployment_get_csum (new_deployment),
-             ostree_deployment_get_bootcsum (new_deployment),
-             ostree_deployment_get_bootserial (new_deployment));
 
   /* FIXME: Cleaning up after update should be non-fatal, since we've
    * already successfully deployed the new OS. This clearly is a

--- a/libeos-updater-util/meson.build
+++ b/libeos-updater-util/meson.build
@@ -36,6 +36,7 @@ libeos_updater_util_deps = [
   dependency('gobject-2.0', version: '>= 2.62'),
   dependency('json-glib-1.0', version: '>= 1.2.6'),
   dependency('libsoup-2.4'),
+  dependency('mount', version: '>= 2.24'),
   dependency('ostree-1', version: '>= 2018.6'),
 ]
 

--- a/libeos-updater-util/ostree-util.c
+++ b/libeos-updater-util/ostree-util.c
@@ -23,6 +23,7 @@
 #include <glib.h>
 #include <libeos-updater-util/ostree-util.h>
 #include <libeos-updater-util/util.h>
+#include <libmount.h>
 #include <libsoup/soup.h>
 #include <ostree.h>
 #include <string.h>
@@ -310,4 +311,80 @@ eos_updater_get_ostree_path (OstreeRepo *repo,
     memmove (path, path + to_move, strlen (path) - to_move + 1);
   *ostree_path = g_steal_pointer (&path);
   return TRUE;
+}
+
+/**
+ * eos_updater_sysroot_boot_is_automount:
+ * @sysroot: loaded OSTree sysroot to use
+ * @mountinfo: (nullable): path to mountinfo file
+ *
+ * Find if the boot directory in @sysroot is an automount mount. The first
+ * mountpoint for the boot directory in @mountinfo is found. If the filesystem
+ * type for the mountpoint is autofs, then the boot directory is automounted.
+ *
+ * If @mountinfo is %NULL, /proc/self/mountinfo is used.
+ *
+ * Returns: %TRUE if boot is an automount
+ */
+gboolean
+eos_updater_sysroot_boot_is_automount (OstreeSysroot *sysroot,
+                                       const gchar   *mountinfo)
+{
+  GFile *sysroot_file;
+  g_autoptr(GFile) boot_file = NULL;
+  g_autofree gchar *boot_path = NULL;
+  gboolean ret = FALSE;
+  struct libmnt_table *tb = NULL;
+  struct libmnt_cache *cache;
+  struct libmnt_fs *fs;
+
+  sysroot_file = ostree_sysroot_get_path (sysroot);
+  boot_file = g_file_get_child (sysroot_file, "boot");
+  boot_path = g_file_get_path (boot_file);
+  if (boot_path == NULL)
+    {
+      g_autofree gchar *sysroot_path = g_file_get_path (sysroot_file);
+      g_warning ("No boot directory in sysroot %s", sysroot_path);
+      goto out;
+    }
+
+  if (mountinfo == NULL)
+    mountinfo = "/proc/self/mountinfo";
+  tb = mnt_new_table_from_file (mountinfo);
+  if (tb == NULL)
+    {
+      g_warning ("Failed to parse %s: %s", mountinfo, g_strerror (errno));
+      goto out;
+    }
+
+  cache = mnt_new_cache ();
+  if (cache == NULL)
+    {
+      g_warning ("Failed to create libmount cache: %s", g_strerror (errno));
+      goto out;
+    }
+  mnt_table_set_cache (tb, cache);
+  mnt_unref_cache (cache);
+
+  /* Find the /boot mountpoint iterating forward so that the autofs mount is
+   * found and not the automount target filesystem, as the autofs mount is
+   * listed first in mountinfo.
+   */
+  fs = mnt_table_find_mountpoint (tb, boot_path, MNT_ITER_FORWARD);
+  if (fs == NULL)
+    {
+      g_warning ("Failed to find mountpoint for %s: %s", boot_path,
+                 g_strerror (errno));
+      goto out;
+    }
+
+  ret = g_strcmp0 (mnt_fs_get_fstype (fs), "autofs") == 0;
+  g_debug ("Boot directory %s is%s on an autofs filesystem",
+           boot_path, ret ? "" : " not");
+
+ out:
+  if (tb != NULL)
+    mnt_unref_table (tb);
+
+  return ret;
 }

--- a/libeos-updater-util/ostree-util.h
+++ b/libeos-updater-util/ostree-util.h
@@ -47,4 +47,7 @@ gboolean eos_updater_get_ostree_path (OstreeRepo *repo,
                                       gchar **ostree_path,
                                       GError **error);
 
+gboolean eos_updater_sysroot_boot_is_automount (OstreeSysroot *sysroot,
+                                                const gchar   *mountinfo);
+
 G_END_DECLS

--- a/libeos-updater-util/tests/ostree-util.c
+++ b/libeos-updater-util/tests/ostree-util.c
@@ -147,6 +147,85 @@ test_ostree_no_deployments (Fixture       *fixture,
   g_assert_cmpuint (commit_timestamp, ==, 0);
 }
 
+static void
+test_ostree_sysroot_boot_automount (Fixture       *fixture,
+                                    gconstpointer  user_data G_GNUC_UNUSED)
+{
+  g_autoptr(GError) error = NULL;
+  gboolean retval;
+  GFile *sysroot_file = ostree_sysroot_get_path (fixture->sysroot);
+  g_autofree gchar *sysroot_path = g_file_get_path (sysroot_file);
+  g_autoptr(GFile) boot_file = g_file_get_child (sysroot_file, "boot");
+  g_autofree gchar *boot_path = g_file_get_path (boot_file);
+  g_autoptr(GFile) mountinfo_file = g_file_get_child (fixture->tmp_dir,
+                                                      "mountinfo");
+  g_autofree gchar *mountinfo_path = g_file_get_path (mountinfo_file);
+  g_autofree gchar *mountinfo_contents = NULL;
+
+  retval = g_file_make_directory (boot_file, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_true (retval);
+
+  /* No separate /boot mount */
+  g_clear_pointer (&mountinfo_contents, g_free);
+  mountinfo_contents =
+    g_strdup_printf ("1 1 1:1 / %s rw - ext4 /dev/sda1 rw\n", sysroot_path);
+  g_test_message ("boot %s, mountinfo:\n%s", boot_path, mountinfo_contents);
+  retval = g_file_replace_contents (mountinfo_file, mountinfo_contents,
+                                    strlen (mountinfo_contents), NULL, FALSE,
+                                    G_FILE_CREATE_NONE, NULL, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_true (retval);
+  retval = eos_updater_sysroot_boot_is_automount (fixture->sysroot, mountinfo_path);
+  g_assert_false (retval);
+
+  /* Non-automount /boot */
+  g_clear_pointer (&mountinfo_contents, g_free);
+  mountinfo_contents =
+    g_strdup_printf ("1 1 1:2 / %s rw - ext4 /dev/sda2 rw\n"
+                     "2 1 1:1 / %s rw - ext4 /dev/sda1 rw\n",
+                     sysroot_path, boot_path);
+  g_test_message ("boot %s, mountinfo:\n%s", boot_path, mountinfo_contents);
+  retval = g_file_replace_contents (mountinfo_file, mountinfo_contents,
+                                    strlen (mountinfo_contents), NULL, FALSE,
+                                    G_FILE_CREATE_NONE, NULL, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_true (retval);
+  retval = eos_updater_sysroot_boot_is_automount (fixture->sysroot, mountinfo_path);
+  g_assert_false (retval);
+
+  /* Automount /boot without target mount */
+  g_clear_pointer (&mountinfo_contents, g_free);
+  mountinfo_contents =
+    g_strdup_printf ("1 1 1:2 / %s rw - ext4 /dev/sda2 rw\n"
+                     "2 1 0:1 / %s rw - autofs systemd-1 rw\n",
+                     sysroot_path, boot_path);
+  g_test_message ("boot %s, mountinfo:\n%s", boot_path, mountinfo_contents);
+  retval = g_file_replace_contents (mountinfo_file, mountinfo_contents,
+                                    strlen (mountinfo_contents), NULL, FALSE,
+                                    G_FILE_CREATE_NONE, NULL, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_true (retval);
+  retval = eos_updater_sysroot_boot_is_automount (fixture->sysroot, mountinfo_path);
+  g_assert_true (retval);
+
+  /* Automount /boot with target mount */
+  g_clear_pointer (&mountinfo_contents, g_free);
+  mountinfo_contents =
+    g_strdup_printf ("1 1 1:2 / %s rw - ext4 /dev/sda2 rw\n"
+                     "2 1 0:1 / %s rw - autofs systemd-1 rw\n"
+                     "3 2 1:1 / %s rw - vfat /dev/sda1 rw\n",
+                     sysroot_path, boot_path, boot_path);
+  g_test_message ("boot %s, mountinfo:\n%s", boot_path, mountinfo_contents);
+  retval = g_file_replace_contents (mountinfo_file, mountinfo_contents,
+                                    strlen (mountinfo_contents), NULL, FALSE,
+                                    G_FILE_CREATE_NONE, NULL, NULL, &error);
+  g_assert_no_error (error);
+  g_assert_true (retval);
+  retval = eos_updater_sysroot_boot_is_automount (fixture->sysroot, mountinfo_path);
+  g_assert_true (retval);
+}
+
 int
 main (int   argc,
       char *argv[])
@@ -157,6 +236,8 @@ main (int   argc,
 
   g_test_add ("/ostree/no-deployments", Fixture, NULL, setup,
               test_ostree_no_deployments, teardown);
+  g_test_add ("/ostree/sysroot-boot-automount", Fixture, NULL, setup,
+              test_ostree_sysroot_boot_automount, teardown);
   /* TODO: More */
 
   return g_test_run ();


### PR DESCRIPTION
Bring back staged deployments for eos4.0 with the workaround to not use them on an automounted `/boot`.

https://phabricator.endlessm.com/T33136