### PR TITLE
eos-updater: Block Weibu F3C updates to EOS 5 from EOS 4

### DIFF
--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -1491,6 +1491,8 @@ test_update_refspec_checkpoint_eos3a_eos4 (EosUpdaterFixture *fixture,
       { NULL, NULL, "ASUSTeK COMPUTER INC.", "Z550MA", FALSE, NULL, NULL, NULL, FALSE, FALSE },
       { NULL, NULL, "Endless", "ELT-JWM", FALSE, NULL, NULL, NULL, FALSE, FALSE },
       { NULL, NULL, "Endless", "ELT-JWM", FALSE, NULL, NULL, NULL, TRUE, TRUE },
+      { "os/eos/amd64/latest1", NULL, "Endless", "EE-200", FALSE, NULL, NULL, NULL, FALSE, FALSE },
+      { "os/eos/amd64/latest1", NULL, "Endless", "EE-200", FALSE, NULL, NULL, NULL, TRUE, TRUE },
 
       /* Read-only in kernel command line args */
       { NULL, NULL, NULL, NULL, FALSE, NULL, NULL, cmdline_not_ro, FALSE, TRUE },


### PR DESCRIPTION
Block Weibu F3C (Endless EE-200) updates to EOS 5 from EOS 4. It is not
on the EOS 5 support list. Add corresponding tests as well.

https://phabricator.endlessm.com/T33311