### PR TITLE
Revert "apply: Don't use staged deployments when /boot is automounted"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,6 @@ Build-Depends:
  libgsystem-dev,
  libjson-glib-dev (>= 1.2.6-1endless2),
  libmogwai-schedule-client-0-dev,
- libmount-dev (>= 2.24),
  libnm-dev (>= 1.2.0),
  libostree-dev (>= 2017.12),
  libsoup2.4-dev,

--- a/eos-updater/apply.c
+++ b/eos-updater/apply.c
@@ -270,13 +270,11 @@ apply_internal (ApplyData     *apply_data,
 
   origin = ostree_sysroot_origin_new_from_refspec (sysroot, update_refspec);
 
-  /* When booted into an OSTree system without an automount /boot, stage the
-   * deployment so that the /etc merge happens during shutdown. Otherwise
-   * (primarily sd-boot and the test suite), deploy the finalized tree
-   * immediately.
+  /* When booted into an OSTree system, stage the deployment so that the
+   * /etc merge happens during shutdown. Otherwise (primarily the test
+   * suite), deploy the finalized tree immediately.
    */
-  staged_deploy = ostree_sysroot_is_booted (sysroot) &&
-    !eos_updater_sysroot_boot_is_automount (sysroot, NULL);
+  staged_deploy = ostree_sysroot_is_booted (sysroot);
   if (staged_deploy)
     {
       g_message ("Creating staged deployment for revision %s", update_id);

--- a/libeos-updater-util/meson.build
+++ b/libeos-updater-util/meson.build
@@ -36,7 +36,6 @@ libeos_updater_util_deps = [
   dependency('gobject-2.0', version: '>= 2.62'),
   dependency('json-glib-1.0', version: '>= 1.2.6'),
   dependency('libsoup-2.4'),
-  dependency('mount', version: '>= 2.24'),
   dependency('ostree-1', version: '>= 2018.6'),
 ]
 

--- a/libeos-updater-util/ostree-util.h
+++ b/libeos-updater-util/ostree-util.h
@@ -47,7 +47,4 @@ gboolean eos_updater_get_ostree_path (OstreeRepo *repo,
                                       gchar **ostree_path,
                                       GError **error);
 
-gboolean eos_updater_sysroot_boot_is_automount (OstreeSysroot *sysroot,
-                                                const gchar   *mountinfo);
-
 G_END_DECLS


### PR DESCRIPTION
This reverts commit a19821a2b419850e188da3eee4fe3465528ca920. OSTree has been fixed to support this use case by keeping `/boot` open in the root namespace until the staged deployment completes finalization. See https://github.com/ostreedev/ostree/pull/2544 for details.

https://phabricator.endlessm.com/T33775