### PR TITLE
tests: Add licensing compliance test

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -160,4 +160,16 @@ foreach test_name, extra_args : python_tests
   endif
 endforeach
 
+reuse = find_program('reuse', required: false)
+if reuse.found()
+  test(
+    'reuse',
+    reuse,
+    args: ['lint'],
+    protocol: 'exitcode',
+    suite: 'eos-updater',
+    workdir: meson.project_source_root(),
+  )
+endif
+
 subdir('services')


### PR DESCRIPTION
This runs `reuse lint` if it’s installed. I’m not adding it as a dependency to `debian/control` at the moment as it’s not packaged on Bullseye. So for the moment this test will only be run locally by developers.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>