### PR TITLE
Document that an empty autoinstall file is legal

### DIFF
--- a/eos-updater-flatpak-installer/docs/eos-updater-flatpak-autoinstall.d.5
+++ b/eos-updater-flatpak-installer/docs/eos-updater-flatpak-autoinstall.d.5
@@ -47,6 +47,9 @@ objects describing a ‘flatpak ref action’, as described below in
 \fIFlatpak Ref Action\fP. These files are intended to be append\-only
 and the \fBserial\fP property in each object must be a monotonically
 increasing counter within the domain of that filename.
+.PP
+As a special case, an empty file is treated as a file containing an empty
+JSON array.
 .\"
 .IP "\fIFlatpak Ref Action\fP"
 .IX Item "Flatpak Ref Action"


### PR DESCRIPTION
This has been true since the very first commit of this functionality,
but was previously undocumented except in a source-code comment.
