### PR TITLE
debian: Fix typo in path in eos-updater-dev.install

### DIFF
--- a/debian/eos-updater-dev.install
+++ b/debian/eos-updater-dev.install
@@ -2,4 +2,4 @@ usr/lib/*/libeos-updater-util-0.so
 usr/lib/*/libeos-updater-flatpak-installer-0.so
 usr/share/gir-1.0/EosUpdaterUtil-0.gir
 usr/share/gir-1.0/EosUpdaterFlatpakInstaller-0.gir
-usr/share/python-dbusmock-templates/eos_updater.py
+usr/share/python-dbusmock/templates/eos_updater.py


### PR DESCRIPTION
Signed-off-by: Philip Withnall <pwithnall@endlessos.org>