### PR TITLE
Fix tests using compound literals

### DIFF
--- a/test-common/utils.c
+++ b/test-common/utils.c
@@ -103,6 +103,19 @@ eos_updater_fixture_teardown (EosUpdaterFixture *fixture,
   g_object_unref (fixture->dbus);
 }
 
+void
+eos_test_add (const char            *testpath,
+              gconstpointer          tdata,
+              EosUpdaterFixtureFunc  ftest)
+{
+  g_test_add (testpath,
+              EosUpdaterFixture,
+              tdata,
+              eos_updater_fixture_setup,
+              ftest,
+              eos_updater_fixture_teardown);
+}
+
 G_DEFINE_TYPE (EosTestSubserver, eos_test_subserver, G_TYPE_OBJECT)
 
 static void

--- a/test-common/utils.h
+++ b/test-common/utils.h
@@ -46,7 +46,12 @@ void eos_updater_fixture_setup_full (EosUpdaterFixture *fixture,
 void eos_updater_fixture_teardown (EosUpdaterFixture *fixture,
                                    gconstpointer user_data);
 
-#define eos_test_add(testpath, tdata, ftest) g_test_add (testpath, EosUpdaterFixture, tdata, eos_updater_fixture_setup, ftest, eos_updater_fixture_teardown)
+typedef void (*EosUpdaterFixtureFunc) (EosUpdaterFixture *fixture,
+                                       gconstpointer      user_data);
+
+void eos_test_add (const char            *testpath,
+                   gconstpointer          tdata,
+                   EosUpdaterFixtureFunc  ftest);
 
 extern const gchar *const default_vendor;
 extern const gchar *const default_product;

--- a/tests/test-update-direct.c
+++ b/tests/test-update-direct.c
@@ -707,7 +707,7 @@ main (int argc,
   eos_test_add ("/updater/update-is-user-visible/major", "2.0.0", test_update_is_user_visible);
   eos_test_add ("/updater/update-release-notes-uri/empty", (&(ReleaseNotesUriData) {
                   .release_notes_uri_template = NULL,
-                  .expected_release_notes_uri = NULL,
+                  .expected_release_notes_uri = "",
                 }), test_update_release_notes_uri);
   eos_test_add ("/updater/update-release-notes-uri/plain", (&(ReleaseNotesUriData) {
                   .release_notes_uri_template = "https://example.com",


### PR DESCRIPTION
Passing compound literals to `eos_test_add` was subtly broken due the implementation of the `g_test_add` macro. Workaround it by converting `eos_test_add` to a function and fixing a test that was silently being skipped.