### PR TITLE
build: Enable fatal warnings from g-ir-scanner

### DIFF
--- a/libeos-updater-flatpak-installer/meson.build
+++ b/libeos-updater-flatpak-installer/meson.build
@@ -58,6 +58,7 @@ libeos_updater_flatpak_installer_gir = gnome.generate_gir(libeos_updater_flatpak
   ],
   install: true,
   dependencies: libeos_updater_flatpak_installer_dep,
+  fatal_warnings: true,
 )
 
 subdir('tests')

--- a/libeos-updater-util/meson.build
+++ b/libeos-updater-util/meson.build
@@ -86,6 +86,7 @@ libeos_updater_util_gir = gnome.generate_gir(libeos_updater_util,
   ],
   install: true,
   dependencies: libeos_updater_util_dep,
+  fatal_warnings: true,
 )
 
 subdir('tests')


### PR DESCRIPTION
We can do this unconditionally since the behaviour of `g-ir-scanner` is unlikely to change significantly, and warnings generally indicate binding problems which should probably count as a release blocker.

Currently, with `g-ir-scanner` 1.72.0, there are no warnings or errors.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T22636