### PR TITLE
eos-updater: Add a ReleaseNotesUri property

### DIFF
--- a/eos-updater/com.endlessm.Updater.xml
+++ b/eos-updater/com.endlessm.Updater.xml
@@ -195,6 +195,14 @@
     <property name="UpdateIsUserVisible" type="b" access="read"/>
 
     <!--
+      ReleaseNotesUri:
+
+      URI of a page containing release notes or news for the update being
+      applied, or the empty string if it’s not set or if no update is available.
+    -->
+    <property name="ReleaseNotesUri" type="s" access="read"/>
+
+    <!--
       DownloadSize:
 
       Size (in bytes) of the update when downloaded, or `-1` if an update is

--- a/eos-updater/docs/eos-updater.8
+++ b/eos-updater/docs/eos-updater.8
@@ -56,6 +56,43 @@ unit. See \fBsystemctl\fP(1).
 If the computer has been converted to not use OSTree, automatic updates are
 permanently disabled.
 .\"
+.SH COMMIT METADATA
+.IX Header "COMMIT METADATA"
+.\"
+\fBeos\-updater\fP understands various well\-known keys in the metadata of the
+OSTree commits it parses, in addition to the ones used by OSTree itself.
+.\"
+.IP "\fIeos.checkpoint\-target\fP (type \fBs\fP)" 4
+.IX Item "eos.checkpoint\-target"
+If this is specified, it contains the name of a new ref to upgrade the
+deployment to, but only if the booted OS is the commit containing the
+\fIeos.checkpoint\-target\fP key. Effectively, this creates a checkpoint commit
+which a computer must boot into before it can upgrade to any subsequent
+releases.
+.\"
+.IP "\fIeos\-updater.release\-notes\-uri\fP (type \fBs\fP)" 4
+.IX Item "eos\-updater.release\-notes\-uri"
+Optional URI pointing to release notes for the OS release contained in the
+commit, intended to be shown to the user in the UI before/when upgrading. This
+may contain zero or more placeholders which will be replaced before the string
+is exposed in \fBeos\-updater\fP’s D\-Bus interface. \fI${booted_version}\fP
+will be replaced with the version of the currently booted OS.
+\fI${update_version}\fP will be replaced with the version of the OS release
+contained in the commit (see the \fIversion\fP key below).
+.\"
+.IP "\fIostree.endoflife\-rebase\fP (type \fBs\fP)" 4
+.IX Item "ostree.endoflife\-rebase"
+If this is specified, it contains the name of a new ref to switch the deployment
+to updating from, as the current one has now reached end\-of\-life. The new ref
+must be on the same remote.
+.\"
+.IP "\fIversion\fP (type \fBs\fP)" 4
+.IX Item "version"
+Version number of the OS release contained in the commit. This is a string, but
+it is assumed to be in \fImajor.minor.micro\fP format. \fBeos\-updater\fP
+assumes that there are user-visible changes between different major versions of
+the OS, and notifies that in its D\-Bus interface.
+.\"
 .SH OPTIONS
 .IX Header "OPTIONS"
 .\"

--- a/eos-updater/main.c
+++ b/eos-updater/main.c
@@ -149,6 +149,7 @@ on_bus_acquired (GDBusConnection *connection,
       eos_updater_set_unpacked_size (updater, 0);
       eos_updater_set_update_id (updater, "");
       eos_updater_set_update_is_user_visible (updater, FALSE);
+      eos_updater_set_release_notes_uri (updater, "");
       eos_updater_clear_error (updater, EOS_UPDATER_STATE_READY);
     }
   else if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND) ||

--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -1153,7 +1153,6 @@ parse_latest_commit (OstreeRepo           *repo,
   g_autofree gchar *checksum = NULL;
   g_autoptr(GVariant) commit = NULL;
   g_autoptr(GVariant) rebase = NULL;
-  g_autoptr(GVariant) version = NULL;
   g_autoptr(GVariant) metadata = NULL;
   g_autofree gchar *collection_id = NULL;
   g_autoptr(GError) local_error = NULL;
@@ -1209,12 +1208,9 @@ parse_latest_commit (OstreeRepo           *repo,
   else
     *out_redirect_followed = FALSE;
 
-  if (metadata != NULL)
-    version = g_variant_lookup_value (metadata, "version", G_VARIANT_TYPE_STRING);
-  if (version == NULL)
+  if (metadata == NULL ||
+      !g_variant_lookup (metadata, "version", "s", out_version))
     *out_version = NULL;
-  else
-    *out_version = g_variant_dup_string (version, NULL);
 
   if (metadata == NULL ||
       !g_variant_lookup (metadata, "eos-updater.release-notes-uri", "s", out_release_notes_uri_template))

--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -124,6 +124,12 @@ compare_major_versions (const char *version_a,
  *   boolean indicating whether the update to @update_checksum contains user
  *   visible changes which should be highlighted to the user; always returns
  *   %FALSE when @out_commit returns %NULL
+ * @out_booted_version: (optional) (nullable) (out): return location for the
+ *   version number of the currently booted commit, or %NULL to not return it;
+ *   the returned value may be %NULL if the version is not known
+ * @out_update_version: (optional) (nullable) (out): return location for the
+ *   version number of the commit to update to, or %NULL to not return it; the
+ *   returned value may be %NULL if the version is not known
  * @error: return location for a #GError, or %NULL
  *
  * Checks whether an update from @booted_ref to @update_ref would actually be
@@ -143,6 +149,8 @@ is_checksum_an_update (OstreeRepo *repo,
                        const gchar *update_ref,
                        GVariant **out_commit,
                        gboolean *out_is_update_user_visible,
+                       gchar **out_booted_version,
+                       gchar **out_update_version,
                        GError **error)
 {
   g_autoptr(GVariant) current_commit = NULL;
@@ -165,6 +173,10 @@ is_checksum_an_update (OstreeRepo *repo,
   /* Default output. */
   *out_commit = NULL;
   *out_is_update_user_visible = FALSE;
+  if (out_booted_version != NULL)
+    *out_booted_version = NULL;
+  if (out_update_version != NULL)
+    *out_update_version = NULL;
 
   booted_checksum = eos_updater_get_booted_checksum (error);
   if (booted_checksum == NULL)
@@ -251,6 +263,11 @@ is_checksum_an_update (OstreeRepo *repo,
   *out_commit = is_newer ? g_steal_pointer (&update_commit) : NULL;
   *out_is_update_user_visible = is_newer ? is_update_user_visible : FALSE;
 
+  if (out_booted_version != NULL)
+    *out_booted_version = g_strdup (current_version);
+  if (out_update_version != NULL)
+    *out_update_version = g_strdup (update_version);
+
   return TRUE;
 }
 
@@ -332,6 +349,7 @@ eos_update_info_new (const gchar *checksum,
                      const gchar *old_refspec,
                      const gchar *version,
                      gboolean is_user_visible,
+                     const gchar *release_notes_uri,
                      const gchar * const *urls,
                      gboolean offline_results_only,
                      OstreeRepoFinderResult **results)
@@ -350,6 +368,7 @@ eos_update_info_new (const gchar *checksum,
   info->old_refspec = g_strdup (old_refspec);
   info->version = g_strdup (version);
   info->is_user_visible = is_user_visible;
+  info->release_notes_uri = g_strdup (release_notes_uri);
   info->urls = g_strdupv ((gchar **) urls);
   info->offline_results_only = offline_results_only;
   info->results = g_steal_pointer (&results);
@@ -970,6 +989,7 @@ fetch_latest_commit (OstreeRepo *repo,
                      gchar **out_checksum,
                      gchar **out_new_refspec,
                      gchar **out_version,
+                     gchar **out_release_notes_uri_template,
                      GError **error)
 {
   g_autofree gchar *checksum = NULL;
@@ -982,6 +1002,7 @@ fetch_latest_commit (OstreeRepo *repo,
   g_autofree gchar *upgrade_refspec = NULL;
   g_autofree gchar *new_refspec = NULL;
   g_autofree gchar *version = NULL;
+  g_autofree gchar *release_notes_uri_template = NULL;
   gboolean redirect_followed = FALSE;
   g_auto(OstreeRepoFinderResultv) results = NULL;
   g_autoptr(OstreeCollectionRef) upgrade_collection_ref = NULL;
@@ -993,6 +1014,7 @@ fetch_latest_commit (OstreeRepo *repo,
   g_return_val_if_fail (out_checksum != NULL, FALSE);
   g_return_val_if_fail (out_new_refspec != NULL, FALSE);
   g_return_val_if_fail (out_version != NULL, FALSE);
+  g_return_val_if_fail (out_release_notes_uri_template != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
   if (finders != NULL && collection_ref == NULL)
@@ -1074,6 +1096,7 @@ fetch_latest_commit (OstreeRepo *repo,
 
       g_clear_pointer (&checksum, g_free);
       g_clear_pointer (&version, g_free);
+      g_clear_pointer (&release_notes_uri_template, g_free);
       g_clear_pointer (&new_refspec, g_free);
       g_clear_pointer (&new_collection_ref, ostree_collection_ref_free);
 
@@ -1081,7 +1104,7 @@ fetch_latest_commit (OstreeRepo *repo,
       if (!parse_latest_commit (repo, upgrade_refspec, &redirect_followed,
                                 &checksum, &new_refspec,
                                 finders == NULL ? NULL : &new_collection_ref,
-                                &version, cancellable, error))
+                                &version, &release_notes_uri_template, cancellable, error))
         return FALSE;
 
       if (new_refspec != NULL)
@@ -1098,6 +1121,7 @@ fetch_latest_commit (OstreeRepo *repo,
   while (redirect_followed);
 
   *out_version = g_steal_pointer (&version);
+  *out_release_notes_uri_template = g_steal_pointer (&release_notes_uri_template);
   *out_checksum = g_steal_pointer (&checksum);
   if (new_refspec != NULL)
     *out_new_refspec = g_steal_pointer (&new_refspec);
@@ -1120,6 +1144,7 @@ parse_latest_commit (OstreeRepo           *repo,
                      gchar               **out_new_refspec,
                      OstreeCollectionRef **out_new_collection_ref,
                      gchar               **out_version,
+                     gchar               **out_release_notes_uri_template,
                      GCancellable         *cancellable,
                      GError              **error)
 {
@@ -1140,6 +1165,7 @@ parse_latest_commit (OstreeRepo           *repo,
   g_return_val_if_fail (out_checksum != NULL, FALSE);
   g_return_val_if_fail (out_new_refspec != NULL, FALSE);
   g_return_val_if_fail (out_version != NULL, FALSE);
+  g_return_val_if_fail (out_release_notes_uri_template != NULL, FALSE);
   g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
   if (!ostree_parse_refspec (refspec, &remote_name, &ref, error))
@@ -1189,6 +1215,10 @@ parse_latest_commit (OstreeRepo           *repo,
     *out_version = NULL;
   else
     *out_version = g_variant_dup_string (version, NULL);
+
+  if (metadata == NULL ||
+      !g_variant_lookup (metadata, "eos-updater.release-notes-uri", "s", out_release_notes_uri_template))
+    *out_release_notes_uri_template = NULL;
 
   *out_checksum = g_steal_pointer (&checksum);
   *out_new_refspec = g_strconcat (remote_name, ":", ref, NULL);
@@ -1374,6 +1404,7 @@ eos_update_info_to_string (EosUpdateInfo *update)
   g_autofree gchar *results = NULL;
   const gchar *version = update->version;
   const gchar *is_user_visible_str = NULL;
+  const gchar *release_notes_uri = update->release_notes_uri;
   gsize i;
 
   if (update->urls != NULL)
@@ -1404,12 +1435,16 @@ eos_update_info_to_string (EosUpdateInfo *update)
 
   is_user_visible_str = update->is_user_visible ? "user visible" : "not user visible";
 
-  return g_strdup_printf ("%s, %s, %s, %s, %s, %s\n   %s%s",
+  if (release_notes_uri == NULL)
+    release_notes_uri = "(no release notes URI)";
+
+  return g_strdup_printf ("%s, %s, %s, %s, %s, %s, %s\n   %s%s",
                           update->checksum,
                           update->new_refspec,
                           update->old_refspec,
                           version,
                           is_user_visible_str,
+                          release_notes_uri,
                           timestamp_str,
                           update_urls,
                           results);
@@ -1703,6 +1738,7 @@ metadata_fetch_finished (GObject *object,
       eos_updater_set_original_refspec (updater, info->old_refspec);
       eos_updater_set_version (updater, info->version);
       eos_updater_set_update_is_user_visible (updater, info->is_user_visible);
+      eos_updater_set_release_notes_uri (updater, info->release_notes_uri);
 
       g_variant_get_child (info->commit, 3, "&s", &label);
       g_variant_get_child (info->commit, 4, "&s", &message);

--- a/eos-updater/poll-common.h
+++ b/eos-updater/poll-common.h
@@ -38,6 +38,8 @@ is_checksum_an_update (OstreeRepo *repo,
                        const gchar *update_ref,
                        GVariant **out_commit,
                        gboolean *out_is_update_user_visible,
+                       gchar **out_booted_version,
+                       gchar **out_update_version,
                        GError **error);
 
 #define EOS_TYPE_METRICS_INFO eos_metrics_info_get_type ()
@@ -78,6 +80,7 @@ struct _EosUpdateInfo
   gchar **urls;
   gboolean offline_results_only;
   gboolean is_user_visible;
+  gchar *release_notes_uri;
 
   OstreeRepoFinderResult **results;  /* (owned) (array zero-terminated=1) */
 };
@@ -89,6 +92,7 @@ eos_update_info_new (const gchar *csum,
                      const gchar *old_refspec,
                      const gchar *version,
                      gboolean is_user_visible,
+                     const gchar *release_notes_uri,
                      const gchar * const *urls,
                      gboolean offline_results_only,
                      OstreeRepoFinderResult **results);
@@ -126,6 +130,7 @@ gboolean fetch_latest_commit (OstreeRepo *repo,
                               gchar **out_checksum,
                               gchar **out_new_refspec,
                               gchar **out_version,
+                              gchar **out_release_notes_uri_template,
                               GError **error);
 
 gboolean parse_latest_commit (OstreeRepo           *repo,
@@ -135,6 +140,7 @@ gboolean parse_latest_commit (OstreeRepo           *repo,
                               gchar               **out_new_refspec,
                               OstreeCollectionRef **out_new_collection_ref,
                               gchar               **out_version,
+                              gchar               **out_release_notes_uri_template,
                               GCancellable         *cancellable,
                               GError              **error);
 

--- a/eos-updater/tests/eos_updater.py
+++ b/eos-updater/tests/eos_updater.py
@@ -100,6 +100,8 @@ def load(mock, parameters):
             'Version': dbus.String(parameters.get('Version', '')),
             'UpdateIsUserVisible':
                 dbus.Boolean(parameters.get('UpdateIsUserVisible', False)),
+            'ReleaseNotesUri':
+                dbus.String(parameters.get('ReleaseNotesUri', '')),
             'DownloadSize': dbus.Int64(parameters.get('DownloadSize', 0)),
             'DownloadedBytes':
                 dbus.Int64(parameters.get('DownloadedBytes', 0)),
@@ -288,7 +290,9 @@ def SetPollAction(self, action, update_properties, error_name, error_message):
             'UpdateMessage':
                 dbus.String('Some release notes.', variant_level=1),
             'Version': dbus.String('3.7.0', variant_level=1),
-            'UpdateIsUserVisible': dbus.Boolean(False),
+            'UpdateIsUserVisible': dbus.Boolean(False, variant_level=1),
+            'ReleaseNotesUri':
+                dbus.String('https://example.com/release-notes', variant_level=1),
             'DownloadSize': dbus.Int64(1000000000, variant_level=1),
             'UnpackedSize': dbus.Int64(1500000000, variant_level=1),
             'FullDownloadSize': dbus.Int64(1000000000 * 0.8, variant_level=1),
@@ -317,6 +321,7 @@ def FinishPoll(self):
             'UpdateMessage',
             'Version',
             'UpdateIsUserVisible',
+            'ReleaseNotesUri',
             'FullDownloadSize',
             'FullUnpackedSize',
             'DownloadSize',

--- a/tests/test-update-direct.c
+++ b/tests/test-update-direct.c
@@ -459,6 +459,88 @@ test_update_is_user_visible (EosUpdaterFixture *fixture,
     g_assert_true (eos_updater_get_update_is_user_visible (updater));
 }
 
+typedef struct
+{
+  const gchar *release_notes_uri_template;  /* (nullable) */
+  const gchar *expected_release_notes_uri;  /* (nullable) */
+} ReleaseNotesUriData;
+
+/* Tests getting the ReleaseNotesUri property when it has a value or is empty. */
+static void
+test_update_release_notes_uri (EosUpdaterFixture *fixture,
+                               gconstpointer      user_data)
+{
+  g_autoptr(GError) error = NULL;
+  g_autoptr(EosTestServer) server = NULL;
+  g_autoptr(EosTestSubserver) subserver = NULL;
+  g_autoptr(EosTestClient) client = NULL;
+  g_autoptr(EosUpdater) updater = NULL;
+  g_autoptr(GHashTable) leaf_commit_nodes =
+    eos_test_subserver_ref_to_commit_new ();
+  DownloadSource main_source = DOWNLOAD_MAIN;
+  const ReleaseNotesUriData *data = user_data;
+
+  if (eos_test_skip_chroot ())
+    return;
+
+  setup_basic_test_server_client (fixture, &server, &subserver, &client, &error);
+  g_assert_no_error (error);
+
+  g_hash_table_insert (leaf_commit_nodes,
+                       ostree_collection_ref_dup (default_collection_ref),
+                       GUINT_TO_POINTER (1));
+  if (data->release_notes_uri_template != NULL)
+    {
+      eos_test_add_metadata_for_commit (&subserver->additional_metadata_for_commit,
+                                        1, "eos-updater.release-notes-uri", data->release_notes_uri_template);
+      eos_test_add_metadata_for_commit (&subserver->additional_metadata_for_commit,
+                                        1, "version", "5.0.0");
+    }
+
+  eos_test_subserver_populate_commit_graph_from_leaf_nodes (subserver,
+                                                            leaf_commit_nodes);
+  eos_test_subserver_update (subserver, &error);
+  g_assert_no_error (error);
+
+  eos_test_client_run_updater (client,
+                               &main_source,
+                               1,
+                               NULL,
+                               NULL,
+                               &error);
+  g_assert_no_error (error);
+
+  updater = eos_updater_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
+                                                G_DBUS_PROXY_FLAGS_NONE,
+                                                "com.endlessm.Updater",
+                                                "/com/endlessm/Updater",
+                                                NULL,
+                                                &error);
+  g_assert_no_error (error);
+
+  EosUpdaterState state = EOS_UPDATER_STATE_POLLING;
+  g_signal_connect (updater, "notify::state",
+                    G_CALLBACK (update_with_loop_state_changed_cb),
+                    &state);
+
+  /* start the state changes */
+  eos_updater_call_poll_sync (updater, NULL, &error);
+  g_assert_no_error (error);
+
+  gboolean timed_out = FALSE;
+  guint timeout_id = g_timeout_add_seconds (DEFAULT_TIMEOUT_SECS, timeout_cb, &timed_out);
+
+  while (state == EOS_UPDATER_STATE_POLLING && !timed_out)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_source_remove (timeout_id);
+
+  g_assert_false (timed_out);
+
+  g_assert_cmpuint (eos_updater_get_state (updater), ==, EOS_UPDATER_STATE_UPDATE_AVAILABLE);
+  g_assert_cmpstr (eos_updater_get_release_notes_uri (updater), ==, data->expected_release_notes_uri);
+}
+
 /* Tests getting an update when there is none available. */
 static void
 test_update_when_none_available (EosUpdaterFixture *fixture,
@@ -623,6 +705,18 @@ main (int argc,
   eos_test_add ("/updater/update-version", "1.2.3", test_update_version);
   eos_test_add ("/updater/update-is-user-visible/minor", "1.3.0", test_update_is_user_visible);
   eos_test_add ("/updater/update-is-user-visible/major", "2.0.0", test_update_is_user_visible);
+  eos_test_add ("/updater/update-release-notes-uri/empty", (&(ReleaseNotesUriData) {
+                  .release_notes_uri_template = NULL,
+                  .expected_release_notes_uri = NULL,
+                }), test_update_release_notes_uri);
+  eos_test_add ("/updater/update-release-notes-uri/plain", (&(ReleaseNotesUriData) {
+                  .release_notes_uri_template = "https://example.com",
+                  .expected_release_notes_uri = "https://example.com",
+                }), test_update_release_notes_uri);
+  eos_test_add ("/updater/update-release-notes-uri/templated", (&(ReleaseNotesUriData) {
+                  .release_notes_uri_template = "https://example.com/from/${booted_version}/to/${update_version}",
+                  .expected_release_notes_uri = "https://example.com/from/1.0.0/to/5.0.0",
+                }), test_update_release_notes_uri);
   eos_test_add ("/updater/update-not-available", NULL, test_update_when_none_available);
   eos_test_add ("/updater/commit-sizes", NULL, test_update_sizes);
 


### PR DESCRIPTION
This adds a `ReleaseNotesUri` property to the D-Bus interface. This is populated from an optional `eos-updater.release-notes-uri` metadata key in OSTree commits, which has a couple of optional string substitutions applied to it to allow a single URI template to be refined for multiple possible update paths.

This allows different release notes pages to be shown to users depending on which version they are updating from.

Includes a unit test.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T34082