### PR TITLE
Backport "Ensure autoupdater poll results are loaded" to eos4.0

### DIFF
--- a/eos-autoupdater/main.c
+++ b/eos-autoupdater/main.c
@@ -558,6 +558,9 @@ do_update_step (UpdateStep step, EosUpdater *proxy)
       if (polled_already)
         return FALSE;
 
+      /* Ensure the in memory poll results are cleared before polling. */
+      g_clear_pointer (&poll_results, poll_results_free);
+
       /* TODO: What to do with the volume code path? */
       polled_already = TRUE;
       if (volume_path != NULL)
@@ -582,10 +585,13 @@ do_update_step (UpdateStep step, EosUpdater *proxy)
           guint64 now = (guint64) MAX (0, g_get_real_time ());
           guint64 next_update = 0;
 
+          g_assert (poll_results != NULL);
+
           if (!g_uint64_checked_add (&next_update,
                                      poll_results->last_changed_usecs,
                                      user_visible_delay_usecs))
             next_update = G_MAXUINT64;
+
           if (now < next_update)
             {
               info (EOS_UPDATER_NOT_TIME_MSGID,
@@ -658,6 +664,9 @@ on_state_changed (EosUpdater *proxy, EosUpdaterState state)
       break;
 
     case EOS_UPDATER_STATE_UPDATE_AVAILABLE: /* Possibly fetch */
+      /* Update the stored poll results if needed. */
+      if (poll_results == NULL)
+        update_poll_results (proxy);
       continue_running = do_update_step (UPDATE_STEP_FETCH, proxy);
       break;
 
@@ -665,6 +674,9 @@ on_state_changed (EosUpdater *proxy, EosUpdaterState state)
       break;
 
     case EOS_UPDATER_STATE_UPDATE_READY: /* Possibly apply */
+      /* Update the stored poll results if needed. */
+      if (poll_results == NULL)
+        update_poll_results (proxy);
       continue_running = do_update_step (UPDATE_STEP_APPLY, proxy);
       break;
 

--- a/test-common/spawn-utils.c
+++ b/test-common/spawn-utils.c
@@ -76,6 +76,7 @@ cmd_result_ensure_ok_verbose (CmdResult *cmd)
   if (cmd_result_ensure_ok (cmd, &error))
     return TRUE;
 
+  g_test_message ("%s", error->message);
   return FALSE;
 }
 

--- a/tests/test-autoupdater.c
+++ b/tests/test-autoupdater.c
@@ -289,6 +289,21 @@ test_user_visible_update_delay (EosUpdaterFixture *fixture,
                                &error);
   g_assert_no_error (error);
 
+  /* First poll so that poll results are written to disk. */
+  g_clear_object (&autoupdater);
+  autoupdater = eos_test_autoupdater_new (autoupdater_root,
+                                          UPDATE_STEP_POLL,
+                                          0,  /* interval (days) */
+                                          test_data->update_delay, /* user visible delay (days) */
+                                          test_data->force_update,  /* force update */
+                                          &error);
+  g_assert_no_error (error);
+  g_assert_true (cmd_result_ensure_ok_verbose (autoupdater->cmd));
+
+  /* Now run through to apply. Since eos-updater is in UPDATE_AVAILABLE state,
+   * polling will be skipped. This will test that the autoupdater loads the
+   * previous poll results even when not polling. */
+  g_clear_object (&autoupdater);
   autoupdater = eos_test_autoupdater_new (autoupdater_root,
                                           UPDATE_STEP_APPLY,
                                           0,  /* interval (days) */

--- a/tests/test-autoupdater.c
+++ b/tests/test-autoupdater.c
@@ -154,7 +154,7 @@ test_poll_results (EosUpdaterFixture *fixture,
                                           FALSE,  /* force update */
                                           &error);
   g_assert_no_error (error);
-  cmd_result_ensure_ok_verbose (autoupdater->cmd);
+  g_assert_true (cmd_result_ensure_ok_verbose (autoupdater->cmd));
 
   get_poll_results (autoupdater_root,
                     &last_changed_usecs,
@@ -186,7 +186,7 @@ test_poll_results (EosUpdaterFixture *fixture,
                                           FALSE,  /* force update */
                                           &error);
   g_assert_no_error (error);
-  cmd_result_ensure_ok_verbose (autoupdater->cmd);
+  g_assert_true (cmd_result_ensure_ok_verbose (autoupdater->cmd));
 
   expected_update_id = g_hash_table_lookup (subserver->commits_in_repo,
                                             GUINT_TO_POINTER (1));
@@ -213,7 +213,7 @@ test_poll_results (EosUpdaterFixture *fixture,
                                           FALSE,  /* force update */
                                           &error);
   g_assert_no_error (error);
-  cmd_result_ensure_ok_verbose (autoupdater->cmd);
+  g_assert_true (cmd_result_ensure_ok_verbose (autoupdater->cmd));
 
   get_poll_results (autoupdater_root,
                     &last_changed_usecs,
@@ -228,7 +228,7 @@ test_poll_results (EosUpdaterFixture *fixture,
                                 &reaped,
                                 &error);
   g_assert_no_error (error);
-  cmd_result_ensure_ok_verbose (&reaped);
+  g_assert_true (cmd_result_ensure_ok_verbose (&reaped));
 }
 
 typedef struct {
@@ -296,7 +296,7 @@ test_user_visible_update_delay (EosUpdaterFixture *fixture,
                                           test_data->force_update,  /* force update */
                                           &error);
   g_assert_no_error (error);
-  cmd_result_ensure_ok_verbose (autoupdater->cmd);
+  g_assert_true (cmd_result_ensure_ok_verbose (autoupdater->cmd));
 
   eos_test_client_has_commit (client,
                               default_remote_name,
@@ -314,7 +314,7 @@ test_user_visible_update_delay (EosUpdaterFixture *fixture,
                                 &reaped,
                                 &error);
   g_assert_no_error (error);
-  cmd_result_ensure_ok_verbose (&reaped);
+  g_assert_true (cmd_result_ensure_ok_verbose (&reaped));
 }
 
 int


### PR DESCRIPTION
This is a backport of #326 to eos4.0. The 3 commits there cherry picked cleanly.

https://phabricator.endlessm.com/T34083