### PR TITLE
Revert "debian: Build-depend on 'reuse'"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,6 @@ Build-Depends:
  ostree (>= 2017.12),
  python3-flake8,
  python3-gi,
- reuse,
 
 Package: eos-updater
 Section: misc


### PR DESCRIPTION
This reverts commit f99859d2ffa2a79094b79f83848f6f2575e9f8bc.

When built on OBS, `reuse lint` complains at great length about build artifacts not containing copyright and licensing information:

    # MISSING COPYRIGHT AND LICENSING INFORMATION

    The following files have no copyright and licensing information:
    * /usr/src/packages/BUILD/obj-x86_64-linux-gnu/.gitignore
    * /usr/src/packages/BUILD/obj-x86_64-linux-gnu/.hgignore
    [ … ]
    * /usr/src/packages/BUILD/obj-x86_64-linux-gnu/eos-autoupdater/eos-autoupdater.p/main.c.o
    [ … ]

All the allegedly-offending files are in
/usr/src/packages/BUILD/obj-x86_64-linux-gnu. We can see above that Meson has written a blanket .gitignore and .hgignore to that directory as normal, so why is reuse complaining? The answer seems to be that reuse does not read these files directly. Instead, it uses the `git` (or `hg`) binary if installed to detect a Git (or Mercurial) checkout, and determines which files to ignore using `git ls-files --ignored` (or `hg status --ignored`).

On Jenkins and developer systems, `git` is in the path so ignored files are identified correctly. In the OBS buildroot for this package, `git` is (correctly) not installed, so ignored files are not ignored.

Drop 'reuse' from the package build dependencies. Instead, I'll adjust the jenkins templates to add it as an extra package for eos-updater.