### PR TITLE
Ensure autoupdater poll results are loaded

### DIFF
--- a/test-common/spawn-utils.c
+++ b/test-common/spawn-utils.c
@@ -78,6 +78,7 @@ cmd_result_ensure_ok_verbose (CmdResult *cmd)
   if (cmd_result_ensure_ok (cmd, &error))
     return TRUE;
 
+  g_test_message ("%s", error->message);
   return FALSE;
 }
 

--- a/tests/test-autoupdater.c
+++ b/tests/test-autoupdater.c
@@ -289,6 +289,21 @@ test_user_visible_update_delay (EosUpdaterFixture *fixture,
                                &error);
   g_assert_no_error (error);
 
+  /* First poll so that poll results are written to disk. */
+  g_clear_object (&autoupdater);
+  autoupdater = eos_test_autoupdater_new (autoupdater_root,
+                                          UPDATE_STEP_POLL,
+                                          0,  /* interval (days) */
+                                          test_data->update_delay, /* user visible delay (days) */
+                                          test_data->force_update,  /* force update */
+                                          &error);
+  g_assert_no_error (error);
+  g_assert_true (cmd_result_ensure_ok_verbose (autoupdater->cmd));
+
+  /* Now run through to apply. Since eos-updater is in UPDATE_AVAILABLE state,
+   * polling will be skipped. This will test that the autoupdater loads the
+   * previous poll results even when not polling. */
+  g_clear_object (&autoupdater);
   autoupdater = eos_test_autoupdater_new (autoupdater_root,
                                           UPDATE_STEP_APPLY,
                                           0,  /* interval (days) */

--- a/tests/test-autoupdater.c
+++ b/tests/test-autoupdater.c
@@ -154,7 +154,7 @@ test_poll_results (EosUpdaterFixture *fixture,
                                           FALSE,  /* force update */
                                           &error);
   g_assert_no_error (error);
-  cmd_result_ensure_ok_verbose (autoupdater->cmd);
+  g_assert_true (cmd_result_ensure_ok_verbose (autoupdater->cmd));
 
   get_poll_results (autoupdater_root,
                     &last_changed_usecs,
@@ -186,7 +186,7 @@ test_poll_results (EosUpdaterFixture *fixture,
                                           FALSE,  /* force update */
                                           &error);
   g_assert_no_error (error);
-  cmd_result_ensure_ok_verbose (autoupdater->cmd);
+  g_assert_true (cmd_result_ensure_ok_verbose (autoupdater->cmd));
 
   expected_update_id = g_hash_table_lookup (subserver->commits_in_repo,
                                             GUINT_TO_POINTER (1));
@@ -213,7 +213,7 @@ test_poll_results (EosUpdaterFixture *fixture,
                                           FALSE,  /* force update */
                                           &error);
   g_assert_no_error (error);
-  cmd_result_ensure_ok_verbose (autoupdater->cmd);
+  g_assert_true (cmd_result_ensure_ok_verbose (autoupdater->cmd));
 
   get_poll_results (autoupdater_root,
                     &last_changed_usecs,
@@ -228,7 +228,7 @@ test_poll_results (EosUpdaterFixture *fixture,
                                 &reaped,
                                 &error);
   g_assert_no_error (error);
-  cmd_result_ensure_ok_verbose (&reaped);
+  g_assert_true (cmd_result_ensure_ok_verbose (&reaped));
 }
 
 typedef struct {
@@ -296,7 +296,7 @@ test_user_visible_update_delay (EosUpdaterFixture *fixture,
                                           test_data->force_update,  /* force update */
                                           &error);
   g_assert_no_error (error);
-  cmd_result_ensure_ok_verbose (autoupdater->cmd);
+  g_assert_true (cmd_result_ensure_ok_verbose (autoupdater->cmd));
 
   eos_test_client_has_commit (client,
                               default_remote_name,
@@ -314,7 +314,7 @@ test_user_visible_update_delay (EosUpdaterFixture *fixture,
                                 &reaped,
                                 &error);
   g_assert_no_error (error);
-  cmd_result_ensure_ok_verbose (&reaped);
+  g_assert_true (cmd_result_ensure_ok_verbose (&reaped));
 }
 
 int


### PR DESCRIPTION
If eos-updater was already past the polling stage, the autoupdater was segfaulting because it wasn't loading the poll results prior to using them in the apply stage. The last commit fixes that while the first 2 are minor test fixes.

https://phabricator.endlessm.com/T34083