### PR TITLE
eos-updater: Add a new UpdateIsUserVisible D-Bus property and implicitly set it if the major version in an update differs from what’s booted

### DIFF
--- a/eos-updater/com.endlessm.Updater.xml
+++ b/eos-updater/com.endlessm.Updater.xml
@@ -186,6 +186,15 @@
     <property name="Version" type="s" access="read"/>
 
     <!--
+      UpdateIsUserVisible:
+
+      If the update contains significant user visible changes which should be
+      notified to the user in advance of the update being applied, this is
+      `True`. Otherwise, or if no update is available, this is `False`.
+    -->
+    <property name="UpdateIsUserVisible" type="b" access="read"/>
+
+    <!--
       DownloadSize:
 
       Size (in bytes) of the update when downloaded, or `-1` if an update is

--- a/eos-updater/main.c
+++ b/eos-updater/main.c
@@ -148,6 +148,7 @@ on_bus_acquired (GDBusConnection *connection,
       eos_updater_set_downloaded_bytes (updater, 0);
       eos_updater_set_unpacked_size (updater, 0);
       eos_updater_set_update_id (updater, "");
+      eos_updater_set_update_is_user_visible (updater, FALSE);
       eos_updater_clear_error (updater, EOS_UPDATER_STATE_READY);
     }
   else if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND) ||

--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -84,6 +84,33 @@ async_result_cb (GObject      *source_object,
   *result_out = g_object_ref (result);
 }
 
+/* Returns a strcmp()-like integer, negative if @version_a < @version_b, zero if
+ * they’re equal (or the comparison is invalid), positive if
+ * @version_a > @version_b. */
+static int
+compare_major_versions (const char *version_a,
+                        const char *version_b)
+{
+  guint64 version_a_major, version_b_major;
+
+  if (version_a == NULL || version_b == NULL)
+    return 0;
+
+  /* Take the first whole integer off each string, and assume it’s the major
+   * version number. This should work regardless of whether the strings are in
+   * `X.Y.Z` form or `X.Y` or `X`. Note that this parsing is locale
+   * independent. */
+  version_a_major = g_ascii_strtoull (version_a, NULL, 10);
+  version_b_major = g_ascii_strtoull (version_b, NULL, 10);
+
+  if (version_a_major > version_b_major)
+    return 1;
+  else if (version_a_major < version_b_major)
+    return -1;
+  else
+    return 0;
+}
+
 /**
  * is_checksum_an_update:
  * @repo: the #OstreeRepo
@@ -93,6 +120,10 @@ async_result_cb (GObject      *source_object,
  * @out_commit: (not optional) (nullable) (out) (transfer full): return location
  *   for the #GVariant containing the commit identified by @update_checksum *if*
  *   it is an update compared to @booted_ref; %NULL is returned otherwise
+ * @out_is_update_user_visible: (not optional) (out): return location for a
+ *   boolean indicating whether the update to @update_checksum contains user
+ *   visible changes which should be highlighted to the user; always returns
+ *   %FALSE when @out_commit returns %NULL
  * @error: return location for a #GError, or %NULL
  *
  * Checks whether an update from @booted_ref to @update_ref would actually be
@@ -111,22 +142,29 @@ is_checksum_an_update (OstreeRepo *repo,
                        const gchar *booted_ref,
                        const gchar *update_ref,
                        GVariant **out_commit,
+                       gboolean *out_is_update_user_visible,
                        GError **error)
 {
   g_autoptr(GVariant) current_commit = NULL;
   g_autoptr(GVariant) update_commit = NULL;
+  g_autoptr(GVariant) current_commit_metadata = NULL;
+  g_autoptr(GVariant) update_commit_metadata = NULL;
   g_autofree gchar *booted_checksum = NULL;
   gboolean is_newer;
+  gboolean is_update_user_visible;
   guint64 update_timestamp, current_timestamp;
+  const char *current_version = NULL, *update_version = NULL;
   g_autoptr(GError) local_error = NULL;
 
   g_return_val_if_fail (OSTREE_IS_REPO (repo), FALSE);
   g_return_val_if_fail (update_checksum != NULL, FALSE);
   g_return_val_if_fail (out_commit != NULL, FALSE);
+  g_return_val_if_fail (out_is_update_user_visible != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
   /* Default output. */
   *out_commit = NULL;
+  *out_is_update_user_visible = FALSE;
 
   booted_checksum = eos_updater_get_booted_checksum (error);
   if (booted_checksum == NULL)
@@ -160,8 +198,17 @@ is_checksum_an_update (OstreeRepo *repo,
   if (current_commit == NULL)
     {
       *out_commit = g_steal_pointer (&update_commit);
+      *out_is_update_user_visible = FALSE;
       return TRUE;
     }
+
+  /* Look up the versions on the current and update commits, so we can determine
+   * if there are meant to be any user visible changes in the update. */
+  current_commit_metadata = g_variant_get_child_value (current_commit, 0);
+  g_variant_lookup (current_commit_metadata, OSTREE_COMMIT_META_KEY_VERSION, "&s", &current_version);
+
+  update_commit_metadata = g_variant_get_child_value (update_commit, 0);
+  g_variant_lookup (update_commit_metadata, OSTREE_COMMIT_META_KEY_VERSION, "&s", &update_version);
 
   /* Determine if the new commit is newer than the old commit to prevent
    * inadvertent (or malicious) attempts to downgrade the system.
@@ -170,8 +217,10 @@ is_checksum_an_update (OstreeRepo *repo,
   current_timestamp = ostree_commit_get_timestamp (current_commit);
 
   g_debug ("%s: current_timestamp: %" G_GUINT64_FORMAT ", "
-           "update_timestamp: %" G_GUINT64_FORMAT,
-           G_STRFUNC, current_timestamp, update_timestamp);
+           "current_version: %s, update_timestamp: %" G_GUINT64_FORMAT ", "
+           "update_version: %s",
+           G_STRFUNC, current_timestamp, current_version,
+           update_timestamp, update_version);
 
   /* "Newer" if we are switching branches or the update timestamp
    * is greater than the timestamp of the current commit.
@@ -193,7 +242,14 @@ is_checksum_an_update (OstreeRepo *repo,
    */
   is_newer = (g_strcmp0 (booted_ref, update_ref) != 0 ||
               update_timestamp > current_timestamp);
+
+  /* We have explicit semantics on our version numbers, which are of the form
+   * `major.minor.micro`. Major versions contain user visible changes, minor
+   * versions are generally branch changes, and micro versions are bug fixes. */
+  is_update_user_visible = compare_major_versions (current_version, update_version) < 0;
+
   *out_commit = is_newer ? g_steal_pointer (&update_commit) : NULL;
+  *out_is_update_user_visible = is_newer ? is_update_user_visible : FALSE;
 
   return TRUE;
 }
@@ -275,6 +331,7 @@ eos_update_info_new (const gchar *checksum,
                      const gchar *new_refspec,
                      const gchar *old_refspec,
                      const gchar *version,
+                     gboolean is_user_visible,
                      const gchar * const *urls,
                      gboolean offline_results_only,
                      OstreeRepoFinderResult **results)
@@ -292,6 +349,7 @@ eos_update_info_new (const gchar *checksum,
   info->new_refspec = g_strdup (new_refspec);
   info->old_refspec = g_strdup (old_refspec);
   info->version = g_strdup (version);
+  info->is_user_visible = is_user_visible;
   info->urls = g_strdupv ((gchar **) urls);
   info->offline_results_only = offline_results_only;
   info->results = g_steal_pointer (&results);
@@ -1315,6 +1373,7 @@ eos_update_info_to_string (EosUpdateInfo *update)
   g_autoptr(GString) results_string = NULL;
   g_autofree gchar *results = NULL;
   const gchar *version = update->version;
+  const gchar *is_user_visible_str = NULL;
   gsize i;
 
   if (update->urls != NULL)
@@ -1343,11 +1402,14 @@ eos_update_info_to_string (EosUpdateInfo *update)
   if (version == NULL)
     version = "(no version information)";
 
-  return g_strdup_printf ("%s, %s, %s, %s, %s\n   %s%s",
+  is_user_visible_str = update->is_user_visible ? "user visible" : "not user visible";
+
+  return g_strdup_printf ("%s, %s, %s, %s, %s, %s\n   %s%s",
                           update->checksum,
                           update->new_refspec,
                           update->old_refspec,
                           version,
+                          is_user_visible_str,
                           timestamp_str,
                           update_urls,
                           results);
@@ -1640,6 +1702,7 @@ metadata_fetch_finished (GObject *object,
       eos_updater_set_update_refspec (updater, info->new_refspec);
       eos_updater_set_original_refspec (updater, info->old_refspec);
       eos_updater_set_version (updater, info->version);
+      eos_updater_set_update_is_user_visible (updater, info->is_user_visible);
 
       g_variant_get_child (info->commit, 3, "&s", &label);
       g_variant_get_child (info->commit, 4, "&s", &message);

--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -150,7 +150,7 @@ is_checksum_an_update (OstreeRepo *repo,
 
   g_debug ("%s: current_timestamp: %" G_GUINT64_FORMAT ", "
            "update_timestamp: %" G_GUINT64_FORMAT,
-           G_STRFUNC, update_timestamp, current_timestamp);
+           G_STRFUNC, current_timestamp, update_timestamp);
 
   /* "Newer" if we are switching branches or the update timestamp
    * is greater than the timestamp of the current commit.

--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -125,6 +125,9 @@ is_checksum_an_update (OstreeRepo *repo,
   g_return_val_if_fail (out_commit != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
+  /* Default output. */
+  *out_commit = NULL;
+
   booted_checksum = eos_updater_get_booted_checksum (error);
   if (booted_checksum == NULL)
     return FALSE;
@@ -134,10 +137,7 @@ is_checksum_an_update (OstreeRepo *repo,
    * on the server to be newer if the commit was re-generated from an
    * existing tree. */
   if (g_str_equal (booted_checksum, update_checksum))
-    {
-      *out_commit = NULL;
-      return TRUE;
-    }
+    return TRUE;
 
   g_debug ("%s: current: %s, update: %s", G_STRFUNC, booted_checksum, update_checksum);
 

--- a/eos-updater/poll-common.h
+++ b/eos-updater/poll-common.h
@@ -33,10 +33,10 @@ G_BEGIN_DECLS
 
 gboolean
 is_checksum_an_update (OstreeRepo *repo,
-                       const gchar *checksum,
+                       const gchar *update_checksum,
                        const gchar *booted_ref,
-                       const gchar *upgrade_ref,
-                       GVariant **commit,
+                       const gchar *update_ref,
+                       GVariant **out_commit,
                        GError **error);
 
 #define EOS_TYPE_METRICS_INFO eos_metrics_info_get_type ()

--- a/eos-updater/poll-common.h
+++ b/eos-updater/poll-common.h
@@ -37,6 +37,7 @@ is_checksum_an_update (OstreeRepo *repo,
                        const gchar *booted_ref,
                        const gchar *update_ref,
                        GVariant **out_commit,
+                       gboolean *out_is_update_user_visible,
                        GError **error);
 
 #define EOS_TYPE_METRICS_INFO eos_metrics_info_get_type ()
@@ -76,6 +77,7 @@ struct _EosUpdateInfo
   gchar *version;
   gchar **urls;
   gboolean offline_results_only;
+  gboolean is_user_visible;
 
   OstreeRepoFinderResult **results;  /* (owned) (array zero-terminated=1) */
 };
@@ -86,6 +88,7 @@ eos_update_info_new (const gchar *csum,
                      const gchar *new_refspec,
                      const gchar *old_refspec,
                      const gchar *version,
+                     gboolean is_user_visible,
                      const gchar * const *urls,
                      gboolean offline_results_only,
                      OstreeRepoFinderResult **results);

--- a/eos-updater/poll.c
+++ b/eos-updater/poll.c
@@ -489,24 +489,31 @@ check_for_update_following_checkpoint_commits (OstreeRepo     *repo,
                               error))
     return FALSE;
 
-  /* The "refspec" member is the *currently booted* refspec
-   * which may get cleaned up later if we change away from it. */
-  out_update_ref_info->refspec = g_steal_pointer (&booted_refspec);
+  if (commit != NULL)
+    {
+      /* The "refspec" member is the *currently booted* refspec
+       * which may get cleaned up later if we change away from it. */
+      out_update_ref_info->refspec = g_steal_pointer (&booted_refspec);
 
-  /* The "remote", "ref" and "collection_ref" refer here to the
-   * ref and remote that we should be following given checkpoints. */
-  out_update_ref_info->remote = g_steal_pointer (&remote);
-  out_update_ref_info->ref = g_steal_pointer (&ref);
+      /* The "remote", "ref" and "collection_ref" refer here to the
+       * ref and remote that we should be following given checkpoints. */
+      out_update_ref_info->remote = g_steal_pointer (&remote);
+      out_update_ref_info->ref = g_steal_pointer (&ref);
 
-  /* "collection_ref", "new_refspec" and "checksum" refer to the collection
-   * ref and refspec of the checksum that we will be pulling and updating to */
-  out_update_ref_info->collection_ref = g_steal_pointer (&collection_ref);
-  out_update_ref_info->new_refspec = g_steal_pointer (&new_refspec);
-  out_update_ref_info->checksum = g_steal_pointer (&checksum);
+      /* "collection_ref", "new_refspec" and "checksum" refer to the collection
+       * ref and refspec of the checksum that we will be pulling and updating to */
+      out_update_ref_info->collection_ref = g_steal_pointer (&collection_ref);
+      out_update_ref_info->new_refspec = g_steal_pointer (&new_refspec);
+      out_update_ref_info->checksum = g_steal_pointer (&checksum);
 
-  out_update_ref_info->results = g_steal_pointer (&results);
-  out_update_ref_info->version = g_steal_pointer (&version);
-  out_update_ref_info->commit = g_steal_pointer (&commit);
+      out_update_ref_info->results = g_steal_pointer (&results);
+      out_update_ref_info->version = g_steal_pointer (&version);
+      out_update_ref_info->commit = g_steal_pointer (&commit);
+    }
+  else
+    {
+      update_ref_info_clear (out_update_ref_info);
+    }
 
   return TRUE;
 }

--- a/eos-updater/poll.c
+++ b/eos-updater/poll.c
@@ -271,6 +271,7 @@ typedef struct {
   gchar *new_refspec;
   gchar *checksum;
   gchar *version;
+  gboolean is_user_visible;
   GVariant *commit;
 } UpdateRefInfo;
 
@@ -285,6 +286,7 @@ update_ref_info_init (UpdateRefInfo *update_ref_info)
   update_ref_info->new_refspec = NULL;
   update_ref_info->checksum = NULL;
   update_ref_info->version = NULL;
+  update_ref_info->is_user_visible = FALSE;
   update_ref_info->commit = NULL;
 }
 
@@ -350,6 +352,7 @@ check_for_update_using_booted_branch (OstreeRepo           *repo,
   gboolean is_update = FALSE;
   g_autofree gchar *checksum = NULL;
   g_autoptr(GVariant) commit = NULL;
+  gboolean is_update_user_visible = FALSE;
   g_autoptr(OstreeSysroot) sysroot = ostree_sysroot_new_default ();
   g_autoptr(OstreeDeployment) booted_deployment = NULL;
   g_auto(OstreeRepoFinderResultv) results = NULL;
@@ -387,6 +390,7 @@ check_for_update_using_booted_branch (OstreeRepo           *repo,
                               ref,
                               new_ref,
                               &commit,
+                              &is_update_user_visible,
                               error))
     return FALSE;
 
@@ -403,6 +407,7 @@ check_for_update_using_booted_branch (OstreeRepo           *repo,
       out_update_ref_info->new_refspec = g_steal_pointer (&new_refspec);
       out_update_ref_info->checksum = g_steal_pointer (&checksum);
       out_update_ref_info->version = g_steal_pointer (&version);
+      out_update_ref_info->is_user_visible = is_update_user_visible;
       out_update_ref_info->commit = g_steal_pointer (&commit);
     }
   else
@@ -432,6 +437,7 @@ check_for_update_following_checkpoint_commits (OstreeRepo     *repo,
   g_autofree gchar *version = NULL;
   g_autofree gchar *checksum = NULL;
   g_autoptr(GVariant) commit = NULL;
+  gboolean is_update_user_visible = FALSE;
   g_auto(OstreeRepoFinderResultv) results = NULL;
 
   g_return_val_if_fail (out_update_ref_info != NULL, FALSE);
@@ -486,6 +492,7 @@ check_for_update_following_checkpoint_commits (OstreeRepo     *repo,
                               booted_ref,
                               ref_after_following_rebases,
                               &commit,
+                              &is_update_user_visible,
                               error))
     return FALSE;
 
@@ -508,6 +515,7 @@ check_for_update_following_checkpoint_commits (OstreeRepo     *repo,
 
       out_update_ref_info->results = g_steal_pointer (&results);
       out_update_ref_info->version = g_steal_pointer (&version);
+      out_update_ref_info->is_user_visible = is_update_user_visible;
       out_update_ref_info->commit = g_steal_pointer (&commit);
     }
   else
@@ -631,6 +639,7 @@ metadata_fetch_new (OstreeRepo    *repo,
                                   update_ref_info.new_refspec,
                                   update_ref_info.refspec,
                                   update_ref_info.version,
+                                  update_ref_info.is_user_visible,
                                   NULL,
                                   offline_results_only,
                                   g_steal_pointer (&update_ref_info.results));
@@ -679,6 +688,7 @@ metadata_fetch_from_main (OstreeRepo     *repo,
                                 update_ref_info.new_refspec,
                                 update_ref_info.refspec,
                                 update_ref_info.version,
+                                update_ref_info.is_user_visible,
                                 NULL,
                                 FALSE,
                                 NULL);

--- a/tests/test-update-direct.c
+++ b/tests/test-update-direct.c
@@ -57,6 +57,11 @@ setup_basic_test_server_client (EosUpdaterFixture *fixture,
   g_autoptr(EosTestSubserver) subserver = NULL;
   g_autoptr(GFile) client_root = NULL;
   g_autoptr(EosTestClient) client = NULL;
+  g_autoptr(GHashTable) additional_metadata_for_commit = NULL;
+
+  /* Arbitrarily say that the currently booted commit is version 1.0.0. */
+  eos_test_add_metadata_for_commit (&additional_metadata_for_commit,
+                                    0, "version", "1.0.0");
 
   server_root = g_file_get_child (fixture->tmpdir, "main");
   server = eos_test_server_new_quick (server_root,
@@ -67,7 +72,8 @@ setup_basic_test_server_client (EosUpdaterFixture *fixture,
                                       fixture->gpg_home,
                                       keyid,
                                       default_ostree_path,
-                                      NULL, NULL, NULL,
+                                      NULL, NULL,
+                                      additional_metadata_for_commit,
                                       error);
 
   if (server == NULL)
@@ -375,6 +381,84 @@ test_update_version (EosUpdaterFixture *fixture,
   g_assert_cmpstr (eos_updater_get_version (updater), ==, version);
 }
 
+/* Tests getting the UpdateIsUserVisible property for an update whose version is
+ * set to @user_data. */
+static void
+test_update_is_user_visible (EosUpdaterFixture *fixture,
+                             gconstpointer      user_data)
+{
+  g_autoptr(GError) error = NULL;
+  g_autoptr(EosTestServer) server = NULL;
+  g_autoptr(EosTestSubserver) subserver = NULL;
+  g_autoptr(EosTestClient) client = NULL;
+  g_autoptr(EosUpdater) updater = NULL;
+  g_autoptr(GHashTable) leaf_commit_nodes =
+    eos_test_subserver_ref_to_commit_new ();
+  DownloadSource main_source = DOWNLOAD_MAIN;
+  const gchar *update_version = (user_data != NULL) ? (const gchar *) user_data : "";
+
+  if (eos_test_skip_chroot ())
+    return;
+
+  setup_basic_test_server_client (fixture, &server, &subserver, &client, &error);
+  g_assert_no_error (error);
+
+  /* setup_basic_test_server_client() sets the booted commit to version 1.0.0,
+   * so @update_version will end up being compared against that. */
+  g_hash_table_insert (leaf_commit_nodes,
+                       ostree_collection_ref_dup (default_collection_ref),
+                       GUINT_TO_POINTER (1));
+  eos_test_add_metadata_for_commit (&subserver->additional_metadata_for_commit,
+                                    1, "version", update_version);
+
+  eos_test_subserver_populate_commit_graph_from_leaf_nodes (subserver,
+                                                            leaf_commit_nodes);
+  eos_test_subserver_update (subserver, &error);
+  g_assert_no_error (error);
+
+  eos_test_client_run_updater (client,
+                               &main_source,
+                               1,
+                               NULL,
+                               NULL,
+                               &error);
+  g_assert_no_error (error);
+
+  updater = eos_updater_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
+                                                G_DBUS_PROXY_FLAGS_NONE,
+                                                "com.endlessm.Updater",
+                                                "/com/endlessm/Updater",
+                                                NULL,
+                                                &error);
+  g_assert_no_error (error);
+
+  EosUpdaterState state = EOS_UPDATER_STATE_POLLING;
+  g_signal_connect (updater, "notify::state",
+                    G_CALLBACK (update_with_loop_state_changed_cb),
+                    &state);
+
+  /* start the state changes */
+  eos_updater_call_poll_sync (updater, NULL, &error);
+  g_assert_no_error (error);
+
+  gboolean timed_out = FALSE;
+  guint timeout_id = g_timeout_add_seconds (DEFAULT_TIMEOUT_SECS, timeout_cb, &timed_out);
+
+  while (state == EOS_UPDATER_STATE_POLLING && !timed_out)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_source_remove (timeout_id);
+
+  g_assert_false (timed_out);
+
+  g_assert_cmpuint (eos_updater_get_state (updater), ==, EOS_UPDATER_STATE_UPDATE_AVAILABLE);
+
+  if (update_version[0] == '1')
+    g_assert_false (eos_updater_get_update_is_user_visible (updater));
+  else
+    g_assert_true (eos_updater_get_update_is_user_visible (updater));
+}
+
 /* Tests getting an update when there is none available. */
 static void
 test_update_when_none_available (EosUpdaterFixture *fixture,
@@ -537,6 +621,8 @@ main (int argc,
   eos_test_add ("/updater/cancel-update", NULL, test_cancel_update);
   eos_test_add ("/updater/update-no-version", NULL, test_update_version);
   eos_test_add ("/updater/update-version", "1.2.3", test_update_version);
+  eos_test_add ("/updater/update-is-user-visible/minor", "1.3.0", test_update_is_user_visible);
+  eos_test_add ("/updater/update-is-user-visible/major", "2.0.0", test_update_is_user_visible);
   eos_test_add ("/updater/update-not-available", NULL, test_update_when_none_available);
   eos_test_add ("/updater/commit-sizes", NULL, test_update_sizes);
 

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -40,17 +40,6 @@ const OstreeCollectionRef *next_collection_ref = &_next_collection_ref;
 const OstreeCollectionRef _default_collection_ref_no_id = { NULL, (gchar *) "REF" };
 const OstreeCollectionRef *default_collection_ref_no_id = &_default_collection_ref_no_id;
 
-static GHashTable *
-create_checkpoint_target_metadata (const gchar *ref_to_upgrade)
-{
-  GHashTable *ht = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
-  g_hash_table_insert (ht,
-                       g_strdup ("eos.checkpoint-target"),
-                       g_strdup (ref_to_upgrade));
-
-  return ht;
-}
-
 /* Add some metadata to add to the given commit, which when running as the
  * deployed commit, tells the updater which ref to pull from (as opposed to
  * the currently booted one) */
@@ -61,15 +50,8 @@ insert_update_refspec_metadata_for_commit (guint         commit,
 {
   g_return_if_fail (out_metadata_hashtable != NULL);
 
-  if (*out_metadata_hashtable == NULL)
-    *out_metadata_hashtable = g_hash_table_new_full (g_direct_hash,
-                                                     g_direct_equal,
-                                                     NULL,
-                                                     (GDestroyNotify) g_hash_table_unref);
-
-  g_hash_table_insert (*out_metadata_hashtable,
-                       GUINT_TO_POINTER (commit),
-                       create_checkpoint_target_metadata (new_ref));
+  eos_test_add_metadata_for_commit (out_metadata_hashtable, commit,
+                                    "eos.checkpoint-target", new_ref);
 }
 
 /* @expected_updater_warnings should typically be set to %NULL. Set it to a


### PR DESCRIPTION
See the commit messages for explanations.

https://phabricator.endlessm.com/T34079