### PR TITLE
eos-updater: Let aarch64 follow the normal eos4 -> eos5 update procedure

### DIFF
--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -1393,10 +1393,10 @@ test_update_refspec_checkpoint_ignore_remote (EosUpdaterFixture *fixture,
 typedef struct
 {
   /* Setup */
-  const gchar *src_ref;
-  const gchar *tgt_ref;
-  const gchar *sys_vendor;
-  const gchar *product_name;
+  const gchar *src_ref;  /* (nullable) for default */
+  const gchar *tgt_ref;  /* (nullable) for default */
+  const gchar *sys_vendor;  /* (nullable) for default */
+  const gchar *product_name;  /* (nullable) for default */
   gboolean is_split_disk;
   const gchar *uname_machine;  /* (nullable) for default */
   const gchar *cpuinfo;  /* (nullable) for default */

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -1661,7 +1661,6 @@ static void
 test_update_refspec_checkpoint_latest1_latest2 (EosUpdaterFixture *fixture,
                                                 gconstpointer      user_data)
 {
-  struct utsname uts;
   gboolean host_is_aarch64;
   CheckpointTestData tests[] =
     {
@@ -1685,11 +1684,11 @@ test_update_refspec_checkpoint_latest1_latest2 (EosUpdaterFixture *fixture,
   if (eos_test_skip_chroot ())
     return;
 
-  /* If the host running the tests is actually aarch64, it will refuse to
-   * follow the checkpoint unless @force_follow_checkpoint is set (or there are
-   * bugs), so the test has to adapt. */
-  g_assert (uname (&uts) == 0);
-  host_is_aarch64 = (g_strcmp0 (uts.machine, "aarch64") == 0);
+  /* The aarch64 platforms can update from EOS 4 to EOS 5. So, let aarch64
+   * platforms follow the normal update checkpoint procedure.
+   *
+   * https://phabricator.endlessm.com/T33759 */
+  host_is_aarch64 = FALSE;
 
   for (gsize i = 0; i < G_N_ELEMENTS (tests); i++)
     {


### PR DESCRIPTION
The host_is_aarch64 flag guards the update from eos4 to eos5 for the aarch64 platforms. It disabled the updating on aarch64 platforms originally. This commit lets aarch64 follow the normal updating check from eos4 to eos5.

https://phabricator.endlessm.com/T33759