### PR TITLE
Support building with no tests

### DIFF
--- a/libeos-updater-flatpak-installer/meson.build
+++ b/libeos-updater-flatpak-installer/meson.build
@@ -61,4 +61,6 @@ libeos_updater_flatpak_installer_gir = gnome.generate_gir(libeos_updater_flatpak
   fatal_warnings: true,
 )
 
-subdir('tests')
+if get_option('tests')
+  subdir('tests')
+endif

--- a/meson.build
+++ b/meson.build
@@ -149,4 +149,6 @@ subdir('eos-updater-avahi')
 subdir('eos-updater-ctl')
 subdir('eos-updater-flatpak-installer')
 subdir('eos-updater-prepare-volume')
-subdir('tests')
+if get_option('tests')
+  subdir('tests')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,3 +19,9 @@ option(
   value: 43381,
   description: 'port number for the update server',
 )
+option(
+  'tests',
+  type: 'boolean',
+  value: true,
+  description: 'Whether to build and run unit tests'
+)


### PR DESCRIPTION
With freedesktop-sdk we build eos-updater but without tests. As part of https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1564 this submission is to allow said build mode without patches