### PR TITLE
eos-updater: Install python-dbusmock template

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,7 @@ Build-Depends:
  libostree-dev (>= 2017.12),
  libsoup2.4-dev,
  libsystemd-dev,
- meson (>= 0.58.0),
+ meson (>= 0.60.0),
  ostree (>= 2017.12),
  ostree-tests (>= 2017.6),
  python3-flake8,

--- a/debian/eos-updater-dev.install
+++ b/debian/eos-updater-dev.install
@@ -2,3 +2,4 @@ usr/lib/*/libeos-updater-util-0.so
 usr/lib/*/libeos-updater-flatpak-installer-0.so
 usr/share/gir-1.0/EosUpdaterUtil-0.gir
 usr/share/gir-1.0/EosUpdaterFlatpakInstaller-0.gir
+usr/share/python-dbusmock-templates/eos_updater.py

--- a/eos-updater/tests/meson.build
+++ b/eos-updater/tests/meson.build
@@ -1,7 +1,10 @@
 # Copyright 2022 Endless OS Foundation, LLC
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-# python-dbusmock doesn’t currently provide a way to install out-of-tree templates
+install_data('eos_updater.py',
+  install_dir : datadir / 'python-dbusmock' / 'templates',
+  install_tag : 'devel',
+)
 
 # lint check
 test(

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@
 
 project('eos-updater', 'c',
   version : '1.0.0',
-  meson_version : '>= 0.58.0',
+  meson_version : '>= 0.60.0',
   license: ['LGPL-2.1-or-later'],
   default_options : [
     'buildtype=debugoptimized',


### PR DESCRIPTION
Since https://github.com/martinpitt/python-dbusmock/pull/169 (not yet released!), python-dbusmock supports loading them from `$XDG_DATA_DIRS`.

If we install the template, other projects (like gnome-software) can eventually use the installed version rather than shipping their own copy.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>