### PR TITLE
T34292 Backport “eos-updater: Add a ReleaseNotesUri property” to eos4.0

### DIFF
--- a/eos-updater/com.endlessm.Updater.xml
+++ b/eos-updater/com.endlessm.Updater.xml
@@ -193,6 +193,14 @@
     <property name="UpdateIsUserVisible" type="b" access="read"/>
 
     <!--
+      ReleaseNotesUri:
+
+      URI of a page containing release notes or news for the update being
+      applied, or the empty string if it’s not set or if no update is available.
+    -->
+    <property name="ReleaseNotesUri" type="s" access="read"/>
+
+    <!--
       DownloadSize:
 
       Size (in bytes) of the update when downloaded, or `-1` if an update is

--- a/eos-updater/docs/eos-updater.8
+++ b/eos-updater/docs/eos-updater.8
@@ -55,6 +55,43 @@ unit. See \fBsystemctl\fP(1).
 If the computer has been converted to not use OSTree, automatic updates are
 permanently disabled.
 .\"
+.SH COMMIT METADATA
+.IX Header "COMMIT METADATA"
+.\"
+\fBeos\-updater\fP understands various well\-known keys in the metadata of the
+OSTree commits it parses, in addition to the ones used by OSTree itself.
+.\"
+.IP "\fIeos.checkpoint\-target\fP (type \fBs\fP)" 4
+.IX Item "eos.checkpoint\-target"
+If this is specified, it contains the name of a new ref to upgrade the
+deployment to, but only if the booted OS is the commit containing the
+\fIeos.checkpoint\-target\fP key. Effectively, this creates a checkpoint commit
+which a computer must boot into before it can upgrade to any subsequent
+releases.
+.\"
+.IP "\fIeos\-updater.release\-notes\-uri\fP (type \fBs\fP)" 4
+.IX Item "eos\-updater.release\-notes\-uri"
+Optional URI pointing to release notes for the OS release contained in the
+commit, intended to be shown to the user in the UI before/when upgrading. This
+may contain zero or more placeholders which will be replaced before the string
+is exposed in \fBeos\-updater\fP’s D\-Bus interface. \fI${booted_version}\fP
+will be replaced with the version of the currently booted OS.
+\fI${update_version}\fP will be replaced with the version of the OS release
+contained in the commit (see the \fIversion\fP key below).
+.\"
+.IP "\fIostree.endoflife\-rebase\fP (type \fBs\fP)" 4
+.IX Item "ostree.endoflife\-rebase"
+If this is specified, it contains the name of a new ref to switch the deployment
+to updating from, as the current one has now reached end\-of\-life. The new ref
+must be on the same remote.
+.\"
+.IP "\fIversion\fP (type \fBs\fP)" 4
+.IX Item "version"
+Version number of the OS release contained in the commit. This is a string, but
+it is assumed to be in \fImajor.minor.micro\fP format. \fBeos\-updater\fP
+assumes that there are user-visible changes between different major versions of
+the OS, and notifies that in its D\-Bus interface.
+.\"
 .SH OPTIONS
 .IX Header "OPTIONS"
 .\"

--- a/eos-updater/main.c
+++ b/eos-updater/main.c
@@ -147,6 +147,7 @@ on_bus_acquired (GDBusConnection *connection,
       eos_updater_set_unpacked_size (updater, 0);
       eos_updater_set_update_id (updater, "");
       eos_updater_set_update_is_user_visible (updater, FALSE);
+      eos_updater_set_release_notes_uri (updater, "");
       eos_updater_clear_error (updater, EOS_UPDATER_STATE_READY);
     }
   else if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND) ||

--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -1151,7 +1151,6 @@ parse_latest_commit (OstreeRepo           *repo,
   g_autofree gchar *checksum = NULL;
   g_autoptr(GVariant) commit = NULL;
   g_autoptr(GVariant) rebase = NULL;
-  g_autoptr(GVariant) version = NULL;
   g_autoptr(GVariant) metadata = NULL;
   g_autofree gchar *collection_id = NULL;
   g_autoptr(GError) local_error = NULL;
@@ -1207,12 +1206,9 @@ parse_latest_commit (OstreeRepo           *repo,
   else
     *out_redirect_followed = FALSE;
 
-  if (metadata != NULL)
-    version = g_variant_lookup_value (metadata, "version", G_VARIANT_TYPE_STRING);
-  if (version == NULL)
+  if (metadata == NULL ||
+      !g_variant_lookup (metadata, "version", "s", out_version))
     *out_version = NULL;
-  else
-    *out_version = g_variant_dup_string (version, NULL);
 
   if (metadata == NULL ||
       !g_variant_lookup (metadata, "eos-updater.release-notes-uri", "s", out_release_notes_uri_template))

--- a/eos-updater/poll-common.h
+++ b/eos-updater/poll-common.h
@@ -36,6 +36,8 @@ is_checksum_an_update (OstreeRepo *repo,
                        const gchar *update_ref,
                        GVariant **out_commit,
                        gboolean *out_is_update_user_visible,
+                       gchar **out_booted_version,
+                       gchar **out_update_version,
                        GError **error);
 
 #define EOS_TYPE_METRICS_INFO eos_metrics_info_get_type ()
@@ -76,6 +78,7 @@ struct _EosUpdateInfo
   gchar **urls;
   gboolean offline_results_only;
   gboolean is_user_visible;
+  gchar *release_notes_uri;
 
   OstreeRepoFinderResult **results;  /* (owned) (array zero-terminated=1) */
 };
@@ -87,6 +90,7 @@ eos_update_info_new (const gchar *csum,
                      const gchar *old_refspec,
                      const gchar *version,
                      gboolean is_user_visible,
+                     const gchar *release_notes_uri,
                      const gchar * const *urls,
                      gboolean offline_results_only,
                      OstreeRepoFinderResult **results);
@@ -124,6 +128,7 @@ gboolean fetch_latest_commit (OstreeRepo *repo,
                               gchar **out_checksum,
                               gchar **out_new_refspec,
                               gchar **out_version,
+                              gchar **out_release_notes_uri_template,
                               GError **error);
 
 gboolean parse_latest_commit (OstreeRepo           *repo,
@@ -133,6 +138,7 @@ gboolean parse_latest_commit (OstreeRepo           *repo,
                               gchar               **out_new_refspec,
                               OstreeCollectionRef **out_new_collection_ref,
                               gchar               **out_version,
+                              gchar               **out_release_notes_uri_template,
                               GCancellable         *cancellable,
                               GError              **error);
 

--- a/tests/test-update-direct.c
+++ b/tests/test-update-direct.c
@@ -457,6 +457,88 @@ test_update_is_user_visible (EosUpdaterFixture *fixture,
     g_assert_true (eos_updater_get_update_is_user_visible (updater));
 }
 
+typedef struct
+{
+  const gchar *release_notes_uri_template;  /* (nullable) */
+  const gchar *expected_release_notes_uri;  /* (nullable) */
+} ReleaseNotesUriData;
+
+/* Tests getting the ReleaseNotesUri property when it has a value or is empty. */
+static void
+test_update_release_notes_uri (EosUpdaterFixture *fixture,
+                               gconstpointer      user_data)
+{
+  g_autoptr(GError) error = NULL;
+  g_autoptr(EosTestServer) server = NULL;
+  g_autoptr(EosTestSubserver) subserver = NULL;
+  g_autoptr(EosTestClient) client = NULL;
+  g_autoptr(EosUpdater) updater = NULL;
+  g_autoptr(GHashTable) leaf_commit_nodes =
+    eos_test_subserver_ref_to_commit_new ();
+  DownloadSource main_source = DOWNLOAD_MAIN;
+  const ReleaseNotesUriData *data = user_data;
+
+  if (eos_test_skip_chroot ())
+    return;
+
+  setup_basic_test_server_client (fixture, &server, &subserver, &client, &error);
+  g_assert_no_error (error);
+
+  g_hash_table_insert (leaf_commit_nodes,
+                       ostree_collection_ref_dup (default_collection_ref),
+                       GUINT_TO_POINTER (1));
+  if (data->release_notes_uri_template != NULL)
+    {
+      eos_test_add_metadata_for_commit (&subserver->additional_metadata_for_commit,
+                                        1, "eos-updater.release-notes-uri", data->release_notes_uri_template);
+      eos_test_add_metadata_for_commit (&subserver->additional_metadata_for_commit,
+                                        1, "version", "5.0.0");
+    }
+
+  eos_test_subserver_populate_commit_graph_from_leaf_nodes (subserver,
+                                                            leaf_commit_nodes);
+  eos_test_subserver_update (subserver, &error);
+  g_assert_no_error (error);
+
+  eos_test_client_run_updater (client,
+                               &main_source,
+                               1,
+                               NULL,
+                               NULL,
+                               &error);
+  g_assert_no_error (error);
+
+  updater = eos_updater_proxy_new_for_bus_sync (G_BUS_TYPE_SESSION,
+                                                G_DBUS_PROXY_FLAGS_NONE,
+                                                "com.endlessm.Updater",
+                                                "/com/endlessm/Updater",
+                                                NULL,
+                                                &error);
+  g_assert_no_error (error);
+
+  EosUpdaterState state = EOS_UPDATER_STATE_POLLING;
+  g_signal_connect (updater, "notify::state",
+                    G_CALLBACK (update_with_loop_state_changed_cb),
+                    &state);
+
+  /* start the state changes */
+  eos_updater_call_poll_sync (updater, NULL, &error);
+  g_assert_no_error (error);
+
+  gboolean timed_out = FALSE;
+  guint timeout_id = g_timeout_add_seconds (DEFAULT_TIMEOUT_SECS, timeout_cb, &timed_out);
+
+  while (state == EOS_UPDATER_STATE_POLLING && !timed_out)
+    g_main_context_iteration (NULL, TRUE);
+
+  g_source_remove (timeout_id);
+
+  g_assert_false (timed_out);
+
+  g_assert_cmpuint (eos_updater_get_state (updater), ==, EOS_UPDATER_STATE_UPDATE_AVAILABLE);
+  g_assert_cmpstr (eos_updater_get_release_notes_uri (updater), ==, data->expected_release_notes_uri);
+}
+
 /* Tests getting an update when there is none available. */
 static void
 test_update_when_none_available (EosUpdaterFixture *fixture,
@@ -621,6 +703,18 @@ main (int argc,
   eos_test_add ("/updater/update-version", "1.2.3", test_update_version);
   eos_test_add ("/updater/update-is-user-visible/minor", "1.3.0", test_update_is_user_visible);
   eos_test_add ("/updater/update-is-user-visible/major", "2.0.0", test_update_is_user_visible);
+  eos_test_add ("/updater/update-release-notes-uri/empty", (&(ReleaseNotesUriData) {
+                  .release_notes_uri_template = NULL,
+                  .expected_release_notes_uri = NULL,
+                }), test_update_release_notes_uri);
+  eos_test_add ("/updater/update-release-notes-uri/plain", (&(ReleaseNotesUriData) {
+                  .release_notes_uri_template = "https://example.com",
+                  .expected_release_notes_uri = "https://example.com",
+                }), test_update_release_notes_uri);
+  eos_test_add ("/updater/update-release-notes-uri/templated", (&(ReleaseNotesUriData) {
+                  .release_notes_uri_template = "https://example.com/from/${booted_version}/to/${update_version}",
+                  .expected_release_notes_uri = "https://example.com/from/1.0.0/to/5.0.0",
+                }), test_update_release_notes_uri);
   eos_test_add ("/updater/update-not-available", NULL, test_update_when_none_available);
   eos_test_add ("/updater/commit-sizes", NULL, test_update_sizes);
 


### PR DESCRIPTION
Fairly trivial backport of https://github.com/endlessm/eos-updater/pull/319 to `eos4.0`.

The only cherry-pick conflict was with the python-dbusmock template for eos-updater: it was modified in the first commit, but doesn’t exist in the `eos4.0` version of eos-updater, so I dropped those changes.

https://phabricator.endlessm.com/T34292