### PR TITLE
debian: Build-depend on 'reuse'

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,6 +29,7 @@ Build-Depends:
  ostree (>= 2017.12),
  python3-flake8,
  python3-gi,
+ reuse,
 
 Package: eos-updater
 Section: misc


### PR DESCRIPTION
459555766dfb2f64147aa052588cc3f1a90baa64 added a test that runs 'reuse
lint'. As described in that message, 'reuse' is not available in Debian
Bullseye. Happily we are now based on Debian Bookworm which has a
'reuse' package.

https://phabricator.endlessm.com/T35253
