### PR TITLE
More eos4 → eos5 checkpoints

### DIFF
--- a/eos-update-server/meson.build
+++ b/eos-update-server/meson.build
@@ -8,7 +8,7 @@ eos_update_server_deps = [
   dependency('gobject-2.0', version: '>= 2.62'),
   dependency('libsoup-2.4'),
   dependency('libsystemd'),
-  dependency('ostree-1', version: '>= 2018.6'),
+  dependency('ostree-1', version: '>= 2019.2'),
   libeos_update_server_dep,
   libeos_updater_util_dep,
 ]

--- a/eos-updater-avahi/meson.build
+++ b/eos-updater-avahi/meson.build
@@ -6,7 +6,7 @@ eos_updater_avahi_deps = [
   dependency('gio-2.0', version: '>= 2.62'),
   dependency('glib-2.0', version: '>= 2.62'),
   dependency('gobject-2.0', version: '>= 2.62'),
-  dependency('ostree-1', version: '>= 2018.6'),
+  dependency('ostree-1', version: '>= 2019.2'),
   libeos_update_server_dep,
   libeos_updater_util_dep,
 ]

--- a/eos-updater-flatpak-installer/meson.build
+++ b/eos-updater-flatpak-installer/meson.build
@@ -8,7 +8,7 @@ eos_update_flatpak_installer_deps = [
   dependency('glib-2.0', version: '>= 2.62'),
   dependency('gobject-2.0', version: '>= 2.62'),
   dependency('json-glib-1.0', version: '>= 1.2.6'),
-  dependency('ostree-1', version: '>= 2018.6'),
+  dependency('ostree-1', version: '>= 2019.2'),
   libeos_updater_flatpak_installer_dep,
   libeos_updater_util_dep,
   eosmetrics_dep,

--- a/eos-updater/meson.build
+++ b/eos-updater/meson.build
@@ -30,7 +30,7 @@ libeos_updater_dbus_deps = [
   dependency('gobject-2.0', version: '>= 2.62'),
   dependency('libsoup-2.4'),
   dependency('mogwai-schedule-client-0'),
-  dependency('ostree-1', version: '>= 2018.6'),
+  dependency('ostree-1', version: '>= 2019.2'),
   libeos_updater_util_dep,
 ]
 

--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -544,8 +544,7 @@ should_follow_checkpoint (OstreeSysroot     *sysroot,
   /* https://phabricator.endlessm.com/T32542,
    * https://phabricator.endlessm.com/T32552 */
   gboolean is_eos3_conditional_upgrade_path =
-    (g_str_equal (booted_ref, "eos3a") ||
-     g_str_has_suffix (booted_ref, "/eos3a") ||
+    (g_str_has_suffix (booted_ref, "/eos3a") ||
      g_str_has_suffix (booted_ref, "nexthw/eos3.9"));
   /* https://phabricator.endlessm.com/T33311 */
   gboolean is_eos4_conditional_upgrade_path = g_str_has_suffix (booted_ref, "/latest1");

--- a/libeos-update-server/meson.build
+++ b/libeos-update-server/meson.build
@@ -29,7 +29,7 @@ libeos_update_server_deps = [
   dependency('gobject-2.0', version: '>= 2.62'),
   dependency('libsoup-2.4'),
   dependency('libsystemd'),
-  dependency('ostree-1', version: '>= 2018.6'),
+  dependency('ostree-1', version: '>= 2019.2'),
   libeos_updater_util_dep,
 ]
 

--- a/libeos-updater-flatpak-installer/meson.build
+++ b/libeos-updater-flatpak-installer/meson.build
@@ -20,7 +20,7 @@ libeos_updater_flatpak_installer_deps = [
   dependency('glib-2.0', version: '>= 2.62'),
   dependency('gobject-2.0', version: '>= 2.62'),
   dependency('json-glib-1.0', version: '>= 1.2.6'),
-  dependency('ostree-1', version: '>= 2018.6'),
+  dependency('ostree-1', version: '>= 2019.2'),
   libeos_updater_util_dep,
 ]
 

--- a/libeos-updater-flatpak-installer/tests/meson.build
+++ b/libeos-updater-flatpak-installer/tests/meson.build
@@ -4,7 +4,7 @@ deps = [
   dependency('glib-2.0', version: '>= 2.62.0'),
   dependency('gobject-2.0', version: '>= 2.44'),
   dependency('json-glib-1.0', version: '>= 1.2.6'),
-  dependency('ostree-1', version: '>= 2018.6'),
+  dependency('ostree-1', version: '>= 2019.2'),
   libeos_updater_flatpak_installer_dep,
   libeos_updater_test_common_dep,
   libeos_updater_util_dep,

--- a/libeos-updater-util/meson.build
+++ b/libeos-updater-util/meson.build
@@ -36,7 +36,7 @@ libeos_updater_util_deps = [
   dependency('gobject-2.0', version: '>= 2.62'),
   dependency('json-glib-1.0', version: '>= 1.2.6'),
   dependency('libsoup-2.4'),
-  dependency('ostree-1', version: '>= 2018.6'),
+  dependency('ostree-1', version: '>= 2019.2'),
 ]
 
 enums = gnome.mkenums_simple('enums',

--- a/libeos-updater-util/tests/meson.build
+++ b/libeos-updater-util/tests/meson.build
@@ -4,7 +4,7 @@ deps = [
   dependency('glib-2.0', version: '>= 2.62.0'),
   dependency('gobject-2.0', version: '>= 2.44'),
   dependency('json-glib-1.0', version: '>= 1.2.6'),
-  dependency('ostree-1', version: '>= 2018.6'),
+  dependency('ostree-1', version: '>= 2019.2'),
   dependency('libsoup-2.4'),
   libeos_updater_util_dep,
 ]

--- a/test-common/convenience.c
+++ b/test-common/convenience.c
@@ -128,6 +128,7 @@ etc_set_up_client_synced_to_server (EtcData *data)
                                       default_collection_ref,
                                       default_vendor,
                                       default_product,
+                                      default_auto_bootloader,
                                       &error);
   g_assert_no_error (error);
 }

--- a/test-common/flatpak-spawn.c
+++ b/test-common/flatpak-spawn.c
@@ -56,6 +56,29 @@ test_spawn_flatpak_cmd_in_local_env (GFile                *updater_dir,
 }
 
 gboolean
+flatpak_init (GFile   *updater_dir,
+              GError **error)
+{
+  g_auto(CmdResult) cmd = CMD_RESULT_CLEARED;
+  CmdArg args[] =
+    {
+      { NULL, FLATPAK_BINARY },
+      { NULL, "list" },
+      { "user", NULL },
+      { NULL, NULL }
+    };
+  g_auto(GStrv) argv = build_cmd_args (args);
+
+  if (!test_spawn_flatpak_cmd_in_local_env (updater_dir,
+                                            (const gchar * const *) argv,
+                                            &cmd,
+                                            error))
+    return FALSE;
+
+  return cmd_result_ensure_ok (&cmd, error);
+}
+
+gboolean
 flatpak_remote_add (GFile        *updater_dir,
                     const gchar  *repo_name,
                     const gchar  *repo_directory,

--- a/test-common/flatpak-spawn.h
+++ b/test-common/flatpak-spawn.h
@@ -28,6 +28,9 @@
 
 G_BEGIN_DECLS
 
+gboolean flatpak_init (GFile   *updater_dir,
+                       GError **error);
+
 gboolean flatpak_remote_add (GFile        *updater_dir,
                              const gchar  *repo_name,
                              const gchar  *repo_directory,

--- a/test-common/meson.build
+++ b/test-common/meson.build
@@ -48,7 +48,7 @@ libeos_updater_test_common_deps = [
   dependency('gio-unix-2.0', version: '>= 2.62'),
   dependency('glib-2.0', version: '>= 2.70'),
   dependency('gobject-2.0', version: '>= 2.62'),
-  dependency('ostree-1', version: '>= 2018.6'),
+  dependency('ostree-1', version: '>= 2019.2'),
   libeos_updater_util_dep,
 ]
 

--- a/test-common/ostree-spawn.c
+++ b/test-common/ostree-spawn.c
@@ -165,6 +165,28 @@ copy_additional_metadata_args_from_hashtable (GArray      *cmd_args,
 }
 
 gboolean
+ostree_set_config (GFile        *repo,
+                   const gchar  *key,
+                   const gchar  *value,
+                   CmdResult    *cmd,
+                   GError      **error)
+{
+  CmdArg args[] =
+    {
+      { NULL, "config" },
+      { NULL, "set" },
+      { NULL, key },
+      { NULL, value },
+      { NULL, NULL }
+    };
+
+  return spawn_ostree_in_repo_args (repo,
+                                    args,
+                                    cmd,
+                                    error);
+}
+
+gboolean
 ostree_cmd_remote_set_collection_id (GFile        *repo,
                                      const gchar  *remote_name,
                                      const gchar  *collection_id,

--- a/test-common/ostree-spawn.h
+++ b/test-common/ostree-spawn.h
@@ -41,6 +41,12 @@ gboolean ostree_init (GFile *repo,
                       CmdResult *cmd,
                       GError **error);
 
+gboolean ostree_set_config (GFile        *repo,
+                            const gchar  *key,
+                            const gchar  *value,
+                            CmdResult    *cmd,
+                            GError      **error);
+
 gboolean ostree_cmd_remote_set_collection_id (GFile        *repo,
                                               const gchar  *remote_name,
                                               const gchar  *collection_id,

--- a/test-common/utils.c
+++ b/test-common/utils.c
@@ -45,6 +45,7 @@ const OstreeCollectionRef _default_collection_ref = { (gchar *) "com.endlessm.Co
 const OstreeCollectionRef *default_collection_ref = &_default_collection_ref;
 const gchar *const default_ostree_path = "OSTREE/PATH";
 const gchar *const default_remote_name = "REMOTE";
+const gboolean default_auto_bootloader = FALSE;
 const gchar *arch_override_name = "arch";
 const guint max_commit_number = 10;
 
@@ -1329,12 +1330,13 @@ prepare_client_sysroot (GFile *client_root,
                         const OstreeCollectionRef *collection_ref,
                         GFile *gpg_home,
                         const gchar *keyid,
+                        gboolean auto_bootloader,
                         GError **error)
 {
   g_autoptr(GFile) sysroot = get_sysroot_for_client (client_root);
   g_auto(CmdResult) cmd = CMD_RESULT_CLEARED;
   g_autoptr(GFile) gpg_key = NULL;
-  g_autoptr(GFile) repo = NULL;
+  g_autoptr(GFile) repo = get_repo_for_sysroot (sysroot);
   g_autofree gchar *refspec = NULL;
 
   if (!create_directory (sysroot,
@@ -1357,11 +1359,29 @@ prepare_client_sysroot (GFile *client_root,
   if (!cmd_result_ensure_ok (&cmd, error))
     return FALSE;
 
-  if (!setup_stub_uboot_config (sysroot, error))
-    return FALSE;
+  if (auto_bootloader)
+    {
+      /* Add a u-boot setup that should be automatically detected. */
+      if (!setup_stub_uboot_config (sysroot, error))
+        return FALSE;
+    }
+  else
+    {
+      /* Set the bootloader to none so only the boot loader spec entries
+       * are updated.
+       */
+      cmd_result_clear (&cmd);
+      if (!ostree_set_config (repo,
+                              "sysroot.bootloader",
+                              "none",
+                              &cmd,
+                              error))
+        return FALSE;
+      if (!cmd_result_ensure_ok (&cmd, error))
+        return FALSE;
+    }
 
   gpg_key = get_gpg_key_file_for_keyid (gpg_home, keyid);
-  repo = get_repo_for_sysroot (sysroot);
   cmd_result_clear (&cmd);
   if (!ostree_remote_add (repo,
                           remote_name,
@@ -1974,6 +1994,7 @@ eos_test_client_new (GFile *client_root,
                      const OstreeCollectionRef *collection_ref,
                      const gchar *vendor,
                      const gchar *product,
+                     gboolean auto_bootloader,
                      GError **error)
 {
   g_autoptr(EosTestClient) client = NULL;
@@ -1995,6 +2016,7 @@ eos_test_client_new (GFile *client_root,
                                collection_ref,
                                subserver->gpg_home,
                                subserver->keyid,
+                               auto_bootloader,
                                error))
     return FALSE;
 
@@ -2010,6 +2032,7 @@ eos_test_client_new (GFile *client_root,
   client->product = g_strdup (product);
   client->remote_name = g_strdup (remote_name);
   client->ostree_path = g_strdup (subserver->ostree_path);
+  client->auto_bootloader = auto_bootloader;
   return g_steal_pointer (&client);
 }
 

--- a/test-common/utils.h
+++ b/test-common/utils.h
@@ -53,6 +53,7 @@ extern const gchar *const default_ref;
 extern const OstreeCollectionRef *default_collection_ref;
 extern const gchar *const default_ostree_path;
 extern const gchar *const default_remote_name;
+extern const gboolean default_auto_bootloader;
 
 typedef struct {
   guint sequence_number;
@@ -225,6 +226,7 @@ struct _EosTestClient
   gchar *cpuinfo;
   gchar *cmdline;
   gchar *uname_machine;
+  gboolean auto_bootloader;
   gboolean is_split_disk;
   gboolean flatpak_repo_is_symlink;
   gboolean force_follow_checkpoint;
@@ -243,6 +245,7 @@ EosTestClient *eos_test_client_new (GFile *client_root,
                                     const OstreeCollectionRef *collection_ref,
                                     const gchar *vendor,
                                     const gchar *product,
+                                    gboolean auto_bootloader,
                                     GError **error);
 
 

--- a/test-common/utils.h
+++ b/test-common/utils.h
@@ -226,6 +226,7 @@ struct _EosTestClient
   gchar *cmdline;
   gchar *uname_machine;
   gboolean is_split_disk;
+  gboolean flatpak_repo_is_symlink;
   gboolean force_follow_checkpoint;
 };
 
@@ -253,6 +254,8 @@ void eos_test_client_set_cpuinfo (EosTestClient *client,
                                   const gchar   *cpuinfo);
 void eos_test_client_set_cmdline (EosTestClient *client,
                                   const gchar   *cmdline);
+void eos_test_client_set_flatpak_repo_is_symlink (EosTestClient *client,
+                                                  gboolean flatpak_repo_is_symlink);
 void eos_test_client_set_force_follow_checkpoint (EosTestClient *client,
                                                   gboolean       force_follow_checkpoint);
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2,7 +2,7 @@ deps = [
   dependency('gio-2.0', version: '>= 2.60.1'),
   dependency('glib-2.0', version: '>= 2.62.0'),
   dependency('gobject-2.0', version: '>= 2.44'),
-  dependency('ostree-1', version: '>= 2018.6'),
+  dependency('ostree-1', version: '>= 2019.2'),
   libeos_updater_test_common_dep,
   libeos_updater_util_dep,
 ]

--- a/tests/test-update-direct.c
+++ b/tests/test-update-direct.c
@@ -81,6 +81,7 @@ setup_basic_test_server_client (EosUpdaterFixture *fixture,
                                 default_collection_ref,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 error);
 
   if (client == NULL)

--- a/tests/test-update-from-lan.c
+++ b/tests/test-update-from-lan.c
@@ -86,6 +86,7 @@ test_update_from_lan (EosUpdaterFixture *fixture,
                                 default_collection_ref,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 
@@ -119,6 +120,7 @@ test_update_from_lan (EosUpdaterFixture *fixture,
                                         default_collection_ref,
                                         default_vendor,
                                         default_product,
+                                        default_auto_bootloader,
                                         &error);
       g_assert_no_error (error);
 

--- a/tests/test-update-from-main.c
+++ b/tests/test-update-from-main.c
@@ -82,6 +82,7 @@ test_update_from_main (EosUpdaterFixture *fixture,
                                 default_collection_ref,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 

--- a/tests/test-update-from-volume.c
+++ b/tests/test-update-from-volume.c
@@ -79,6 +79,7 @@ test_update_from_volume (EosUpdaterFixture *fixture,
                                  default_collection_ref,
                                  default_vendor,
                                  default_product,
+                                 default_auto_bootloader,
                                  &error);
   g_assert_no_error (error);
 
@@ -98,6 +99,7 @@ test_update_from_volume (EosUpdaterFixture *fixture,
                                  default_collection_ref,
                                  default_vendor,
                                  default_product,
+                                 default_auto_bootloader,
                                  &error);
   g_assert_no_error (error);
 

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -1573,17 +1573,39 @@ test_update_refspec_checkpoint_eos3a_eos4 (EosUpdaterFixture *fixture,
   CheckpointTestData tests[] =
     {
       /* Normal system */
-      { NULL, NULL, NULL, NULL, FALSE, NULL, NULL, NULL, FALSE, TRUE },
-      { NULL, NULL, NULL, NULL, FALSE, NULL, NULL, NULL, TRUE, TRUE },
+      {
+        .expect_checkpoint_followed = TRUE,
+      },
+      {
+        .force_follow_checkpoint = TRUE,
+        .expect_checkpoint_followed = TRUE,
+      },
 
       /* Split disk */
-      { NULL, NULL, NULL, NULL, TRUE, NULL, NULL, NULL, FALSE, FALSE },
-      { NULL, NULL, NULL, NULL, TRUE, NULL, NULL, NULL, TRUE, TRUE },
+      {
+        .is_split_disk = TRUE,
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .is_split_disk = TRUE,
+        .force_follow_checkpoint = TRUE,
+        .expect_checkpoint_followed = TRUE,
+      },
 
       /* aarch64 */
-      { NULL, NULL, NULL, NULL, FALSE, "x86_64", NULL, NULL, FALSE, TRUE },
-      { NULL, NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
-      { NULL, NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, TRUE, TRUE },
+      {
+        .uname_machine = "x86_64",
+        .expect_checkpoint_followed = TRUE,
+      },
+      {
+        .uname_machine = "aarch64",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .uname_machine = "aarch64",
+        .force_follow_checkpoint = TRUE,
+        .expect_checkpoint_followed = TRUE,
+      },
 
       /* Ref matching. When the ref does not match the expected "eos3a"
        * and "eos4" patterns, the checkpoint is followed. Since that
@@ -1591,42 +1613,147 @@ test_update_refspec_checkpoint_eos3a_eos4 (EosUpdaterFixture *fixture,
        * refs, the machine is set to aarch64. The result being that the
        * checkpoint is skipped for ref matches and followed for ref
        * mismatches. */
-      { "os/eos/arm64/eos3", NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, TRUE },
-      { "os/eos/arm64/eos3a2", NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, TRUE },
-      { NULL, "os/eos/arm64/eos3b", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
-      { NULL, "os/eos/arm64/eos4a", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
-      { "os/eos/arm64/eos3a", NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
-      { NULL, "os/eos/arm64/eos4", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
-      { "os/eos/arm64/eos3a", "os/eos/arm64/eos4", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
-      { "os/eos/arm64/eos3a", "os/eos/arm64/latest1", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
-      { "os/eos/arm64/eos3a", "os/eos/arm64/eos4", NULL, NULL, FALSE, "aarch64", NULL, NULL, TRUE, TRUE },
+      {
+        .src_ref = "os/eos/arm64/eos3",
+        .uname_machine = "aarch64",
+        .expect_checkpoint_followed = TRUE,
+      },
+      {
+        .src_ref = "os/eos/arm64/eos3a2",
+        .uname_machine = "aarch64",
+        .expect_checkpoint_followed = TRUE,
+      },
+      {
+        .tgt_ref = "os/eos/arm64/eos3b",
+        .uname_machine = "aarch64",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .tgt_ref = "os/eos/arm64/eos4a",
+        .uname_machine = "aarch64",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .src_ref = "os/eos/arm64/eos3a",
+        .uname_machine = "aarch64",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .tgt_ref = "os/eos/arm64/eos4",
+        .uname_machine = "aarch64",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .src_ref = "os/eos/arm64/eos3a",
+        .tgt_ref = "os/eos/arm64/eos4",
+        .uname_machine = "aarch64",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .src_ref = "os/eos/arm64/eos3a",
+        .tgt_ref = "os/eos/arm64/latest1",
+        .uname_machine = "aarch64",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .src_ref = "os/eos/arm64/eos3a",
+        .tgt_ref = "os/eos/arm64/eos4",
+        .uname_machine = "aarch64",
+        .force_follow_checkpoint = TRUE,
+        .expect_checkpoint_followed = TRUE,
+      },
 
       /* Ref matching. When the ref matches the "nexthw/eos3.9", the checkpoint
        * is followed. It should allow updating to "eos4" directly.
        * https://phabricator.endlessm.com/T32542 */
-      { "os/eos/nexthw/eos3.9", NULL, NULL, NULL, FALSE, NULL, NULL, NULL, FALSE, TRUE },
+      {
+        .src_ref = "os/eos/nexthw/eos3.9",
+        .expect_checkpoint_followed = TRUE,
+      },
 
       /* Asus with i-8565U CPU */
-      { NULL, NULL, NULL, NULL, FALSE, NULL, cpuinfo_i8565u, NULL, FALSE, TRUE },
-      { NULL, NULL, "Asus", NULL, FALSE, NULL, cpuinfo_not_i8565u, NULL, FALSE, TRUE },
-      { NULL, NULL, "Asus", NULL, FALSE, NULL, cpuinfo_i8565u, NULL, FALSE, FALSE },
-      { NULL, NULL, "Asus", NULL, FALSE, NULL, cpuinfo_i8565u, NULL, TRUE, TRUE },
+      {
+        .cpuinfo = cpuinfo_i8565u,
+        .expect_checkpoint_followed = TRUE,
+      },
+      {
+        .sys_vendor = "Asus",
+        .cpuinfo = cpuinfo_not_i8565u,
+        .expect_checkpoint_followed = TRUE,
+      },
+      {
+        .sys_vendor = "Asus",
+        .cpuinfo = cpuinfo_i8565u,
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .sys_vendor = "Asus",
+        .cpuinfo = cpuinfo_i8565u,
+        .force_follow_checkpoint = TRUE,
+        .expect_checkpoint_followed = TRUE,
+      },
 
       /* Various systems unsupported by the new kernel */
-      { NULL, NULL, "Acer", "Aspire ES1-533", FALSE, NULL, NULL, NULL, FALSE, FALSE },
-      { NULL, NULL, "Acer", "Aspire ES1-732", FALSE, NULL, NULL, NULL, FALSE, FALSE },
-      { NULL, NULL, "Acer", "Veriton Z4660G", FALSE, NULL, NULL, NULL, FALSE, FALSE },
-      { NULL, NULL, "Acer", "Veriton Z4860G", FALSE, NULL, NULL, NULL, FALSE, FALSE },
-      { NULL, NULL, "Acer", "Veriton Z6860G", FALSE, NULL, NULL, NULL, FALSE, FALSE },
-      { NULL, NULL, "ASUSTeK COMPUTER INC.", "Z550MA", FALSE, NULL, NULL, NULL, FALSE, FALSE },
-      { NULL, NULL, "Endless", "ELT-JWM", FALSE, NULL, NULL, NULL, FALSE, FALSE },
-      { NULL, NULL, "Endless", "ELT-JWM", FALSE, NULL, NULL, NULL, TRUE, TRUE },
+      {
+        .sys_vendor = "Acer",
+        .product_name = "Aspire ES1-533",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .sys_vendor = "Acer",
+        .product_name = "Aspire ES1-732",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .sys_vendor = "Acer",
+        .product_name = "Veriton Z4660G",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .sys_vendor = "Acer",
+        .product_name = "Veriton Z4860G",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .sys_vendor = "Acer",
+        .product_name = "Veriton Z6860G",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .sys_vendor = "ASUSTeK COMPUTER INC.",
+        .product_name = "Z550MA",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .sys_vendor = "Endless",
+        .product_name = "ELT-JWM",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .sys_vendor = "Endless",
+        .product_name = "ELT-JWM",
+        .force_follow_checkpoint = TRUE,
+        .expect_checkpoint_followed = TRUE,
+      },
 
       /* Read-only in kernel command line args */
-      { NULL, NULL, NULL, NULL, FALSE, NULL, NULL, cmdline_not_ro, FALSE, TRUE },
-      { NULL, NULL, NULL, NULL, FALSE, NULL, NULL, cmdline_ro_end, FALSE, FALSE },
-      { NULL, NULL, NULL, NULL, FALSE, NULL, NULL, cmdline_ro_middle, FALSE, FALSE },
-      { NULL, NULL, NULL, NULL, FALSE, NULL, NULL, cmdline_ro_end, TRUE, TRUE },
+      {
+        .cmdline = cmdline_not_ro,
+        .expect_checkpoint_followed = TRUE,
+      },
+      {
+        .cmdline = cmdline_ro_end,
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .cmdline = cmdline_ro_middle,
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .cmdline = cmdline_ro_end,
+        .force_follow_checkpoint = TRUE,
+        .expect_checkpoint_followed = TRUE,
+      },
     };
 
   if (eos_test_skip_chroot ())
@@ -1663,20 +1790,58 @@ test_update_refspec_checkpoint_latest1_latest2 (EosUpdaterFixture *fixture,
   CheckpointTestData tests[] =
     {
       /* Normal system */
-      { NULL, NULL, NULL, NULL, FALSE, NULL, NULL, NULL, FALSE, TRUE },
-      { NULL, NULL, NULL, NULL, FALSE, NULL, NULL, NULL, TRUE, TRUE },
+      {
+        .expect_checkpoint_followed = TRUE,
+      },
+      {
+        .force_follow_checkpoint = TRUE,
+        .expect_checkpoint_followed = TRUE,
+      },
 
       /* Platforms: x86_64 and aarch64 */
-      { NULL, NULL, NULL, NULL, FALSE, "x86_64", NULL, NULL, FALSE, TRUE },
-      { NULL, NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, TRUE },
+      {
+        .uname_machine = "x86_64",
+        .expect_checkpoint_followed = TRUE,
+      },
+      {
+        .uname_machine = "aarch64",
+        .expect_checkpoint_followed = TRUE,
+      },
 
       /* Various systems unsupported by the new kernel */
-      { NULL, NULL, "Endless", "EE-200", FALSE, NULL, NULL, NULL, FALSE, FALSE },
-      { NULL, NULL, "Endless", "EE-200", FALSE, NULL, NULL, NULL, TRUE, TRUE },
-      { NULL, NULL, "Standard", "EF20", FALSE, NULL, NULL, NULL, FALSE, FALSE },
-      { NULL, NULL, "Standard", "EF20", FALSE, NULL, NULL, NULL, TRUE, TRUE },
-      { NULL, NULL, "Standard", "EF20EA", FALSE, NULL, NULL, NULL, FALSE, FALSE },
-      { NULL, NULL, "Standard", "EF20EA", FALSE, NULL, NULL, NULL, TRUE, TRUE },
+      {
+        .sys_vendor = "Endless",
+        .product_name = "EE-200",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .sys_vendor = "Endless",
+        .product_name = "EE-200",
+        .force_follow_checkpoint = TRUE,
+        .expect_checkpoint_followed = TRUE,
+      },
+      {
+        .sys_vendor = "Standard",
+        .product_name = "EF20",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .sys_vendor = "Standard",
+        .product_name = "EF20",
+        .force_follow_checkpoint = TRUE,
+        .expect_checkpoint_followed = TRUE,
+      },
+      {
+        .sys_vendor = "Standard",
+        .product_name = "EF20EA",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .sys_vendor = "Standard",
+        .product_name = "EF20EA",
+        .force_follow_checkpoint = TRUE,
+        .expect_checkpoint_followed = TRUE,
+      },
     };
 
   if (eos_test_skip_chroot ())

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -1589,10 +1589,10 @@ test_update_refspec_checkpoint_eos3a_eos4 (EosUpdaterFixture *fixture,
        * refs, the machine is set to aarch64. The result being that the
        * checkpoint is skipped for ref matches and followed for ref
        * mismatches. */
-      { "eos3", NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, TRUE },
-      { "eos3a2", NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, TRUE },
-      { NULL, "eos3b", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
-      { NULL, "eos4a", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
+      { "os/eos/arm64/eos3", NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, TRUE },
+      { "os/eos/arm64/eos3a2", NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, TRUE },
+      { NULL, "os/eos/arm64/eos3b", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
+      { NULL, "os/eos/arm64/eos4a", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
       { "os/eos/arm64/eos3a", NULL, NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
       { NULL, "os/eos/arm64/eos4", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
       { "os/eos/arm64/eos3a", "os/eos/arm64/eos4", NULL, NULL, FALSE, "aarch64", NULL, NULL, FALSE, FALSE },
@@ -1602,7 +1602,7 @@ test_update_refspec_checkpoint_eos3a_eos4 (EosUpdaterFixture *fixture,
       /* Ref matching. When the ref matches the "nexthw/eos3.9", the checkpoint
        * is followed. It should allow updating to "eos4" directly.
        * https://phabricator.endlessm.com/T32542 */
-      { "nexthw/eos3.9", NULL, NULL, NULL, FALSE, NULL, NULL, NULL, FALSE, TRUE },
+      { "os/eos/nexthw/eos3.9", NULL, NULL, NULL, FALSE, NULL, NULL, NULL, FALSE, TRUE },
 
       /* Asus with i-8565U CPU */
       { NULL, NULL, NULL, NULL, FALSE, NULL, cpuinfo_i8565u, NULL, FALSE, TRUE },
@@ -1640,8 +1640,8 @@ test_update_refspec_checkpoint_eos3a_eos4 (EosUpdaterFixture *fixture,
     {
       g_test_message ("Test eos3a to eos4 %" G_GSIZE_FORMAT, i);
 
-      tests[i].src_ref = tests[i].src_ref ? tests[i].src_ref : "eos3a";
-      tests[i].tgt_ref = tests[i].tgt_ref ? tests[i].tgt_ref : "eos4";
+      tests[i].src_ref = tests[i].src_ref ? tests[i].src_ref : "os/eos/amd64/eos3a";
+      tests[i].tgt_ref = tests[i].tgt_ref ? tests[i].tgt_ref : "os/eos/amd64/eos4";
       tests[i].sys_vendor = tests[i].sys_vendor ? tests[i].sys_vendor : default_vendor;
       tests[i].product_name = tests[i].product_name ? tests[i].product_name : default_product;
       do_update_refspec_checkpoint (fixture, user_data, &tests[i], host_is_aarch64);

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -29,6 +29,8 @@
 #include <locale.h>
 #include <sys/utsname.h>
 
+const gchar *default_src_ref = "os/eos/amd64/eos3a";
+const gchar *default_tgt_ref = "os/eos/amd64/eos4";
 const gchar *next_ref = "REFv2";
 const OstreeCollectionRef _next_collection_ref = { (gchar *) "com.endlessm.CollectionId", (gchar *) "REFv2" };
 const OstreeCollectionRef *next_collection_ref = &_next_collection_ref;
@@ -1413,10 +1415,10 @@ do_update_refspec_checkpoint (EosUpdaterFixture  *fixture,
                               CheckpointTestData *test_machine,
                               gboolean            host_is_aarch64)
 {
-  const gchar *src_ref = test_machine->src_ref;
+  const gchar *src_ref = test_machine->src_ref ? test_machine->src_ref : default_src_ref;
   const OstreeCollectionRef _src_collection_ref = { (gchar *) "com.endlessm.CollectionId", (gchar *) src_ref };
   const OstreeCollectionRef *src_collection_ref = &_src_collection_ref;
-  const gchar *tgt_ref = test_machine->tgt_ref;
+  const gchar *tgt_ref = test_machine->tgt_ref ? test_machine->tgt_ref : default_tgt_ref;
   const OstreeCollectionRef _tgt_collection_ref = { (gchar *) "com.endlessm.CollectionId", (gchar *) tgt_ref };
   const OstreeCollectionRef *tgt_collection_ref = &_tgt_collection_ref;
   g_autoptr(GFile) server_root = NULL;
@@ -1457,8 +1459,8 @@ do_update_refspec_checkpoint (EosUpdaterFixture  *fixture,
                                 default_remote_name,
                                 subserver,
                                 src_collection_ref,
-                                test_machine->sys_vendor,
-                                test_machine->product_name,
+                                test_machine->sys_vendor ? test_machine->sys_vendor : default_vendor,
+                                test_machine->product_name ? test_machine->product_name : default_product,
                                 &error);
   g_assert_no_error (error);
 
@@ -1640,10 +1642,6 @@ test_update_refspec_checkpoint_eos3a_eos4 (EosUpdaterFixture *fixture,
     {
       g_test_message ("Test eos3a to eos4 %" G_GSIZE_FORMAT, i);
 
-      tests[i].src_ref = tests[i].src_ref ? tests[i].src_ref : "os/eos/amd64/eos3a";
-      tests[i].tgt_ref = tests[i].tgt_ref ? tests[i].tgt_ref : "os/eos/amd64/eos4";
-      tests[i].sys_vendor = tests[i].sys_vendor ? tests[i].sys_vendor : default_vendor;
-      tests[i].product_name = tests[i].product_name ? tests[i].product_name : default_product;
       do_update_refspec_checkpoint (fixture, user_data, &tests[i], host_is_aarch64);
     }
 }
@@ -1696,8 +1694,6 @@ test_update_refspec_checkpoint_latest1_latest2 (EosUpdaterFixture *fixture,
 
       tests[i].src_ref = tests[i].src_ref ? tests[i].src_ref : "os/eos/amd64/latest1";
       tests[i].tgt_ref = tests[i].tgt_ref ? tests[i].tgt_ref : "os/eos/amd64/latest2";
-      tests[i].sys_vendor = tests[i].sys_vendor ? tests[i].sys_vendor : default_vendor;
-      tests[i].product_name = tests[i].product_name ? tests[i].product_name : default_product;
       do_update_refspec_checkpoint (fixture, user_data, &tests[i], host_is_aarch64);
     }
 }

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -1403,6 +1403,7 @@ typedef struct
   const gchar *uname_machine;  /* (nullable) for default */
   const gchar *cpuinfo;  /* (nullable) for default */
   const gchar *cmdline;  /* (nullable) for default */
+  gboolean flatpak_repo_is_symlink;
   gboolean force_follow_checkpoint;
 
   /* Results */
@@ -1430,6 +1431,8 @@ checkpoint_test_data_description (CheckpointTestData *data)
     g_ptr_array_add (fields, g_strdup_printf ("cpuinfo=%s", data->cpuinfo));
   if (data->cmdline)
     g_ptr_array_add (fields, g_strdup_printf ("cmdline=%s", data->cmdline));
+  if (data->flatpak_repo_is_symlink)
+    g_ptr_array_add (fields, g_strdup ("flatpak_repo_is_symlink=TRUE"));
   if (data->force_follow_checkpoint)
     g_ptr_array_add (fields, g_strdup ("force_follow_checkpoint=TRUE"));
 
@@ -1502,6 +1505,7 @@ do_update_refspec_checkpoint (EosUpdaterFixture  *fixture,
   eos_test_client_set_uname_machine (client, test_machine->uname_machine);
   eos_test_client_set_cpuinfo (client, test_machine->cpuinfo);
   eos_test_client_set_cmdline (client, test_machine->cmdline);
+  eos_test_client_set_flatpak_repo_is_symlink (client, test_machine->flatpak_repo_is_symlink);
   eos_test_client_set_force_follow_checkpoint (client, test_machine->force_follow_checkpoint);
 
   g_hash_table_insert (leaf_commit_nodes,
@@ -1872,6 +1876,17 @@ test_update_refspec_checkpoint_latest1_latest2 (EosUpdaterFixture *fixture,
       {
         .sys_vendor = "Standard",
         .product_name = "EF20EA",
+        .force_follow_checkpoint = TRUE,
+        .expect_checkpoint_followed = TRUE,
+      },
+
+      /* Merged flatpak repo */
+      {
+        .flatpak_repo_is_symlink = TRUE,
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .flatpak_repo_is_symlink = TRUE,
         .force_follow_checkpoint = TRUE,
         .expect_checkpoint_followed = TRUE,
       },

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -1414,6 +1414,7 @@ typedef struct
   const gchar *cpuinfo;  /* (nullable) for default */
   const gchar *cmdline;  /* (nullable) for default */
   gboolean flatpak_repo_is_symlink;
+  gboolean auto_bootloader;
   gboolean force_follow_checkpoint;
 
   /* Results */
@@ -1443,6 +1444,8 @@ checkpoint_test_data_description (CheckpointTestData *data)
     g_ptr_array_add (fields, g_strdup_printf ("cmdline=%s", data->cmdline));
   if (data->flatpak_repo_is_symlink)
     g_ptr_array_add (fields, g_strdup ("flatpak_repo_is_symlink=TRUE"));
+  if (data->auto_bootloader)
+    g_ptr_array_add (fields, g_strdup ("auto_bootloader=TRUE"));
   if (data->force_follow_checkpoint)
     g_ptr_array_add (fields, g_strdup ("force_follow_checkpoint=TRUE"));
 
@@ -1506,7 +1509,7 @@ do_update_refspec_checkpoint (EosUpdaterFixture  *fixture,
                                 src_collection_ref,
                                 test_machine->sys_vendor ? test_machine->sys_vendor : default_vendor,
                                 test_machine->product_name ? test_machine->product_name : default_product,
-                                default_auto_bootloader,
+                                test_machine->auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 
@@ -1898,6 +1901,17 @@ test_update_refspec_checkpoint_latest1_latest2 (EosUpdaterFixture *fixture,
       },
       {
         .flatpak_repo_is_symlink = TRUE,
+        .force_follow_checkpoint = TRUE,
+        .expect_checkpoint_followed = TRUE,
+      },
+
+      /* Auto bootloader */
+      {
+        .auto_bootloader = TRUE,
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .auto_bootloader = TRUE,
         .force_follow_checkpoint = TRUE,
         .expect_checkpoint_followed = TRUE,
       },

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -178,6 +178,7 @@ test_update_refspec_checkpoint (EosUpdaterFixture *fixture,
                                 default_collection_ref,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 
@@ -317,6 +318,7 @@ test_update_refspec_checkpoint_old_ref_deleted (EosUpdaterFixture *fixture,
                                 default_collection_ref,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 
@@ -412,6 +414,7 @@ test_update_refspec_checkpoint_even_if_downgrade (EosUpdaterFixture *fixture,
                                 default_collection_ref,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 
@@ -525,6 +528,7 @@ test_update_refspec_checkpoint_no_collection_ref_server (EosUpdaterFixture *fixt
                                 default_collection_ref_no_id,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 
@@ -628,6 +632,7 @@ test_update_refspec_checkpoint_malformed_checkpoint (EosUpdaterFixture *fixture,
                                 default_collection_ref,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 
@@ -745,6 +750,7 @@ test_update_refspec_checkpoint_malformed_checkpoint_recovery (EosUpdaterFixture 
                                 default_collection_ref,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 
@@ -899,6 +905,7 @@ test_update_refspec_checkpoint_no_collection_ref_client (EosUpdaterFixture *fixt
                                 default_collection_ref_no_id,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 
@@ -1012,6 +1019,7 @@ test_update_refspec_checkpoint_continue_old_branch (EosUpdaterFixture *fixture,
                                 default_collection_ref,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 
@@ -1159,6 +1167,7 @@ test_update_refspec_checkpoint_continue_old_branch_then_new_branch (EosUpdaterFi
                                 default_collection_ref,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 
@@ -1336,6 +1345,7 @@ test_update_refspec_checkpoint_ignore_remote (EosUpdaterFixture *fixture,
                                 default_collection_ref,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 
@@ -1496,6 +1506,7 @@ do_update_refspec_checkpoint (EosUpdaterFixture  *fixture,
                                 src_collection_ref,
                                 test_machine->sys_vendor ? test_machine->sys_vendor : default_vendor,
                                 test_machine->product_name ? test_machine->product_name : default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 

--- a/tests/test-update-refspec-endoflife.c
+++ b/tests/test-update-refspec-endoflife.c
@@ -181,6 +181,7 @@ _test_update_refspec_endoflife (EosUpdaterFixture *fixture,
                                 collection_ref,
                                 default_vendor,
                                 default_product,
+                                default_auto_bootloader,
                                 &error);
   g_assert_no_error (error);
 


### PR DESCRIPTION
This adds checkpoints to:

* Confirm `/var/lib/flatpak/repo` has been split from `/ostree/repo`
* Confirm that the `sysroot.bootloader` option is set in the `/ostree/repo` config

before allowing upgrade from eos4 → eos5.

Both of the actual checks were pretty simple. I ended up spending much more time mucking with the test suite. Probably some of that can be split out to a separate PR if desired.

https://phabricator.endlessm.com/T34110