### PR TITLE
Remove support for overriding hardware descriptors

### DIFF
--- a/eos-updater/poll-common.c
+++ b/eos-updater/poll-common.c
@@ -963,44 +963,6 @@ parse_latest_commit (OstreeRepo           *repo,
 }
 
 static void
-get_custom_hw_descriptors (GHashTable *hw_descriptors,
-                           const gchar *path)
-{
-  g_autoptr(GKeyFile) keyfile = NULL;
-  g_auto(GStrv) keys = NULL;
-  gchar **iter;
-  const gchar *group = "descriptors";
-
-  keyfile = g_key_file_new ();
-  if (!g_key_file_load_from_file (keyfile,
-                                  path,
-                                  G_KEY_FILE_NONE,
-                                  NULL))
-    return;
-
-  keys = g_key_file_get_keys (keyfile,
-                              group,
-                              NULL,
-                              NULL);
-  if (keys == NULL)
-    return;
-
-  for (iter = keys; *iter != NULL; ++iter)
-    {
-      const gchar *key = *iter;
-      gchar *value = g_key_file_get_string (keyfile,
-                                            group,
-                                            key,
-                                            NULL);
-
-      if (value == NULL)
-        continue;
-
-      g_hash_table_insert (hw_descriptors, g_strdup (key), value);
-    }
-}
-
-static void
 get_arm_hw_descriptors (GHashTable *hw_descriptors)
 {
   g_autoptr(GFile) fp = g_file_new_for_path (DT_COMPATIBLE);
@@ -1043,23 +1005,13 @@ get_x86_hw_descriptors (GHashTable *hw_descriptors)
     }
 }
 
-static const gchar *
-get_custom_descriptors_path (void)
-{
-  return g_getenv ("EOS_UPDATER_TEST_UPDATER_CUSTOM_DESCRIPTORS_PATH");
-}
-
 GHashTable *
 get_hw_descriptors (void)
 {
   GHashTable *hw_descriptors = g_hash_table_new_full (g_str_hash, g_str_equal,
                                                       g_free, g_free);
-  const gchar *custom_descriptors = get_custom_descriptors_path ();
 
-  if (custom_descriptors != NULL)
-    get_custom_hw_descriptors (hw_descriptors,
-                               custom_descriptors);
-  else if (g_file_test (DT_COMPATIBLE, G_FILE_TEST_EXISTS))
+  if (g_file_test (DT_COMPATIBLE, G_FILE_TEST_EXISTS))
     get_arm_hw_descriptors (hw_descriptors);
   else
     get_x86_hw_descriptors (hw_descriptors);


### PR DESCRIPTION
The logic in the tests that used this
EOS_UPDATER_TEST_UPDATER_CUSTOM_DESCRIPTORS_PATH environment variable was removed in 019eb5971e75f3ec2087758822e9ea0a3c233586.

https://phabricator.endlessm.com/T35247