### PR TITLE
apply: Check the partition's free size of /boot before apply

### DIFF
--- a/eos-updater/apply.c
+++ b/eos-updater/apply.c
@@ -22,6 +22,7 @@
  *  - Vivek Dasmohapatra <vivek@etla.org>
  */
 
+#include <sys/statvfs.h>
 #include <eos-updater/apply.h>
 #include <eos-updater/data.h>
 #include <eos-updater/object.h>
@@ -230,6 +231,47 @@ update_remote_branches (OstreeRepo   *repo,
 }
 
 static gboolean
+check_boot_free_space (GError **error)
+{
+  g_autofree gchar *cmdline = NULL;
+  struct statvfs boot_stat;
+  guint64 boot_free_bytes;
+  /* Require at least 100 MiB free on /boot */
+  const guint64 boot_min_free_bytes = 100 * 1024 * 1024;
+
+  /* Only check free space on provisioned PAYG systems, identified by the
+   * presence of "eospayg" in the kernel command line.
+   */
+  if (!g_file_get_contents ("/proc/cmdline", &cmdline, NULL, error))
+    return FALSE;
+
+  if (strstr (cmdline, "eospayg") == NULL)
+    return TRUE;
+
+  if (statvfs ("/boot", &boot_stat) != 0)
+    {
+      g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno),
+                   "Failed to check free space on /boot: %s",
+                   g_strerror (errno));
+      return FALSE;
+    }
+
+  boot_free_bytes = (guint64) boot_stat.f_bavail * (guint64) boot_stat.f_frsize;
+  g_message ("Free space on /boot: %" G_GUINT64_FORMAT " bytes", boot_free_bytes);
+
+  if (boot_free_bytes < boot_min_free_bytes)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NO_SPACE,
+                   "Not enough free space on /boot: have %" G_GUINT64_FORMAT " bytes, "
+                   "need at least %" G_GUINT64_FORMAT " bytes",
+                   boot_free_bytes, boot_min_free_bytes);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
 apply_internal (ApplyData     *apply_data,
                 GCancellable  *cancellable,
                 GError       **error)
@@ -254,6 +296,10 @@ apply_internal (ApplyData     *apply_data,
   if (!ostree_sysroot_lock (sysroot, error))
     return FALSE;
   if (!ostree_sysroot_load (sysroot, cancellable, error))
+    return FALSE;
+
+  /* Check that /boot has enough free space before deploying. */
+  if (!check_boot_free_space (error))
     return FALSE;
 
   booted_deployment = eos_updater_get_booted_deployment_from_loaded_sysroot (sysroot,

--- a/eos-updater/apply.c
+++ b/eos-updater/apply.c
@@ -272,6 +272,55 @@ check_boot_free_space (GError **error)
 }
 
 static gboolean
+remove_one_unused_deployment (OstreeSysroot  *sysroot,
+                              GCancellable   *cancellable,
+                              GError        **error)
+{
+  g_autoptr(OstreeDeployment) pending = NULL;
+  g_autoptr(OstreeDeployment) rollback = NULL;
+  g_autoptr(GPtrArray) deployments = NULL;
+  g_autoptr(GPtrArray) new_deployments = NULL;
+  OstreeDeployment *to_remove = NULL;
+
+  ostree_sysroot_query_deployments_for (sysroot, NULL, &pending, &rollback);
+
+  /* Prefer removing the rollback (older) over the pending deployment */
+  if (rollback != NULL)
+    to_remove = rollback;
+  else if (pending != NULL)
+    to_remove = pending;
+  else
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NO_SPACE,
+                   "Not enough free space on /boot and no unused deployment to remove");
+      return FALSE;
+    }
+
+  g_message ("Removing %s deployment to free space on /boot: "
+             "OS name: %s, checksum: %s",
+             to_remove == rollback ? "rollback" : "pending",
+             ostree_deployment_get_osname (to_remove),
+             ostree_deployment_get_csum (to_remove));
+
+  deployments = ostree_sysroot_get_deployments (sysroot);
+  new_deployments = g_ptr_array_new_with_free_func (g_object_unref);
+  for (guint i = 0; i < deployments->len; i++)
+    {
+      OstreeDeployment *d = deployments->pdata[i];
+      if (d != to_remove)
+        g_ptr_array_add (new_deployments, g_object_ref (d));
+    }
+
+  if (!ostree_sysroot_write_deployments (sysroot, new_deployments, cancellable, error))
+    return FALSE;
+
+  if (!ostree_sysroot_cleanup (sysroot, cancellable, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static gboolean
 apply_internal (ApplyData     *apply_data,
                 GCancellable  *cancellable,
                 GError       **error)
@@ -298,9 +347,19 @@ apply_internal (ApplyData     *apply_data,
   if (!ostree_sysroot_load (sysroot, cancellable, error))
     return FALSE;
 
-  /* Check that /boot has enough free space before deploying. */
+  /* Check that /boot has enough free space before deploying. A new
+   * kernel/initramfs image may need to be written there. If not enough
+   * space is available, try to free some by removing an unused deployment.
+   */
   if (!check_boot_free_space (error))
-    return FALSE;
+    {
+      if (!g_error_matches (*error, G_IO_ERROR, G_IO_ERROR_NO_SPACE))
+        return FALSE;
+      g_clear_error (error);
+
+      if (!remove_one_unused_deployment (sysroot, cancellable, error))
+        return FALSE;
+    }
 
   booted_deployment = eos_updater_get_booted_deployment_from_loaded_sysroot (sysroot,
                                                                              error);


### PR DESCRIPTION
The systems which start before EOS 5.0.0 have only 250 MB ESP partition. However, the kernel & initramfs composed EFI image has grown to almost 100 MB. The PAYG system mounts ESP partition to /boot. The space is not enough to hold the 3rd EFI image for PAYG provisioned system in the ESP during OSTree deploying the new updated OSTree. So, here introduces `check_boot_free_space()` function to check the partition's free size of /boot in the early apply.

Delete one unused ostree deployment if the the partition's free size of /boot is not enough. The used ostree deployment could be **pending**, or **rollback** ostree deployment. But, prefer removing the **rollback** (older) over the **pending** deployment. Then, there should be enough free space for the new updated OSTree deployment.

https://phabricator.endlessm.com/T33799