### PR TITLE
eos-updater: Only allow latest2 checkpoint from latest1

### DIFF
--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -706,7 +706,7 @@ should_follow_checkpoint (OstreeSysroot     *sysroot,
     (g_str_has_suffix (booted_ref, "/eos3a") ||
      g_str_has_suffix (booted_ref, "nexthw/eos3.9"));
   /* https://phabricator.endlessm.com/T33311 */
-  gboolean is_eos4_conditional_upgrade_path = g_str_has_suffix (booted_ref, "/latest1");
+  gboolean is_eos4_conditional_upgrade_path = g_str_has_suffix (target_ref, "/latest2");
 
   /* Simplifies the code below. */
   g_assert (out_reason != NULL);
@@ -732,6 +732,17 @@ should_follow_checkpoint (OstreeSysroot     *sysroot,
       booted_system_is_arm64 ())
     {
       *out_reason = g_strdup (_("ARM64 system upgrades are not supported in EOS 4. Please reinstall."));
+      return FALSE;
+    }
+
+  /* Only EOS 4 systems on the latest ref (latest1) should upgrade to EOS 5.
+   * Systems on the LTS ref (eos4) or any other ref should not.
+   *
+   * https://phabricator.endlessm.com/T34298  */
+  if (is_eos4_conditional_upgrade_path &&
+      !g_str_has_suffix (booted_ref, "/latest1"))
+    {
+      *out_reason = g_strdup (_("Only systems following the latest updates can upgrade to EOS 5."));
       return FALSE;
     }
 

--- a/tests/test-update-refspec-checkpoint.c
+++ b/tests/test-update-refspec-checkpoint.c
@@ -1804,6 +1804,31 @@ test_update_refspec_checkpoint_latest1_latest2 (EosUpdaterFixture *fixture,
         .expect_checkpoint_followed = TRUE,
       },
 
+      /* Ref matching. The only allowed path is from latest1 to latest2. Any
+       * other booted ref cannot follow the checkpoint to latest2. */
+      {
+        .src_ref = "os/eos/amd64/eos4",
+        .tgt_ref = "os/eos/amd64/latest2",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        .src_ref = "os/eos/amd64/eos4.0",
+        .tgt_ref = "os/eos/amd64/latest2",
+        .expect_checkpoint_followed = FALSE,
+      },
+      {
+        /* Hypothetical LTS checkpoint that should not be affected by the
+         * latest2 checkpoint handling. */
+        .src_ref = "os/eos/amd64/eos4",
+        .tgt_ref = "os/eos/amd64/eos4a",
+        .expect_checkpoint_followed = TRUE,
+      },
+      {
+        .src_ref = "os/eos/arm64/latest1",
+        .tgt_ref = "os/eos/arm64/latest2",
+        .expect_checkpoint_followed = TRUE,
+      },
+
       /* Platforms: x86_64 and aarch64 */
       {
         .uname_machine = "x86_64",


### PR DESCRIPTION
Only EOS 4 systems on the latest ref (latest1) should upgrade to EOS 5 (latest2). Systems on the LTS ref (eos4) or any other ref should not. In order to ensure that the validation applies to any ref trying to follow the latest2 checkpoint, switch the initial check so that it applies to the target ref instead of the booted ref.

https://phabricator.endlessm.com/T34298